### PR TITLE
Refine transform prefilter complements

### DIFF
--- a/src/paperconan/_prefilter.py
+++ b/src/paperconan/_prefilter.py
@@ -79,12 +79,12 @@ _IMAGE_DERIVED_RE = re.compile(
     re.I,
 )
 _GENOMIC_START_RE = re.compile(
-    r"(^|[^a-z])(chrom)?(motif|midpoint|block|thick)?[_ -]*(start|s1|bp)([^a-z]|$)"
+    r"(^|[^a-z])(chrom)?(motif|midpoint|block|thick)?[_ -]*(start[lr]?|s1|bp)([^a-z]|$)"
     r"|start[_ -]*position",
     re.I,
 )
 _GENOMIC_END_RE = re.compile(
-    r"(^|[^a-z])(chrom)?(motif|midpoint|block|thick)?[_ -]*(end|stop|e1|genpos)([^a-z]|$)"
+    r"(^|[^a-z])(chrom)?(motif|midpoint|block|thick)?[_ -]*(end[lr]?|stop|e1|genpos)([^a-z]|$)"
     r"|end[_ -]*position",
     re.I,
 )
@@ -169,18 +169,39 @@ def _samples_sum_constant(sa: list[Any] | None, sb: list[Any] | None, tol: float
     return all(abs(x - target) <= tol * scale for x in sums[1:])
 
 
-def _complement_percentage(kind: str | None, a: str | None, b: str | None,
-                           sa: list[Any] | None, sb: list[Any] | None) -> bool:
-    if kind != "sum_constant":
+def _exact_linear_negative_unit_intercept(slope: Any, intercept: Any, target: float,
+                                          tol: float = 1e-9) -> bool:
+    try:
+        s = float(slope)
+        b = float(intercept)
+    except (TypeError, ValueError):
         return False
-    if _percent_label(a) or _percent_label(b):
+    return abs(s + 1.0) <= tol and abs(b - target) <= tol * max(abs(target), 1.0)
+
+
+def _complement_percentage(kind: str | None, a: str | None, b: str | None,
+                           sa: list[Any] | None, sb: list[Any] | None,
+                           slope: Any = None, intercept: Any = None) -> bool:
+    if kind not in {"sum_constant", "exact_linear"}:
+        return False
+    if kind == "sum_constant" and (_percent_label(a) or _percent_label(b)):
         return True
+    if kind == "exact_linear" and not _exact_linear_negative_unit_intercept(slope, intercept, 100.0):
+        return False
     return _sample_sums_to(sa, sb, 100.0)
 
 
 def _complement_fraction(kind: str | None, _a: str | None, _b: str | None,
-                         sa: list[Any] | None, sb: list[Any] | None) -> bool:
-    if kind != "sum_constant":
+                         sa: list[Any] | None, sb: list[Any] | None,
+                         slope: Any = None, intercept: Any = None) -> bool:
+    if kind not in {"sum_constant", "exact_linear"}:
+        return False
+    if not (_derived_label(_a) or _derived_label(_b) or _percent_label(_a) or _percent_label(_b)):
+        return False
+    if kind == "exact_linear" and not (
+        _exact_linear_negative_unit_intercept(slope, intercept, 1.0)
+        or _exact_linear_negative_unit_intercept(slope, intercept, 2.0)
+    ):
         return False
     return _sample_sums_to(sa, sb, 1.0) or _sample_sums_to(sa, sb, 2.0)
 
@@ -190,8 +211,13 @@ def _tokenized_label(label: str | None) -> set[str]:
 
 
 def _complement_category(kind: str | None, a: str | None, b: str | None,
-                         sa: list[Any] | None, sb: list[Any] | None) -> bool:
-    if kind != "sum_constant" or not _samples_sum_constant(sa, sb):
+                         sa: list[Any] | None, sb: list[Any] | None,
+                         slope: Any = None, intercept: Any = None) -> bool:
+    if kind not in {"sum_constant", "exact_linear"} or not _samples_sum_constant(sa, sb):
+        return False
+    if kind == "exact_linear" and not _exact_linear_negative_unit_intercept(
+        slope, intercept, _nums(sa)[0] + _nums(sb)[0] if _nums(sa) and _nums(sb) else 0.0
+    ):
         return False
     ta, tb = _tokenized_label(a), _tokenized_label(b)
     for left, right in _COMPLEMENT_LABEL_PAIRS:
@@ -285,6 +311,16 @@ def _explicit_formula_label(label: str | None) -> bool:
     return bool(_EXPLICIT_FORMULA_RE.search(label or ""))
 
 
+def _signed_formula_counterpart(a: str | None, b: str | None) -> bool:
+    left = re.sub(r"\s+", "", a or "")
+    right = re.sub(r"\s+", "", b or "")
+    if not left or not right:
+        return False
+    if not any(ch in left + right for ch in "/^*"):
+        return False
+    return right == "-" + left or left == "-" + right
+
+
 def _count_to_probability_or_rate(kind: str | None, a: str | None, b: str | None) -> bool:
     if kind not in {"constant_ratio", "exact_linear"}:
         return False
@@ -361,6 +397,8 @@ def prefilter(kind: str | None, a: str | None, b: str | None,
     if flags.get("common_unit_scale"):
         return "drop", "unit_conversion_or_normalization"
     if flags["derived_label"]:
+        if kind in {"constant_ratio", "constant_offset", "exact_linear", "sum_constant"}:
+            return "downweight", "derived_normalized"
         return "drop", "derived_normalized"
     if flags.get("low_information_sparse"):
         return "downweight", "low_information_sparse_transform"
@@ -382,10 +420,13 @@ def make_finding(kind: str | None, a: str | None, b: str | None, n: int,
         "qpcr_derived_label": _qpcr_derived_label(a) or _qpcr_derived_label(b),
         "summary_scale_label": _summary_scale_label(a) or _summary_scale_label(b),
         "image_derived_label": _image_derived_label(a) or _image_derived_label(b),
-        "complement_percentage": _complement_percentage(kind, a, b, sa, sb),
-        "complement_fraction": _complement_fraction(kind, a, b, sa, sb),
-        "complement_category": _complement_category(kind, a, b, sa, sb),
-        "explicit_formula_label": _explicit_formula_label(a) or _explicit_formula_label(b),
+        "complement_percentage": _complement_percentage(kind, a, b, sa, sb, extra.get("slope"), extra.get("intercept")),
+        "complement_fraction": _complement_fraction(kind, a, b, sa, sb, extra.get("slope"), extra.get("intercept")),
+        "complement_category": _complement_category(kind, a, b, sa, sb, extra.get("slope"), extra.get("intercept")),
+        "explicit_formula_label": (
+            _explicit_formula_label(a) or _explicit_formula_label(b)
+            or _signed_formula_counterpart(a, b)
+        ),
         "count_to_probability_or_rate": _count_to_probability_or_rate(kind, a, b),
         "common_unit_scale": _common_unit_scale(kind, sa, sb),
         "genome_size_unit_conversion": _genome_size_unit_conversion(kind, a, b, sa, sb),

--- a/src/paperconan/_profiles.py
+++ b/src/paperconan/_profiles.py
@@ -144,6 +144,8 @@ def _relation_prefilter(f: dict) -> tuple[str, str | None] | None:
         f.get("rule"),
         f.get("col_a_sample"),
         f.get("col_b_sample"),
+        slope=f.get("slope"),
+        intercept=f.get("intercept"),
     )
     action = pf.get("prefilter")
     reason = pf.get("prefilter_reason")

--- a/tests/test_batch2_prefilter.py
+++ b/tests/test_batch2_prefilter.py
@@ -606,3 +606,141 @@ def test_prefilter_keeps_small_high_precision_independent_transform():
     )
 
     assert f["prefilter"] == "keep"
+
+
+def test_prefilter_keeps_independent_conditions_that_sum_to_one():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "sum_constant",
+        "shControl",
+        "shPACSIN2-D11",
+        20,
+        1.0,
+        "col[4] + col[5] = 1",
+        [1.0, 1.0, 0.8889, 0.8889, 0.5556],
+        [0.0, 0.0, 0.1111, 0.1111, 0.4444],
+    )
+
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_keeps_independent_repeats_that_sum_to_two():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "sum_constant",
+        "Repeat1",
+        "Repeat2",
+        10,
+        1.0,
+        "col[6] + col[7] = 2",
+        [1.109006, 0.830224, 1.32632, 1.139431, 1.223372],
+        [0.890994, 1.169776, 0.67368, 0.860569, 0.776628],
+    )
+
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_drops_exact_linear_percent_complements():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "exact_linear",
+        "GPR15-",
+        "GPR15+",
+        10,
+        1.0,
+        "col[2] = -1 * col[1] + 100",
+        [80.0, 72.0, 61.5, 54.0, 43.2],
+        [20.0, 28.0, 38.5, 46.0, 56.8],
+        slope=-1.0,
+        intercept=100.0,
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "complement_percentage_sum_to_100"
+
+
+def test_prefilter_downweights_exact_linear_percent_columns_that_do_not_complement():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "exact_linear",
+        "percent viability day 1",
+        "percent viability day 2",
+        20,
+        1.0,
+        "col[2] = 0.8 * col[1] + 5",
+        [80.0, 72.0, 61.5, 54.0, 43.2],
+        [69.0, 62.6, 54.2, 48.2, 39.56],
+        slope=0.8,
+        intercept=5.0,
+    )
+
+    assert f["prefilter"] == "downweight"
+    assert f["prefilter_reason"] == "derived_normalized"
+
+
+def test_prefilter_does_not_drop_exact_linear_complement_from_sample_only():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "exact_linear",
+        "GPR15-",
+        "GPR15+",
+        100,
+        1.0,
+        "col[2] = -0.8 * col[1] + 84",
+        [80.0, 72.0, 61.5, 54.0, 43.2],
+        [20.0, 28.0, 38.5, 46.0, 56.8],
+        slope=-0.8,
+        intercept=84.0,
+    )
+
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_drops_signed_formula_counterpart_labels():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio",
+        "A/r^2",
+        "-A/r^2",
+        304,
+        1.0,
+        "col[8] = col[7] * -1",
+        [5.31488, 4.74074, 4.25485, 3.84, 3.48299],
+        [-5.31488, -4.74074, -4.25485, -3.84, -3.48299],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "explicit_formula_or_unit_conversion"
+
+
+def test_prefilter_keeps_signed_parenthetical_condition_labels():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio",
+        "Signal (baseline)",
+        "-Signal (baseline)",
+        30,
+        1.0,
+        "col[2] = col[1] * -1",
+        [1.2, 2.5, 3.1, 5.8, 6.4],
+        [-1.2, -2.5, -3.1, -5.8, -6.4],
+    )
+
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_drops_left_right_genomic_bin_coordinates():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_offset",
+        "startL",
+        "endL",
+        1165,
+        1.0,
+        "col[2] = col[1] + 10000",
+        [74520000.0, 18780000.0, 13710000.0, 18780000.0, 18730000.0],
+        [74530000.0, 18790000.0, 13720000.0, 18790000.0, 18740000.0],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "genomic_coordinate_table"


### PR DESCRIPTION
## Summary
- refine complement prefiltering so `exact_linear` complements require numeric slope/intercept proof instead of sampled preview values
- keep sum-to-1/2 independent conditions and repeats reviewable; only derived/fraction-style labels auto-drop as complement fractions
- add signed-formula counterpart handling for explicit formula labels like `A/r^2` vs `-A/r^2`
- expand genomic coordinate recognition for `startL/endL` and `startR/endR` bins

## Calibration
- judged refreshed transform_stat batch `1781984382_7573`: 26 submitted, 1 KEEP / 25 DROP
- local replay on that wave keeps all survivors for the KEEP; old packets only auto-drop rules that have structural fields available
- KEEP regression replay: 157 checked, zero papers lost all survivors

## Verification
- `.venv/bin/python -m pytest -q tests/test_batch2_prefilter.py` -> 44 passed
- KEEP regression replay -> zero survivor KEEPs = 0
- `.venv/bin/python -m pytest -q` -> 226 passed, 3 skipped