### PR TITLE
fix(detect): per-row/per-cell tolerance in fraction-reuse detectors (M2-1)

### DIFF
--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -756,7 +756,13 @@ def detect_relations(sheet, r0, r1, c0, c1, header):
             # (e.g. 178.7615 vs 112.7615, 169.8687 vs 115.8687). The precision requirement lets this
             # fire from n>=5 without the false positives a bare small-diff-set floor would admit.
             if n >= 5:
-                diff_is_int = np.abs(diff - np.round(diff)) < tol
+                # Per-row tolerance for the integer-difference test: representation noise at each
+                # row's OWN magnitude, not the column-wide max. A single extreme value (an inf /
+                # placeholder like a 1e99 fold-change for a zero-denominator row) must not inflate
+                # the tolerance so that every row's diff reads as a whole number — that produced
+                # spurious whole-sheet integer_diff_shared_fraction findings (M2-1).
+                diff_tol = 1e-9 * np.maximum(np.maximum(np.abs(x), np.abs(y)), 1e-300)
+                diff_is_int = np.abs(diff - np.round(diff)) < diff_tol
                 frac_x = x - np.round(x)                       # signed distance to nearest integer
                 hp_rows = diff_is_int & (np.abs(frac_x) > 1e-6)
                 hp_fracs = [float(v) for v in frac_x[hp_rows] if _sig_frac_digits(v) >= 4]
@@ -2318,13 +2324,16 @@ def detect_within_sheet_fraction_reuse(grid_sheets, profile="review", min_cells=
                 common = [k for k in ca if k in cb]
                 if len(common) < min_cells:
                     continue
-                scale = max(max(abs(ca[k]) for k in common), max(abs(cb[k]) for k in common), 1.0)
-                tol = 1e-6 * scale
                 shared = int_diffs = hp = 0
                 fracs, diffset = set(), set()
                 for k in common:
                     x, y = ca[k], cb[k]
                     d = y - x
+                    # Per-cell tolerance at THIS cell's magnitude, not the block-wide max. A single
+                    # extreme value (a huge integer coordinate like distanceToTSS ~3.6e6, or a
+                    # placeholder) must not inflate the tolerance so that every cell reads as an
+                    # integer difference — that produced spurious whole-block fraction_reuse (M2-1).
+                    tol = 1e-6 * max(abs(x), abs(y), 1.0)
                     if abs(d - round(d)) < tol:                 # integer difference => same fraction
                         shared += 1
                         if abs(round(d)) >= 1:

--- a/tests/test_fraction_reuse.py
+++ b/tests/test_fraction_reuse.py
@@ -92,6 +92,24 @@ def test_b3_no_flag_when_blocks_are_independent():
     assert _b3_oracle(a_rows, b_rows) is False
 
 
+def test_b3_no_flag_when_one_large_integer_column_inflates_block_scale():
+    # regression (M2-1): a large-integer column (e.g. distanceToTSS up to ~3.6e6) must not
+    # inflate the block-wide tolerance (1e-6 * block_max ~= 3.6) so that every independent
+    # fractional cell reads as an integer-difference shared fraction. Two GENUINELY INDEPENDENT
+    # fractional matrices that merely happen to include a big-integer coordinate column must NOT
+    # flag; a per-cell tolerance keeps the fractional cells honest.
+    a_rows, _ = _matrix_block(_BASE, _SHIFTS)
+    b_rows = [[round(v * 0.837 + 1.1119, 5) for v in row] for row in a_rows]   # independent
+    dist_a = [37.0, 128000.0, 3600000.0, 4200.0, 990000.0, 17.0, 250000.0]
+    dist_b = [512.0, 44000.0, 1800000.0, 63.0, 770000.0, 209.0, 130000.0]
+    a_rows = [list(r) + [dist_a[i]] for i, r in enumerate(a_rows)]
+    b_rows = [list(r) + [dist_b[i]] for i, r in enumerate(b_rows)]
+    gs = _grid_sheets_two_blocks(a_rows, b_rows)
+    f = detect_within_sheet_fraction_reuse(gs)
+    assert not [x for x in f if x["severity"] == "high"], f
+    assert _b3_oracle(a_rows, b_rows) is False
+
+
 def test_b3_no_flag_on_low_precision_half_grid():
     base = [[round((r * 7 + c) * 0.5, 1) for c in range(7)] for r in range(7)]   # .0/.5 only
     shifts = [[(r + c) % 5 for c in range(7)] for r in range(7)]

--- a/tests/test_relations_tolerance.py
+++ b/tests/test_relations_tolerance.py
@@ -110,17 +110,20 @@ def test_metadata_coordinate_row_does_not_loosen_many_equal_pair_tolerance():
 
 def _b5_oracle(a, b):
     """Independent ground truth: >=max(5,0.8n) rows differ by a (near-)integer, >=3 distinct
-    high-precision (>=4 sig frac digit) shared fractions, and >=2 distinct integer offsets."""
+    high-precision (>=4 sig frac digit) shared fractions, and >=2 distinct integer offsets.
+    Tolerance is per-row (at each row's own magnitude), so one extreme value can't inflate it."""
     n = len(a)
-    scale = max(max(abs(v) for v in a), max(abs(v) for v in b), 1.0)
-    tol = 1e-9 * scale
+    def _is_int_diff(aa, bb):
+        tol = 1e-9 * max(abs(aa), abs(bb), 1e-300)
+        d = bb - aa
+        return abs(d - round(d)) < tol
     diffs = [bb - aa for aa, bb in zip(a, b)]
-    int_diffs = [d for d in diffs if abs(d - round(d)) < tol]
+    int_diffs = [bb - aa for aa, bb in zip(a, b) if _is_int_diff(aa, bb)]
     def sig(v):
         fv = abs(v - round(v))
         return 0 if fv < 1e-9 else len(f"{fv:.9f}".split(".")[1].rstrip("0"))
-    hp = {round(aa - round(aa), 6) for aa, d in zip(a, diffs)
-          if abs(d - round(d)) < tol and sig(aa) >= 4}
+    hp = {round(aa - round(aa), 6) for aa, bb in zip(a, b)
+          if _is_int_diff(aa, bb) and sig(aa) >= 4}
     return (len(int_diffs) >= max(5, round(0.8 * n))
             and len(hp) >= 3
             and len({round(d) for d in int_diffs}) >= 2)
@@ -167,6 +170,31 @@ def test_b5_no_fp_on_independent_measurements():
     f = _kinds(a, b)
     assert not any(x["kind"] == "integer_diff_shared_fraction" for x in f)
     assert _b5_oracle(a, b) is False
+
+
+def test_b5_no_fp_when_one_extreme_value_inflates_tolerance():
+    # regression (M2-1): a single extreme value (an inf/placeholder like a 1e99 fold-change)
+    # must NOT inflate the column-wide tolerance so that every row's diff reads as a whole
+    # number. x and y are independent measurements whose diffs are genuinely non-integer, plus
+    # one 1e99 placeholder row. With a column-wide tol = 1e-9 * max|value| ~ 1e90 every row
+    # passed vacuously and the detector emitted a spurious whole-sheet integer_diff_shared_fraction;
+    # a per-row tolerance rejects the normal rows.
+    x = [2.3456, -1.7890, 3.0112, 0.5561, -2.8834, 1.2207, 4.9019, 1e99]
+    y = [100.0, 50.0, 3000.0, 7.0, 12.0, 900.0, 45.0, 0.0]
+    f = _kinds(x, y)
+    assert not any(k["kind"] == "integer_diff_shared_fraction" for k in f), f
+    assert _b5_oracle(x, y) is False
+
+
+def test_b5_no_fp_on_large_integer_coordinate_column():
+    # regression (M2-1): a big integer column (e.g. distanceToTSS up to ~3.6e6) paired with a
+    # small fractional score column must not read as shared-fraction integer-diff on every row.
+    frac_score = [0.31, 0.47, 0.12, 0.58, 0.09, 0.66, 0.23, 0.41, 0.77, 0.05]
+    dist_to_tss = [5000.0, 128000.0, 3600000.0, 42.0, 990000.0, 17.0, 250000.0,
+                   8100.0, 33.0, 1400000.0]
+    f = _kinds(frac_score, dist_to_tss)
+    assert not any(k["kind"] == "integer_diff_shared_fraction" for k in f), f
+    assert _b5_oracle(frac_score, dist_to_tss) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`integer_diff_shared_fraction` (B5, `detect_relations`) and
`within_table_fraction_reuse` (B3, `detect_within_sheet_fraction_reuse`) decide
whether the difference between two values is a whole number using a tolerance
derived from the **column/block-wide max magnitude**: `tol = c · max|value|`.

A single extreme value in either column then inflates the tolerance so that
**every** row/cell trivially reads as an integer difference, emitting a spurious
whole-sheet cluster of HIGH findings.

## Evidence (3 retracted papers, found during a gold-standard recall eval)

| DOI | trigger | before | after |
|-----|---------|-------:|------:|
| `10.1038/s41467-020-20506-4` | a `1e99` log2FoldChange placeholder (zero-read gene) → tol ≈ 1e90 | 8 HIGH `integer_diff_shared_fraction` | **0** |
| `10.1038/s41586-022-05487-2` | `distanceToTSS` integers up to ~3.6e6 → tol ≈ 3.6 | 8 HIGH `within_table_fraction_reuse` | **0** |
| `10.1038/s41467-024-50838-4` | integer-valued columns | same class | eliminated |

A **genuine** `small_diff_set` signal in `05487-2` (ED Fig. 5g, avg.exp identical
for 20/22 genes) is **preserved** — the fix removes only the false positives.

## Fix

Compute the integer-difference tolerance **per row (B5) / per cell (B3)** at that
row/cell's own magnitude, matching the `_isclose_rowwise` pattern already used by
the identical / linear / offset relation tests. An outlier now only affects its
own row instead of the whole comparison.

## Tests

- 3 regression tests added (`test_b5_no_fp_when_one_extreme_value_inflates_tolerance`,
  `test_b5_no_fp_on_large_integer_coordinate_column`,
  `test_b3_no_flag_when_one_large_integer_column_inflates_block_scale`) — each fails
  without the fix.
- The B5/B3 brute-force oracles were updated to per-row/per-cell tolerance to stay
  correct ground truth.
- Full suite: 376 passed (the one pre-existing `test_corpus_is_fully_read_including_xls`
  failure is unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)