### PR TITLE
Improve derived transform prefilter rules

### DIFF
--- a/src/paperconan/_prefilter.py
+++ b/src/paperconan/_prefilter.py
@@ -65,21 +65,44 @@ _STAT_DERIVED_RE = re.compile(
     r"q[._ -]?val(?:ue)?|fdr|fwer|padj|p\.?value|adj\.?p\.?val|"
     r"bonferroni|benjamini|critical|rank|log2err|z[._ -]?score|"
     r"aic|bic|aicc|effect[._ -]?size|lcl|ucl|"
+    r"firstingroupbyenrichment|by[ _-]?logp|"
     r"confidence[ _-]*interval)\b",
     re.I,
 )
 _QPCR_DERIVED_RE = re.compile(
     r"\b(?:dct|ddct|delta[ _-]*ct|delta[ _-]*delta[ _-]*ct|"
     r"deltacq|delta[ _-]*cq|delta[ _-]*delta[ _-]*cq|"
-    r"2\^-?ddct|relative[ _-]*(?:expression|quantity|value)|rq)\b",
+    r"2\^-?ddct|relative[ _-]*(?:expression|quantity|value)|rq|"
+    r"from[ _-]*equation)\b",
     re.I,
 )
 _SUMMARY_SCALE_RE = re.compile(r"\b(?:sem|s\.e\.m|se|sd|s\.d|std|stdev|stddev)\b", re.I)
 _IMAGE_DERIVED_RE = re.compile(
-    r"\b(gray|grey|intensity|pixel|invert|background|bg|normalized|normalised|"
-    r"set\s*0|threshold|roi)\b",
+    r"\b(gray|grey|intensity|pixel|invert|normalized|normalised|"
+    r"set\s*0|threshold|roi|intden|rawintden|raw\s*int\s*den|integrated\s*density|"
+    r"mean\s*gr[ae]y)\b",
     re.I,
 )
+# A single-sided correction token is only safe to auto-drop when the rest of the
+# label still names the same measurement, e.g. "Absorbance" vs "Absorbance corrected".
+_DERIVED_TRANSFORM_RE = re.compile(
+    r"\b(?:corrected|baseline[ _-]*(?:correction|subtract(?:ion|ed)?)|"
+    r"background[ _-]*(?:correction|subtract(?:ion|ed)?)|"
+    r"blank[ _-]*(?:correction|subtract(?:ion|ed)?)|"
+    r"bkg[ _-]*sub(?:tract(?:ion|ed)?)?|drift[ _-]*correct(?:ion|ed)?|"
+    r"debleach(?:ed)?)\b",
+    re.I,
+)
+_DERIVED_TRANSFORM_STRIP_RE = re.compile(
+    r"\b(?:corrected|baseline[ _-]*(?:correction|subtract(?:ion|ed)?)|"
+    r"background[ _-]*(?:correction|subtract(?:ion|ed)?)|"
+    r"blank[ _-]*(?:correction|subtract(?:ion|ed)?)|"
+    r"bkg[ _-]*sub(?:tract(?:ion|ed)?)?|drift[ _-]*correct(?:ion|ed)?|"
+    r"debleach(?:ed)?)\b",
+    re.I,
+)
+# Proteome Discoverer / MaxQuant export twin:  "X" vs "X (by Search Engine): Sequest HT"
+_SEARCH_ENGINE_SUFFIX_RE = re.compile(r"\s*\(by\s+search\s+engine\)?:?.*$", re.I)
 _GENOMIC_START_RE = re.compile(
     r"(^|[^a-z])(chrom)?(motif|midpoint|block|thick)?[_ -]*(start[lr]?|s1|bp)([^a-z]|$)"
     r"|start[_ -]*position",
@@ -159,6 +182,42 @@ def _derived_stat_label(label: str | None) -> bool:
 
 def _image_derived_label(label: str | None) -> bool:
     return bool(_IMAGE_DERIVED_RE.search(label or ""))
+
+
+def _derived_transform_token(label: str | None) -> bool:
+    return bool(_DERIVED_TRANSFORM_RE.search(label or ""))
+
+
+def _substantive_label_tokens(label: str | None) -> set[str]:
+    text = _DERIVED_TRANSFORM_STRIP_RE.sub(" ", label or "")
+    return {
+        token
+        for token in re.findall(r"[a-z0-9]+", text.lower())
+        if len(token) > 1 and token not in {"raw", "nominal", "value", "values", "data"}
+    }
+
+
+def _derived_transform_pair(a: str | None, b: str | None) -> bool:
+    """One side carries a correction token and both sides name the same base measurement."""
+    if _derived_transform_token(a) == _derived_transform_token(b):
+        return False
+    ta = _substantive_label_tokens(a)
+    tb = _substantive_label_tokens(b)
+    if not ta or not tb:
+        return False
+    return ta == tb
+
+
+def _search_engine_export_twin(kind: str | None, a: str | None, b: str | None) -> bool:
+    if kind not in {"identical_column", "many_equal_pairs"}:
+        return False
+    if not a or not b:
+        return False
+    if not (_SEARCH_ENGINE_SUFFIX_RE.search(a) or _SEARCH_ENGINE_SUFFIX_RE.search(b)):
+        return False
+    base_a = _SEARCH_ENGINE_SUFFIX_RE.sub("", a).strip().lower()
+    base_b = _SEARCH_ENGINE_SUFFIX_RE.sub("", b).strip().lower()
+    return bool(base_a) and base_a == base_b
 
 
 def _percent_label(label: str | None) -> bool:
@@ -435,6 +494,8 @@ def prefilter(kind: str | None, a: str | None, b: str | None,
         return "drop", "qpcr_formula_derived_column"
     if flags.get("summary_scale_label"):
         return "drop", "summary_statistic_scaling"
+    if flags.get("search_engine_export_twin"):
+        return "drop", "search_engine_export_duplicate"
     if flags.get("derived_stat_label"):
         return "downweight", "derived_statistical_column"
     if flags.get("explicit_formula_label"):
@@ -447,6 +508,8 @@ def prefilter(kind: str | None, a: str | None, b: str | None,
         return "drop", "n_column"
     if flags.get("image_derived_label"):
         return "drop", "image_processing_derived_column"
+    if flags.get("derived_transform_pair") and kind in {"constant_offset", "constant_ratio", "exact_linear"}:
+        return "drop", "baseline_correction_derived"
     if flags.get("genome_size_unit_conversion"):
         return "drop", "unit_conversion_or_normalization"
     if flags.get("common_unit_scale"):
@@ -475,6 +538,8 @@ def make_finding(kind: str | None, a: str | None, b: str | None, n: int,
         "qpcr_derived_label": _qpcr_derived_label(a) or _qpcr_derived_label(b),
         "summary_scale_label": _summary_scale_label(a) or _summary_scale_label(b),
         "image_derived_label": _image_derived_label(a) or _image_derived_label(b),
+        "derived_transform_pair": _derived_transform_pair(a, b),
+        "search_engine_export_twin": _search_engine_export_twin(kind, a, b),
         "complement_percentage": _complement_percentage(kind, a, b, sa, sb, extra.get("slope"), extra.get("intercept")),
         "complement_fraction": _complement_fraction(kind, a, b, sa, sb, extra.get("slope"), extra.get("intercept")),
         "complement_category": _complement_category(kind, a, b, sa, sb, extra.get("slope"), extra.get("intercept")),

--- a/tests/test_batch2_prefilter.py
+++ b/tests/test_batch2_prefilter.py
@@ -878,3 +878,332 @@ def test_prefilter_drops_latitude_longitude_coordinate_pairs():
 
     assert f["prefilter"] == "drop"
     assert f["prefilter_reason"] == "coordinate_table"
+
+
+# --- R2 rules: ImageJ IntDen / qPCR from-equation / Metascape / baseline-correction / PD export twin ---
+
+def test_prefilter_drops_imagej_intden_equals_rawintden():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "identical_column",
+        "IntDen",
+        "RawIntDen",
+        27,
+        1.0,
+        "col[2] == col[1]",
+        [120.5, 340.2, 560.8, 78.1, 910.3],
+        [120.5, 340.2, 560.8, 78.1, 910.3],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "image_processing_derived_column"
+
+
+def test_prefilter_drops_qpcr_quantity_from_equation():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio",
+        "Cq",
+        "Copies from equation",
+        30,
+        1.0,
+        "col[2] = col[1] * 0.5",
+        [22.1, 20.4, 24.7, 19.5, 26.3],
+        [11.05, 10.2, 12.35, 9.75, 13.15],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "qpcr_formula_derived_column"
+
+
+def test_prefilter_downweights_metascape_enrichment_columns():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "exact_linear",
+        "LogP",
+        "FirstInGroupByEnrichment",
+        40,
+        1.0,
+        "col[2] = 1 * col[1] + 0",
+        [-5.2, -3.1, -8.4, -2.0, -10.1],
+        [-5.2, -3.1, -8.4, -2.0, -10.1],
+    )
+
+    assert f["prefilter"] == "downweight"
+    assert f["prefilter_reason"] == "derived_statistical_column"
+
+
+def test_prefilter_drops_single_sided_baseline_corrected_transform():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_offset",
+        "Absorbance",
+        "Absorbance corrected",
+        16,
+        1.0,
+        "col[2] = col[1] + -0.08",
+        [0.81, 0.72, 0.69, 0.63, 0.51],
+        [0.73, 0.64, 0.61, 0.55, 0.43],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "baseline_correction_derived"
+
+
+def test_prefilter_drops_baseline_correction_noun_form():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_offset",
+        "Signal",
+        "Signal baseline correction",
+        16,
+        1.0,
+        "col[2] = col[1] + -0.08",
+        [0.81, 0.72, 0.69, 0.63, 0.51],
+        [0.73, 0.64, 0.61, 0.55, 0.43],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "baseline_correction_derived"
+
+
+def test_prefilter_drops_blank_subtraction_noun_form():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_offset",
+        "OD",
+        "OD blank subtraction",
+        16,
+        1.0,
+        "col[2] = col[1] + -0.08",
+        [0.81, 0.72, 0.69, 0.63, 0.51],
+        [0.73, 0.64, 0.61, 0.55, 0.43],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "baseline_correction_derived"
+
+
+def test_prefilter_drops_nominal_to_corrected_same_measurement():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio",
+        "Nominal response",
+        "Corrected response",
+        16,
+        1.0,
+        "col[2] = col[1] * 0.727",
+        [1.0, 2.4, 3.1, 4.8, 5.2],
+        [0.727, 1.7448, 2.2537, 3.4896, 3.7804],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "baseline_correction_derived"
+
+
+def test_prefilter_keeps_two_independent_corrected_columns():
+    # Both sides carry the token -> NOT a raw->corrected derivation; two corrected things being
+    # identical is itself the concern. Must NOT be auto-dropped.
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "identical_column",
+        "WT corrected",
+        "KO corrected",
+        30,
+        1.0,
+        "col[2] == col[1]",
+        [1.21, 2.34, 3.56, 4.78, 5.91],
+        [1.21, 2.34, 3.56, 4.78, 5.91],
+    )
+
+    assert f["flags"]["derived_transform_pair"] is False
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_keeps_one_sided_corrected_independent_groups():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_offset",
+        "WT",
+        "KO corrected",
+        30,
+        1.0,
+        "col[2] = col[1] + -0.08",
+        [1.21, 2.34, 3.56, 4.78, 5.91],
+        [1.13, 2.26, 3.48, 4.70, 5.83],
+    )
+
+    assert f["flags"]["derived_transform_pair"] is False
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_keeps_shared_measurement_token_but_different_groups():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_offset",
+        "WT OD",
+        "KO OD corrected",
+        30,
+        1.0,
+        "col[2] = col[1] + -0.08",
+        [1.21, 2.34, 3.56, 4.78, 5.91],
+        [1.13, 2.26, 3.48, 4.70, 5.83],
+    )
+
+    assert f["flags"]["derived_transform_pair"] is False
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_keeps_baseline_condition_with_corrected_other_group():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_offset",
+        "Baseline OD",
+        "OD corrected",
+        30,
+        1.0,
+        "col[2] = col[1] + -0.08",
+        [1.21, 2.34, 3.56, 4.78, 5.91],
+        [1.13, 2.26, 3.48, 4.70, 5.83],
+    )
+
+    assert f["flags"]["derived_transform_pair"] is False
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_keeps_blank_condition_token_when_not_correction_phrase():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_offset",
+        "Blank media OD",
+        "Media OD corrected",
+        30,
+        1.0,
+        "col[2] = col[1] + -0.08",
+        [1.21, 2.34, 3.56, 4.78, 5.91],
+        [1.13, 2.26, 3.48, 4.70, 5.83],
+    )
+
+    assert f["flags"]["derived_transform_pair"] is False
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_keeps_background_condition_token_when_not_correction_phrase():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_offset",
+        "Background OD",
+        "OD corrected",
+        30,
+        1.0,
+        "col[2] = col[1] + -0.08",
+        [1.21, 2.34, 3.56, 4.78, 5.91],
+        [1.13, 2.26, 3.48, 4.70, 5.83],
+    )
+
+    assert f["flags"]["derived_transform_pair"] is False
+    assert f["flags"]["image_derived_label"] is False
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_keeps_original_independent_condition_label():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio",
+        "Control original",
+        "Treatment",
+        30,
+        1.0,
+        "col[2] = col[1] * 0.7",
+        [10.0, 22.0, 31.0, 48.0, 56.0],
+        [7.0, 15.4, 21.7, 33.6, 39.2],
+    )
+
+    assert f["flags"]["derived_transform_pair"] is False
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_keeps_independent_groups_with_fixed_ratio_no_derivation_token():
+    # Real Tier-1 pattern (e.g. PBS vs Phosphatidylcholine x0.7): a fixed ratio between two
+    # independent groups with no derivation token must survive.
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio",
+        "PBS",
+        "Phosphatidylcholine",
+        6,
+        1.0,
+        "col[2] = col[1] * 0.7",
+        [10.0, 22.0, 31.0, 48.0, 56.0],
+        [7.0, 15.4, 21.7, 33.6, 39.2],
+    )
+
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_drops_search_engine_export_twin():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "identical_column",
+        "# Peptides",
+        "# Peptides (by Search Engine): Sequest HT",
+        50,
+        1.0,
+        "col[2] == col[1]",
+        [3.0, 12.0, 7.0, 21.0, 9.0],
+        [3.0, 12.0, 7.0, 21.0, 9.0],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "search_engine_export_duplicate"
+
+
+def test_prefilter_drops_statistical_search_engine_export_twin_before_stat_downweight():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "identical_column",
+        "P.Value",
+        "P.Value (by Search Engine): Sequest HT",
+        50,
+        1.0,
+        "col[2] == col[1]",
+        [0.01, 0.23, 0.04, 0.5, 0.91],
+        [0.01, 0.23, 0.04, 0.5, 0.91],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "search_engine_export_duplicate"
+
+
+def test_prefilter_does_not_drop_search_engine_suffix_transform():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio",
+        "# Peptides",
+        "# Peptides (by Search Engine): Sequest HT",
+        50,
+        1.0,
+        "col[2] = col[1] * 2",
+        [3.0, 12.0, 7.0, 21.0, 9.0],
+        [6.0, 24.0, 14.0, 42.0, 18.0],
+    )
+
+    assert f["flags"]["search_engine_export_twin"] is False
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_keeps_different_bases_with_search_engine_suffix():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "identical_column",
+        "Metric A",
+        "Metric B (by Search Engine): Mascot",
+        12,
+        1.0,
+        "col[2] == col[1]",
+        [0.11, 0.29, 0.37, 0.68, 0.91],
+        [0.11, 0.29, 0.37, 0.68, 0.91],
+    )
+
+    assert f["flags"]["search_engine_export_twin"] is False
+    assert f["prefilter"] == "keep"


### PR DESCRIPTION
## Summary

- Add conservative semantic prefilter rules for one-sided baseline/background/blank correction transforms.
- Expand derived labels for ImageJ intensity exports, qPCR formula outputs, Metascape/statistical helper columns, and Proteome Discoverer / search-engine export twins.
- Add regression tests to keep independent corrected columns, one-sided corrected independent groups, baseline/background/blank condition labels, search-engine suffix transforms, and independent treatment/group fixed-ratio candidates from being auto-dropped.

## Validation

- `uv run pytest -q` -> 253 passed, 3 skipped
- `git diff --check`
- Replay on 2,155 judged `transform_stat/transform` packets after tightening: lost KEEP = 0; additional fully auto-dropped judged DROP = 29; one NEEDS_HUMAN would auto-drop and should be spot-checked before using replay to retire NEEDS_HUMAN rows.

## Review Follow-up

- Tightened baseline/correction derived-pair detection so one-sided correction only drops when both labels have the same substantive base measurement after stripping complete correction/subtraction phrases.
- Removed `orig/original` as a standalone trigger.
- Avoid stripping standalone `baseline`, `background`, or `blank` condition words unless they are part of an explicit correction/subtraction phrase.
- Removed standalone `background/bg` from image-derived auto-drop matching.
- Moved search-engine export twins before broad statistical downweighting, and limited that rule to duplicate/equal finding kinds.
- Added negative tests for `WT` vs `KO corrected`, `Control original` vs `Treatment`, `WT OD` vs `KO OD corrected`, `Baseline OD` vs `OD corrected`, `Background OD` vs `OD corrected`, `Blank media OD` vs `Media OD corrected`, and non-identical search-engine-suffix transforms.

## Notes

This PR only changes product prefilter code and tests. Batch audit notes, downloaded packets, and reports remain uncommitted under `recheck/`.
