### PR TITLE
Improve transform prefilter for SEM and ID sums

### DIFF
--- a/src/paperconan/_prefilter.py
+++ b/src/paperconan/_prefilter.py
@@ -76,7 +76,14 @@ _QPCR_DERIVED_RE = re.compile(
     r"from[ _-]*equation)\b",
     re.I,
 )
-_SUMMARY_SCALE_RE = re.compile(r"\b(?:sem|s\.e\.m|se|sd|s\.d|std|stdev|stddev)\b", re.I)
+_SEM_LABEL_RE = re.compile(
+    r"\b(?:sem|s\.e\.m|se|standard[ _-]*error|std[._ -]*error|st[._ -]*error)\b",
+    re.I,
+)
+_SD_LABEL_RE = re.compile(
+    r"\b(?:sd|s\.d|stdev|stddev|standard[ _-]*deviation)\b|\bstd\b(?![._ -]*error)",
+    re.I,
+)
 _IMAGE_DERIVED_RE = re.compile(
     r"\b(gray|grey|intensity|pixel|invert|normalized|normalised|"
     r"set\s*0|threshold|roi|intden|rawintden|raw\s*int\s*den|integrated\s*density|"
@@ -144,6 +151,11 @@ _LONGITUDE_RE = re.compile(r"\b(?:longitude|lon|long)\b", re.I)
 _INFO_CRITERION_RE = re.compile(r"^(?:aic|bic|aicc)$", re.I)
 _CENTERED_STANDARDIZED_RE = re.compile(
     r"(?:^|[_\s-])(?:centered|centred|standardi[sz]ed)(?:$|[_\s-])",
+    re.I,
+)
+_ID_TIMESTAMP_RE = re.compile(
+    r"\b(?:id|identifier|accession|barcode|timestamp|time[ _-]*stamp|epoch|unix[ _-]*time|"
+    r"date[ _-]*(?:time|stamp)?|sample[ _-]*(?:id|identifier)|specimen[ _-]*id)\b",
     re.I,
 )
 _COMPLEMENT_LABEL_PAIRS = (
@@ -343,6 +355,121 @@ def _genome_size_unit_conversion(kind: str | None, a: str | None, b: str | None,
     return has_genome_size_context and has_pg and (has_mbp or has_gbp)
 
 
+def _median(vals: list[float]) -> float:
+    ordered = sorted(vals)
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2.0
+
+
+def _sample_ratio(sa: list[Any] | None, sb: list[Any] | None) -> float | None:
+    pairs = [(x, y) for x, y in zip(_nums(sa), _nums(sb)) if abs(x) > 1e-12 and abs(y) > 1e-12]
+    if len(pairs) < 3:
+        return None
+    ratios = [y / x for x, y in pairs]
+    ratio = _median(ratios)
+    scale = max(abs(ratio), 1.0)
+    if not all(abs(r - ratio) <= 1e-4 * scale for r in ratios):
+        return None
+    return abs(ratio)
+
+
+def _adjacent_column_rule(rule: str | None) -> bool:
+    if not rule:
+        return False
+    cols = [int(x) for x in re.findall(r"col\[(\d+)\]", rule)]
+    return len(cols) >= 2 and abs(cols[0] - cols[1]) == 1
+
+
+def _low_context_label(label: str | None) -> bool:
+    text = (label or "").strip()
+    return not text or re.fullmatch(r"(?:col(?:umn)?|var|x|y)?\s*\d*", text, re.I) is not None
+
+
+def _near_zero_intercept(intercept: Any) -> bool:
+    if intercept is None:
+        return True
+    try:
+        return abs(float(intercept)) <= 1e-8
+    except (TypeError, ValueError):
+        return False
+
+
+def _sem_sd_integer_n_scaling(kind: str | None, a: str | None, b: str | None,
+                              sa: list[Any] | None, sb: list[Any] | None,
+                              slope: Any = None, intercept: Any = None,
+                              n: int = 0, rule: str | None = None) -> bool:
+    if kind not in {"constant_ratio", "exact_linear"}:
+        return False
+    has_sd_sem_pair = (
+        (_SD_LABEL_RE.search(a or "") and _SEM_LABEL_RE.search(b or ""))
+        or (_SEM_LABEL_RE.search(a or "") and _SD_LABEL_RE.search(b or ""))
+    )
+    unlabeled_adjacent_pair = (
+        not has_sd_sem_pair
+        and int(n or 0) >= 100
+        and _low_context_label(a)
+        and _low_context_label(b)
+        and _adjacent_column_rule(rule)
+    )
+    if not (has_sd_sem_pair or unlabeled_adjacent_pair):
+        return False
+    ratio = None
+    if kind == "exact_linear":
+        if not _near_zero_intercept(intercept):
+            return False
+        try:
+            ratio = abs(float(slope))
+        except (TypeError, ValueError):
+            ratio = None
+    if ratio is None:
+        ratio = _sample_ratio(sa, sb)
+    if ratio is None or ratio <= 1e-12:
+        return False
+    ratio = min(ratio, 1.0 / ratio)
+    implied_n = 1.0 / (ratio * ratio)
+    nearest = round(implied_n)
+    if abs(implied_n - nearest) > 0.03:
+        return False
+    if has_sd_sem_pair:
+        return 2 <= nearest <= 200
+    return 5 <= nearest <= 30
+
+
+def _mostly_integerish(vals: list[float]) -> bool:
+    if len(vals) < 3:
+        return False
+    return sum(1 for v in vals if abs(v - round(v)) <= 1e-6) >= max(3, len(vals) - 1)
+
+
+def _dominant_id_timestamp_values(vals: list[float], other: list[float], label: str | None) -> bool:
+    if len(vals) < 3 or len(other) < 3 or not _mostly_integerish(vals):
+        return False
+    abs_vals = [abs(v) for v in vals if abs(v) > 0]
+    abs_other = [abs(v) for v in other]
+    if not abs_vals or not abs_other:
+        return False
+    median_large = _median(abs_vals)
+    max_other = max(abs_other)
+    label_match = _ID_TIMESTAMP_RE.search(label or "") is not None
+    spread = max(abs_vals) - min(abs_vals)
+    # Unlabeled timestamp-like columns are restricted to epoch-millisecond scale
+    # and tight local ranges; other ID/timestamp ranges require label support.
+    timestamp_like = 1e12 <= median_large <= 3e12 and spread <= 1e8
+    if not (label_match or timestamp_like):
+        return False
+    return median_large >= 1e9 and max_other / median_large <= 1e-4
+
+
+def _id_timestamp_dominant_sum(kind: str | None, a: str | None, b: str | None,
+                               sa: list[Any] | None, sb: list[Any] | None) -> bool:
+    if kind != "sum_constant" or not _samples_sum_constant(sa, sb):
+        return False
+    va, vb = _nums(sa), _nums(sb)
+    return _dominant_id_timestamp_values(va, vb, a) or _dominant_id_timestamp_values(vb, va, b)
+
+
 def _large_integer_coordinates(sa: list[Any] | None, sb: list[Any] | None) -> bool:
     vals = _nums(sa) + _nums(sb)
     if len(vals) < 4:
@@ -367,10 +494,6 @@ def _coordinate_pair(a: str | None, b: str | None, sa: list[Any] | None, sb: lis
 
 def _qpcr_derived_label(label: str | None) -> bool:
     return bool(_QPCR_DERIVED_RE.search(label or ""))
-
-
-def _summary_scale_label(label: str | None) -> bool:
-    return bool(_SUMMARY_SCALE_RE.search(label or ""))
 
 
 def _replicate_label(label: str | None) -> bool:
@@ -490,6 +613,8 @@ def prefilter(kind: str | None, a: str | None, b: str | None,
         return "drop", "complement_fraction_sum_to_constant"
     if flags.get("complement_category"):
         return "drop", "complement_category_sum_to_constant"
+    if flags.get("id_timestamp_dominant_sum"):
+        return "drop", "id_timestamp_dominant_sum"
     if flags.get("qpcr_derived_label"):
         return "drop", "qpcr_formula_derived_column"
     if flags.get("summary_scale_label"):
@@ -536,13 +661,16 @@ def make_finding(kind: str | None, a: str | None, b: str | None, n: int,
         "derived_label": _derived_label(a) or _derived_label(b),
         "derived_stat_label": _derived_stat_label(a) or _derived_stat_label(b),
         "qpcr_derived_label": _qpcr_derived_label(a) or _qpcr_derived_label(b),
-        "summary_scale_label": _summary_scale_label(a) or _summary_scale_label(b),
+        "summary_scale_label": _sem_sd_integer_n_scaling(
+            kind, a, b, sa, sb, extra.get("slope"), extra.get("intercept"), int(n or 0), rule
+        ),
         "image_derived_label": _image_derived_label(a) or _image_derived_label(b),
         "derived_transform_pair": _derived_transform_pair(a, b),
         "search_engine_export_twin": _search_engine_export_twin(kind, a, b),
         "complement_percentage": _complement_percentage(kind, a, b, sa, sb, extra.get("slope"), extra.get("intercept")),
         "complement_fraction": _complement_fraction(kind, a, b, sa, sb, extra.get("slope"), extra.get("intercept")),
         "complement_category": _complement_category(kind, a, b, sa, sb, extra.get("slope"), extra.get("intercept")),
+        "id_timestamp_dominant_sum": _id_timestamp_dominant_sum(kind, a, b, sa, sb),
         "interval_bound_pair": _interval_bound_pair(a, b),
         "coordinate_label_pair": _coordinate_label_pair(a, b),
         "information_criterion_pair": _information_criterion_pair(a, b),

--- a/tests/test_batch2_prefilter.py
+++ b/tests/test_batch2_prefilter.py
@@ -124,6 +124,125 @@ def test_prefilter_drops_explicit_sem_sd_scaling():
     assert f["prefilter_reason"] == "summary_statistic_scaling"
 
 
+def test_prefilter_drops_sem_sd_scaling_for_integer_sample_size():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio",
+        "standard deviation",
+        "standard error",
+        24,
+        1.0,
+        "col[2] = col[1] * 0.447214",
+        [2.0, 3.2, 4.7, 5.1, 6.8],
+        [0.894428, 1.4310848, 2.1019058, 2.2807914, 3.0410552],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "summary_statistic_scaling"
+
+
+def test_prefilter_does_not_drop_sem_sd_scaling_for_non_integer_sample_size():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio",
+        "material A SD",
+        "material B SEM",
+        24,
+        1.0,
+        "col[2] = col[1] * 0.5468",
+        [2.0, 3.2, 4.7, 5.1, 6.8],
+        [1.0936, 1.74976, 2.56996, 2.78868, 3.71824],
+    )
+
+    assert f["flags"]["summary_scale_label"] is False
+    assert f["prefilter"] != "drop"
+
+
+def test_prefilter_drops_explicit_sem_sd_scaling_for_large_sample_size():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio",
+        "SD",
+        "SEM",
+        300,
+        1.0,
+        "col[2] = col[1] * 0.141421",
+        [2.0, 3.2, 4.7, 5.1, 6.8],
+        [0.282842, 0.4525472, 0.6646787, 0.7212471, 0.9616628],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "summary_statistic_scaling"
+
+
+def test_prefilter_drops_unlabeled_adjacent_sem_scale_ratio():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio",
+        "",
+        "",
+        360,
+        1.0,
+        "col[4] = col[3] * 0.377964",
+        [23.530812, 33.67896, 33.460176, 29.0, 31.5],
+        [8.893811, 12.72945, 12.646758, 10.9609697, 11.9058809],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "summary_statistic_scaling"
+
+
+def test_prefilter_keeps_unlabeled_adjacent_low_sample_sqrt_ratio():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio",
+        "",
+        "",
+        360,
+        1.0,
+        "col[4] = col[3] * 0.5",
+        [2.0, 3.2, 4.7, 5.1, 6.8],
+        [1.0, 1.6, 2.35, 2.55, 3.4],
+    )
+
+    assert f["flags"]["summary_scale_label"] is False
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_keeps_small_unlabeled_adjacent_sqrt_ratio():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio",
+        "",
+        "",
+        24,
+        1.0,
+        "col[4] = col[3] * 0.377964",
+        [23.530812, 33.67896, 33.460176, 29.0, 31.5],
+        [8.893811, 12.72945, 12.646758, 10.9609697, 11.9058809],
+    )
+
+    assert f["flags"]["summary_scale_label"] is False
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_keeps_labeled_independent_integer_sqrt_ratio():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio",
+        "PBS",
+        "Phosphatidylcholine",
+        360,
+        1.0,
+        "col[4] = col[3] * 0.5",
+        [2.0, 3.2, 4.7, 5.1, 6.8],
+        [1.0, 1.6, 2.35, 2.55, 3.4],
+    )
+
+    assert f["flags"]["summary_scale_label"] is False
+    assert f["prefilter"] == "keep"
+
+
 def test_prefilter_drops_image_processing_derived_columns():
     cp = _collector()
     f = cp.prefilter_relation_finding(
@@ -621,6 +740,57 @@ def test_prefilter_keeps_independent_conditions_that_sum_to_one():
         [0.0, 0.0, 0.1111, 0.1111, 0.4444],
     )
 
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_drops_id_timestamp_dominant_sum_constant():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "sum_constant",
+        "timestamp_ms",
+        "elapsed_seconds",
+        50,
+        1.0,
+        "col[1] + col[2] = 1700000010000",
+        [1700000000000, 1700000000001, 1700000000002, 1700000000003, 1700000000004],
+        [10000, 9999, 9998, 9997, 9996],
+    )
+
+    assert f["prefilter"] == "drop"
+    assert f["prefilter_reason"] == "id_timestamp_dominant_sum"
+
+
+def test_prefilter_keeps_large_measurements_that_sum_without_id_context():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "sum_constant",
+        "treatment signal",
+        "control signal",
+        50,
+        1.0,
+        "col[1] + col[2] = 2000000000",
+        [1200000000, 1300000000, 1100000000, 1250000000, 1400000000],
+        [800000000, 700000000, 900000000, 750000000, 600000000],
+    )
+
+    assert f["flags"]["id_timestamp_dominant_sum"] is False
+    assert f["prefilter"] == "keep"
+
+
+def test_prefilter_keeps_unlabeled_dominant_large_sum_outside_timestamp_range():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "sum_constant",
+        "",
+        "residual",
+        50,
+        1.0,
+        "col[1] + col[2] = 5000000010000",
+        [5000000000000, 5000000000001, 5000000000004, 5000000000009, 5000000000016],
+        [10000, 9999, 9996, 9991, 9984],
+    )
+
+    assert f["flags"]["id_timestamp_dominant_sum"] is False
     assert f["prefilter"] == "keep"
 
 


### PR DESCRIPTION
## Summary
- make summary-statistic scaling ratio-aware using integer 1/sqrt(n) SD/SEM relationships
- cover unlabeled adjacent high-row-count SEM-like source-data columns, with safeguards for labeled independent comparisons and low implied sample sizes
- add conservative ID/timestamp-dominant sum_constant auto-drop rule with label or tight epoch-ms safeguards

## Verification
- uv run pytest
- replayed cached KEEP packets: 198 packets, 0 lost all survivors
- replayed rereview KEEP packets: 20 packets, 0 lost all survivors
- replayed exemplar 10.1038/s41586-020-2805-8: 27 survivors -> 3, with 24 removed by summary_statistic_scaling
- reviewed by subagent; tightened unlabeled SD/SEM and timestamp-like safeguards after review
