### PR TITLE
Tighten transform relation filtering

### DIFF
--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -585,6 +585,29 @@ def _attach_evidence(findings, sheet, r0, r1, c0, c1, header):
 
 # ---------- detectors ----------
 
+def _isclose_rowwise(actual, expected, rtol=1e-9):
+    """Return row-wise closeness at each row's own numeric scale.
+
+    A single coordinate/metadata row can be orders of magnitude larger than
+    the measurement rows. A block-wide absolute tolerance lets those small
+    measurement rows drift substantially while still passing a relation check.
+    """
+    actual = np.asarray(actual, dtype=float)
+    expected = np.asarray(expected, dtype=float)
+    row_scale = np.maximum.reduce([
+        np.abs(actual),
+        np.abs(expected),
+        np.full_like(actual, 1e-300, dtype=float),
+    ])
+    typical_scale = max(float(np.median(row_scale)), 1e-300)
+    tol = rtol * row_scale + (np.finfo(float).eps * typical_scale * 64)
+    return np.abs(actual - expected) <= tol
+
+
+def _allclose_rowwise(actual, expected, rtol=1e-9):
+    return bool(np.all(_isclose_rowwise(actual, expected, rtol=rtol)))
+
+
 _GRIM_MEAN_RE = re.compile(r"\b(mean|average|avg)\b|均值|平均", re.I)
 _GRIM_SD_RE = re.compile(r"\b(s\.?d\.?|std)\b|标准差", re.I)
 _GRIM_N_RE = re.compile(r"\bn\b|sample.?size|样本量|例数", re.I)
@@ -617,7 +640,7 @@ def detect_relations(sheet, r0, r1, c0, c1, header):
             # aren't held to an unreasonably tight absolute bound either).
             tol = 1e-9 * max(float(np.max(np.abs(x))), float(np.max(np.abs(y))), 1e-300)
             # identical
-            if np.allclose(x, y, atol=tol, rtol=1e-9):
+            if _allclose_rowwise(x, y):
                 findings.append(dict(kind="identical_column", col_a=header[ci - c0], col_b=header[cj - c0],
                                      col_a_idx=ci, col_b_idx=cj, n=n, severity="high",
                                      col_a_sample=sa, col_b_sample=sb,
@@ -625,22 +648,30 @@ def detect_relations(sheet, r0, r1, c0, c1, header):
                 continue
             # constant offset
             diff = y - x
-            if np.std(diff) < tol and abs(np.mean(diff)) > tol:
+            mean_diff = float(np.mean(diff))
+            if abs(mean_diff) > tol and _allclose_rowwise(y, x + mean_diff):
                 findings.append(dict(kind="constant_offset", col_a=header[ci - c0], col_b=header[cj - c0],
-                                     col_a_idx=ci, col_b_idx=cj, n=n, offset=float(np.mean(diff)),
+                                     col_a_idx=ci, col_b_idx=cj, n=n, offset=mean_diff,
                                      severity="high",
                                      col_a_sample=sa, col_b_sample=sb,
-                                     rule=f"col[{cj}] = col[{ci}] + {np.mean(diff):.6g}"))
+                                     rule=f"col[{cj}] = col[{ci}] + {mean_diff:.6g}"))
                 continue
             # constant ratio
             if np.all(np.abs(x) > 1e-12):
                 ratio = y / x
-                if np.std(ratio) < 1e-9 and abs(np.mean(ratio) - 1) > 1e-9 and abs(np.mean(ratio)) > 1e-9:
+                mean_ratio = float(np.mean(ratio))
+                ratio_tol = 1e-9 * max(abs(mean_ratio), 1e-300)
+                if (
+                    np.std(ratio) < ratio_tol
+                    and abs(mean_ratio - 1) > 1e-9
+                    and abs(mean_ratio) > 1e-9
+                    and _allclose_rowwise(y, mean_ratio * x)
+                ):
                     findings.append(dict(kind="constant_ratio", col_a=header[ci - c0], col_b=header[cj - c0],
-                                         col_a_idx=ci, col_b_idx=cj, n=n, ratio=float(np.mean(ratio)),
+                                         col_a_idx=ci, col_b_idx=cj, n=n, ratio=mean_ratio,
                                          severity="high",
                                          col_a_sample=sa, col_b_sample=sb,
-                                         rule=f"col[{cj}] = col[{ci}] * {np.mean(ratio):.6g}"))
+                                         rule=f"col[{cj}] = col[{ci}] * {mean_ratio:.6g}"))
             # mirror: x + y == constant
             csum = x + y
             if n >= 5 and np.std(csum) < tol:
@@ -657,8 +688,8 @@ def detect_relations(sheet, r0, r1, c0, c1, header):
                     slope, intercept, r, _p, _se = stats.linregress(x, y)
                 except ValueError:
                     continue
-                resid = y - (slope * x + intercept)
-                if np.std(y) > 0 and np.std(resid) < tol and abs(r) > 0.99:
+                fitted = slope * x + intercept
+                if np.std(y) > 0 and _allclose_rowwise(y, fitted, rtol=1e-7) and abs(r) > 0.99:
                     if not (abs(slope - 1) < 1e-9 and abs(intercept) < tol):
                         findings.append(dict(kind="exact_linear", col_a=header[ci - c0], col_b=header[cj - c0],
                                              col_a_idx=ci, col_b_idx=cj, n=n,
@@ -993,10 +1024,10 @@ def detect_equal_pairs(sheet, r0, r1, c0, c1, header):
             if n < 6:
                 continue
             am, bm = a[mask], b[mask]
-            # scale-relative tolerances (a fixed atol misfires on tiny-magnitude data — see detect_relations)
-            scale = max(float(np.max(np.abs(am))), float(np.max(np.abs(bm))), 1e-300)
-            eq = int((np.isclose(am, bm, atol=1e-6 * scale, rtol=1e-6)).sum())
-            if eq >= max(6, n // 2) and eq / n >= 0.5 and not np.allclose(am, bm, atol=1e-9 * scale, rtol=1e-9):
+            # scale-relative tolerances, applied per row so one large metadata
+            # coordinate does not make small measurement rows look equal.
+            eq = int(_isclose_rowwise(am, bm, rtol=1e-6).sum())
+            if eq >= max(6, n // 2) and eq / n >= 0.5 and not _allclose_rowwise(am, bm, rtol=1e-9):
                 findings.append(dict(kind="many_equal_pairs", col_a=header[i], col_b=header[j],
                                      col_a_idx=c0 + i, col_b_idx=c0 + j, n=n, equal=eq,
                                      severity="medium" if eq < n else "high",

--- a/src/paperconan/_prefilter.py
+++ b/src/paperconan/_prefilter.py
@@ -123,6 +123,8 @@ _COMMON_UNIT_FACTORS = {
     1e-12, 1e-9, 1e-6, 1e-3, 1e-2,
     1e2, 1e3, 1e6, 1e9, 1e12,
 }
+_GENOME_SIZE_MBP_FACTORS = {980.0, 1.0 / 980.0}
+_GENOME_SIZE_GBP_FACTORS = {0.98, 1.0 / 0.98}
 
 
 def _derived_label(label: str | None) -> bool:
@@ -210,6 +212,33 @@ def _common_unit_scale(kind: str | None, sa: list[Any] | None, sb: list[Any] | N
         return False
     scale = max(max(abs(x) for pair in pairs for x in pair), 1.0)
     return all(abs(y - ratio * x) <= 1e-9 * scale for x, y in pairs)
+
+
+def _genome_size_unit_conversion(kind: str | None, a: str | None, b: str | None,
+                                 sa: list[Any] | None, sb: list[Any] | None) -> bool:
+    if kind not in {"constant_ratio", "exact_linear"}:
+        return False
+    labels = f" {a or ''} {b or ''} ".lower()
+    has_genome_size_context = any(token in labels for token in ("1c", "c-value", "c value", "genome"))
+    has_pg = re.search(r"(^|[^a-z])pg([^a-z]|$)", labels) is not None
+    has_mbp = re.search(r"(^|[^a-z])mbp([^a-z]|$)", labels) is not None
+    has_gbp = re.search(r"(^|[^a-z])gbp([^a-z]|$)", labels) is not None
+    pairs = [(x, y) for x, y in zip(_nums(sa), _nums(sb)) if abs(x) > 1e-12 and abs(y) > 1e-12]
+    if len(pairs) < 3:
+        return False
+    ratios = [y / x for x, y in pairs]
+    ratio = sum(ratios) / len(ratios)
+    factors = set()
+    if has_mbp:
+        factors.update(_GENOME_SIZE_MBP_FACTORS)
+    if has_gbp:
+        factors.update(_GENOME_SIZE_GBP_FACTORS)
+    if not factors or not any(abs(ratio - k) <= 1e-9 * max(abs(k), 1.0) for k in factors):
+        return False
+    scale = max(max(abs(x) for pair in pairs for x in pair), 1.0)
+    if not all(abs(y - ratio * x) <= 1e-9 * scale for x, y in pairs):
+        return False
+    return has_genome_size_context and has_pg and (has_mbp or has_gbp)
 
 
 def _large_integer_coordinates(sa: list[Any] | None, sb: list[Any] | None) -> bool:
@@ -327,6 +356,8 @@ def prefilter(kind: str | None, a: str | None, b: str | None,
         return "drop", "n_column"
     if flags.get("image_derived_label"):
         return "drop", "image_processing_derived_column"
+    if flags.get("genome_size_unit_conversion"):
+        return "drop", "unit_conversion_or_normalization"
     if flags.get("common_unit_scale"):
         return "drop", "unit_conversion_or_normalization"
     if flags["derived_label"]:
@@ -357,6 +388,7 @@ def make_finding(kind: str | None, a: str | None, b: str | None, n: int,
         "explicit_formula_label": _explicit_formula_label(a) or _explicit_formula_label(b),
         "count_to_probability_or_rate": _count_to_probability_or_rate(kind, a, b),
         "common_unit_scale": _common_unit_scale(kind, sa, sb),
+        "genome_size_unit_conversion": _genome_size_unit_conversion(kind, a, b, sa, sb),
         "genomic_coordinate": _coordinate_pair(a, b, sa, sb),
         "low_information_sparse": _low_information_sparse(kind, int(n or 0), sa, sb, hp),
         "replicate": _replicate_label(a) and _replicate_label(b),

--- a/tests/test_batch2_prefilter.py
+++ b/tests/test_batch2_prefilter.py
@@ -225,6 +225,88 @@ def test_prefilter_drops_common_unit_scale_even_with_blank_labels():
     assert f["prefilter_reason"] == "unit_conversion_or_normalization"
 
 
+def test_prefilter_drops_genome_size_pg_to_mbp_conversion():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio",
+        "1C_pg",
+        "1C_Mbp",
+        42,
+        1.0,
+        "col[5] = col[4] * 980",
+        [4.43, 4.70, 6.00, 7.35, 8.28],
+        [4341.4, 4606.0, 5880.0, 7203.0, 8114.4],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "unit_conversion_or_normalization"
+
+
+def test_prefilter_does_not_treat_pg_to_gbp_factor_as_mbp_conversion():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio",
+        "1C_pg",
+        "1C_Mbp",
+        42,
+        1.0,
+        "col[7] = col[4] * 0.98",
+        [4.43, 4.70, 6.00, 7.35, 8.28],
+        [4.3414, 4.606, 5.88, 7.203, 8.1144],
+    )
+
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_drops_genome_size_pg_to_gbp_conversion():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio",
+        "1C_pg",
+        "1C_Gbp",
+        42,
+        1.0,
+        "col[7] = col[4] * 0.98",
+        [4.43, 4.70, 6.00, 7.35, 8.28],
+        [4.3414, 4.606, 5.88, 7.203, 8.1144],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "unit_conversion_or_normalization"
+
+
+def test_prefilter_keeps_unlabeled_980_factor_without_genome_size_context():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio",
+        "",
+        "",
+        23,
+        1.0,
+        "col[5] = col[4] * 980",
+        [0.63, 0.93, 1.05, 1.27, 1.50],
+        [617.4, 911.4, 1029.0, 1244.6, 1470.0],
+    )
+
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_keeps_non_genome_size_text_labels_with_980_ratio():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio",
+        "Drug A response",
+        "Drug B response",
+        12,
+        1.0,
+        "col[2] = col[1] * 980",
+        [0.63, 0.93, 1.05, 1.27, 1.50],
+        [617.4, 911.4, 1029.0, 1244.6, 1470.0],
+    )
+
+    assert f["prefilter"] == "keep"
+
+
 def test_prefilter_keeps_non_unit_tiny_ratio():
     cp = _collector()
     f = cp.prefilter_relation_finding(

--- a/tests/test_relations_tolerance.py
+++ b/tests/test_relations_tolerance.py
@@ -38,3 +38,89 @@ def test_arithmetic_progression_not_fp_on_tiny_noise():
     # a real progression at normal scale still flags
     s2 = _sheet([[2.0,4.0,6.0,8.0,10.0,12.0]])
     assert any(x['kind']=='arithmetic_progression' for x in detect_arithmetic_progression(s2,1,7,0,1,["c0"]))
+
+def test_nearby_genomic_position_does_not_create_constant_ratio_with_maf():
+    position = [
+        26030666.0, 26030328.0, 26531117.0, 26030701.0, 26030654.0,
+        26531317.0, 26477782.0, 25594855.0, 26365765.0, 26631621.0,
+    ]
+    maf = [
+        0.479865771812081, 0.483221476510067, 0.476510067114094,
+        0.483221476510067, 0.483221476510067, 0.48993288590604,
+        0.48993288590604, 0.493288590604027, 0.466442953020134,
+        0.496644295302013,
+    ]
+    s = _sheet([position, maf])
+
+    findings = detect_relations(s, 1, len(position) + 1, 0, 2, ["Position", "maf"])
+
+    bad = [x for x in findings if x["kind"] in {"constant_ratio", "exact_linear"}]
+    assert not bad, f"nearby genomic coordinates and bounded MAF values are not fixed transforms: {bad}"
+
+def test_metadata_coordinate_row_does_not_loosen_exact_linear_tolerance():
+    cg41120748_bc21 = [
+        89276696.0, 0.192189246698232, 0.830456994543439, 0.471174254359565,
+        0.128797390103186, 0.0840155637834975, 0.0697729457989007,
+        0.488260981357202, 0.804403139030435, 0.426880065569606,
+        0.805091030159345,
+    ]
+    cg41120749_bc11 = [
+        89276717.0, 0.217214016881297, 0.897669027613707, 0.526408804387175,
+        0.196871166522583, 0.0359387519803685, 0.0116139589367601,
+        0.608879541042533, 0.908971334297428, 0.491393656716141,
+        0.89279878393404,
+    ]
+    s = _sheet([cg41120748_bc21, cg41120749_bc11])
+
+    findings = detect_relations(
+        s, 1, len(cg41120748_bc21) + 1, 0, 2,
+        ["cg41120748_BC21", "cg41120749_BC11"],
+    )
+
+    bad = [x for x in findings if x["kind"] in {"constant_offset", "exact_linear"}]
+    assert not bad, f"one large Pos.start row must not make beta-value columns look linear: {bad}"
+
+def test_metadata_coordinate_row_does_not_loosen_many_equal_pair_tolerance():
+    cg41120748_bc21 = [
+        89276696.0, 0.192189246698232, 0.830456994543439, 0.471174254359565,
+        0.128797390103186, 0.0840155637834975, 0.0697729457989007,
+        0.488260981357202, 0.804403139030435, 0.426880065569606,
+        0.805091030159345,
+    ]
+    cg41120749_bc11 = [
+        89276717.0, 0.217214016881297, 0.897669027613707, 0.526408804387175,
+        0.196871166522583, 0.0359387519803685, 0.0116139589367601,
+        0.608879541042533, 0.908971334297428, 0.491393656716141,
+        0.89279878393404,
+    ]
+    s = _sheet([cg41120748_bc21, cg41120749_bc11])
+
+    findings = detect_equal_pairs(
+        s, 1, len(cg41120748_bc21) + 1, 0, 2,
+        ["cg41120748_BC21", "cg41120749_BC11"],
+    )
+
+    assert not findings, f"one large Pos.start row must not make beta values look equal: {findings}"
+
+def test_metadata_coordinate_row_does_not_loosen_identical_column_tolerance():
+    left = [
+        3_000_000_000.0, 0.10, 0.25, 0.44, 0.72, 0.91,
+    ]
+    right = [
+        3_000_000_002.0, 0.15, 0.29, 0.41, 0.66, 0.84,
+    ]
+    s = _sheet([left, right])
+
+    findings = detect_relations(s, 1, len(left) + 1, 0, 2, ["probe_a", "probe_b"])
+
+    bad = [x for x in findings if x["kind"] == "identical_column"]
+    assert not bad, f"one huge metadata row must not make small measurement rows identical: {bad}"
+
+def test_mixed_scale_true_exact_linear_still_flags():
+    x = [1_000_000_000.0, 0.10, 0.25, 0.44, 0.72, 0.91]
+    y = [3 * v + 7 for v in x]
+    s = _sheet([x, y])
+
+    findings = detect_relations(s, 1, len(x) + 1, 0, 2, ["x", "y"])
+
+    assert any(f["kind"] == "exact_linear" for f in findings), findings


### PR DESCRIPTION
## Summary
- tighten relation detection tolerance so large metadata rows do not make small measurement rows look linearly related, equal, or identical
- keep true mixed-scale exact-linear relations by using row-wise tolerance plus a median-scale floating-point floor
- require constant-ratio stability relative to the ratio magnitude
- auto-drop genome-size pg-to-Mbp/Gbp conversions only when labels explicitly carry genome-size/unit context, with Mbp and Gbp factors handled separately
- intentionally keep unlabeled or unrelated-text `* 980` transforms for review rather than hard-coding a one-paper fallback
- add regression coverage for Position/MAF, CpG probe metadata rows, identical-column mixed-scale rows, mixed-scale true exact-linear rows, and genome-size unit conversions

## Verification
- `uv run pytest -q tests/test_batch2_prefilter.py tests/test_relations_tolerance.py tests/test_profiles.py tests/test_relations_flood.py tests/test_finding_sample.py` -> 64 passed
- `uv run pytest -q` -> 218 passed, 3 skipped
- local replay on the 6 KEEP + 3 corrected FP source Excel files from batch `1781979131_81429`: Position/MAF and CpG metadata FP samples now have no survivor; 6 KEEP samples retain their core survivor findings; unlabeled 980 genome-size case remains for human review because the source block lacks unit labels
