### PR TITLE
Improve batch2 transform prefilter profiles

### DIFF
--- a/src/paperconan/_prefilter.py
+++ b/src/paperconan/_prefilter.py
@@ -49,7 +49,8 @@ _AGG = (
     "average", "mean", "median", "std", " sd", "sd ", "stdev", "stddev",
     "s.d", "sem", "s.e.m", "variance", " var", "error", "95%", " ci",
     "sum", "total", "%", "percent", "ratio", "norm", "fold", "relative",
-    "cumulative", "fraction",
+    "cumulative", "fraction", "centered", "centred", "standardized",
+    "standardised", "scaled",
 )
 _AXIS_LABEL_RE = re.compile(
     r"(^|[^a-z0-9])("
@@ -63,6 +64,7 @@ _STAT_DERIVED_RE = re.compile(
     r"\b(adj(?:usted)?[._ -]?p(?:[._ -]?val(?:ue)?)?|p[._ -]?val(?:ue)?|"
     r"q[._ -]?val(?:ue)?|fdr|fwer|padj|p\.?value|adj\.?p\.?val|"
     r"bonferroni|benjamini|critical|rank|log2err|z[._ -]?score|"
+    r"aic|bic|aicc|effect[._ -]?size|lcl|ucl|"
     r"confidence[ _-]*interval)\b",
     re.I,
 )
@@ -103,7 +105,22 @@ _EXPLICIT_FORMULA_RE = re.compile(
 )
 _PROBABILITY_RATE_RE = re.compile(
     r"\b(?:probability|prob|frequency|freq|rate|coverage|depth|mapping[ _-]*rate|"
-    r"frac(?:tion)?(?:of)?samples?)\b",
+    r"precision|recall|sensitivity|specificity|frac(?:tion)?(?:of)?samples?)\b",
+    re.I,
+)
+_INTERVAL_BOUND_CONTEXT_RE = re.compile(
+    r"\b(?:limit|bound|ci|interval|parallel|outlier)\b|"
+    r"\bconfidence[ _-]*interval\b|"
+    r"(?:^|[_ -])(?:lcl|ucl)(?:$|[_ -])",
+    re.I,
+)
+_LOWER_BOUND_RE = re.compile(r"\b(?:lower|low|lcl)\b|(?:^|[_ -])lwr(?:$|[_ -])", re.I)
+_UPPER_BOUND_RE = re.compile(r"\b(?:upper|high|ucl)\b|(?:^|[_ -])upr(?:$|[_ -])", re.I)
+_LATITUDE_RE = re.compile(r"\b(?:latitude|lat)\b", re.I)
+_LONGITUDE_RE = re.compile(r"\b(?:longitude|lon|long)\b", re.I)
+_INFO_CRITERION_RE = re.compile(r"^(?:aic|bic|aicc)$", re.I)
+_CENTERED_STANDARDIZED_RE = re.compile(
+    r"(?:^|[_\s-])(?:centered|centred|standardi[sz]ed)(?:$|[_\s-])",
     re.I,
 )
 _COMPLEMENT_LABEL_PAIRS = (
@@ -304,7 +321,10 @@ def _replicate_label(label: str | None) -> bool:
 
 def _count_label(label: str | None) -> bool:
     text = " " + (label or "").lower() + " "
-    return any(token in text for token in ("count", "number of", "sample size", " n=", "n =", "(n)", " n ", "ndots", " dots", "reads"))
+    return any(token in text for token in (
+        "count", "number of", "sample size", " n=", "n =", "(n)", " n ",
+        "ndots", " dots", "reads", "intersection_size", "intersection size",
+    ))
 
 
 def _explicit_formula_label(label: str | None) -> bool:
@@ -328,6 +348,33 @@ def _count_to_probability_or_rate(kind: str | None, a: str | None, b: str | None
     rate_a = bool(_PROBABILITY_RATE_RE.search(a or ""))
     rate_b = bool(_PROBABILITY_RATE_RE.search(b or ""))
     return (count_a and rate_b) or (count_b and rate_a)
+
+
+def _interval_bound_pair(a: str | None, b: str | None) -> bool:
+    la, lb = a or "", b or ""
+    text = f"{la} {lb}"
+    if not _INTERVAL_BOUND_CONTEXT_RE.search(text):
+        return False
+    return (
+        (_LOWER_BOUND_RE.search(la) and _UPPER_BOUND_RE.search(lb))
+        or (_UPPER_BOUND_RE.search(la) and _LOWER_BOUND_RE.search(lb))
+    )
+
+
+def _coordinate_label_pair(a: str | None, b: str | None) -> bool:
+    la, lb = a or "", b or ""
+    return (
+        (_LATITUDE_RE.search(la) and _LONGITUDE_RE.search(lb))
+        or (_LONGITUDE_RE.search(la) and _LATITUDE_RE.search(lb))
+    )
+
+
+def _information_criterion_pair(a: str | None, b: str | None) -> bool:
+    return bool(_INFO_CRITERION_RE.search(a or "") and _INFO_CRITERION_RE.search(b or ""))
+
+
+def _centered_or_standardized_label(a: str | None, b: str | None) -> bool:
+    return bool(_CENTERED_STANDARDIZED_RE.search(a or "") or _CENTERED_STANDARDIZED_RE.search(b or ""))
 
 
 def _low_information_sparse(kind: str | None, n: int, sa: list[Any] | None,
@@ -368,6 +415,14 @@ def prefilter(kind: str | None, a: str | None, b: str | None,
               flags: dict[str, bool]) -> tuple[str, str | None]:
     if flags["trivial"]:
         return "drop", "trivial_constant"
+    if flags.get("interval_bound_pair"):
+        return "drop", "interval_bounds"
+    if flags.get("coordinate_label_pair"):
+        return "drop", "coordinate_table"
+    if flags.get("information_criterion_pair"):
+        return "drop", "information_criterion_columns"
+    if flags.get("centered_or_standardized_label"):
+        return "drop", "centered_or_standardized_column"
     if flags.get("genomic_coordinate"):
         return "drop", "genomic_coordinate_table"
     if flags.get("complement_percentage"):
@@ -423,6 +478,10 @@ def make_finding(kind: str | None, a: str | None, b: str | None, n: int,
         "complement_percentage": _complement_percentage(kind, a, b, sa, sb, extra.get("slope"), extra.get("intercept")),
         "complement_fraction": _complement_fraction(kind, a, b, sa, sb, extra.get("slope"), extra.get("intercept")),
         "complement_category": _complement_category(kind, a, b, sa, sb, extra.get("slope"), extra.get("intercept")),
+        "interval_bound_pair": _interval_bound_pair(a, b),
+        "coordinate_label_pair": _coordinate_label_pair(a, b),
+        "information_criterion_pair": _information_criterion_pair(a, b),
+        "centered_or_standardized_label": _centered_or_standardized_label(a, b),
         "explicit_formula_label": (
             _explicit_formula_label(a) or _explicit_formula_label(b)
             or _signed_formula_counterpart(a, b)

--- a/tests/test_batch2_prefilter.py
+++ b/tests/test_batch2_prefilter.py
@@ -744,3 +744,137 @@ def test_prefilter_drops_left_right_genomic_bin_coordinates():
 
     assert f["prefilter"] == "drop"
     assert f["prefilter_reason"] == "genomic_coordinate_table"
+
+
+def test_prefilter_drops_information_criterion_statistics():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_offset",
+        "AIC",
+        "BIC",
+        8054,
+        1.0,
+        "col[8] = col[7] + 4.55333",
+        [101.2, 98.4, 103.7, 110.5, 95.3],
+        [105.75333, 102.95333, 108.25333, 115.05333, 99.85333],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "information_criterion_columns"
+
+
+def test_prefilter_drops_interval_bound_pairs():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_offset",
+        "Lower limit",
+        "Upper limit",
+        72,
+        1.0,
+        "col[7] = col[6] + 0.0264234",
+        [0.101, 0.205, 0.308, 0.401, 0.552],
+        [0.1274234, 0.2314234, 0.3344234, 0.4274234, 0.5784234],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "interval_bounds"
+
+
+def test_prefilter_does_not_drop_independent_lower_upper_condition_names():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_offset",
+        "Lower airway",
+        "Upper airway",
+        12,
+        1.0,
+        "col[2] = col[1] + 0.3",
+        [1.2, 2.5, 3.1, 5.8, 6.4],
+        [1.5, 2.8, 3.4, 6.1, 6.7],
+    )
+
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_does_not_drop_low_high_confidence_condition_names():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_offset",
+        "Low confidence",
+        "High confidence",
+        24,
+        1.0,
+        "col[2] = col[1] + 0.1",
+        [0.2, 0.4, 0.5, 0.7, 0.8],
+        [0.3, 0.5, 0.6, 0.8, 0.9],
+    )
+
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_drops_intersection_size_to_precision():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio",
+        "intersection_size",
+        "precision",
+        537,
+        1.0,
+        "col[6] = col[5] * 0.00127065",
+        [1.0, 3.0, 5.0, 8.0, 13.0],
+        [0.00127065, 0.00381195, 0.00635325, 0.0101652, 0.01651845],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "count_to_probability_or_rate"
+
+
+def test_prefilter_drops_centered_log_columns():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_offset",
+        "DMSO_R1_log2",
+        "DMSO_R1_log2_centered",
+        3288,
+        1.0,
+        "col[17] = col[9] + -21.62",
+        [22.1, 23.4, 24.7, 25.5, 26.3],
+        [0.48, 1.78, 3.08, 3.88, 4.68],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "centered_or_standardized_column"
+
+
+def test_prefilter_drops_centered_labels_with_spaces():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_offset",
+        "sample value",
+        "sample value centered",
+        120,
+        1.0,
+        "col[2] = col[1] + -4.2",
+        [5.1, 6.4, 7.2, 8.9, 10.3],
+        [0.9, 2.2, 3.0, 4.7, 6.1],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "centered_or_standardized_column"
+
+
+def test_prefilter_drops_latitude_longitude_coordinate_pairs():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_offset",
+        "Latitude",
+        "Longitude",
+        261,
+        1.0,
+        "col[2] = col[1] + 90",
+        [-87.2, -86.9, -86.5, -86.0, -85.7],
+        [2.8, 3.1, 3.5, 4.0, 4.3],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "coordinate_table"


### PR DESCRIPTION
## Summary
- Add conservative batch2 prefilter rules for interval bounds, geographic coordinate pairs, information-criterion columns, centered/standardized columns, and intersection-size to precision/rate conversions.
- Add regression tests for the new FP patterns and one guard that keeps independent lower/upper condition labels.

## Validation
- `uv run pytest -q tests/test_batch2_prefilter.py tests/test_profiles.py tests/test_relations_tolerance.py`
- `uv run pytest -q`
- Local replay on batch `1782013031_78897`: 4/4 KEEP remain surviving; 3 additional DROP packets would be auto-dropped. One NEEDS_HUMAN replay drop was caused by top5-only packet replay making a column look constant, so I did not count it as real filter evidence.
