### PR TITLE
fix(detect): demote reused arithmetic progressions as re-plotted axes (M2-2)

### DIFF
--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -538,6 +538,10 @@ def benign_reason(f):
     """
     kind = f.get("kind")
     if kind == "arithmetic_progression":
+        if f.get("reused_progression"):
+            return ("this exact progression is re-plotted across >=2 panels — an "
+                    "independent-variable axis (field / angle / time / dose / wavelength "
+                    "sweep), not measured data")
         step = f.get("step")
         if step is not None and abs(step - round(step)) < 1e-9:
             return ("an integer-step progression is usually an axis (day / dose / "
@@ -1046,6 +1050,37 @@ def _demote_dense_sheets(report_blocks, cap=RELATION_FLOOD_CAP):
         _demote_dense_relations(agg["relations"], cap)   # same dict objects as in blocks
         _demote_dense_relations(agg["equal_pairs"], cap)
         _demote_within_col_flood(agg["within_col"])      # per-sheet within-col flood gate
+    return report_blocks
+
+
+def _demote_reused_progressions(report_blocks):
+    """A perfect arithmetic progression that is REUSED — the identical (step, n, first)
+    appears in >=2 numeric blocks/sheets — is an independent-variable axis re-plotted across
+    panels (magnetic-field / 2-theta / time / dose / wavelength sweep), not fabricated data.
+    Real measured data is never a perfect progression; a reused perfect progression is an axis.
+    Demote these out of the high/medium review priority (kept in scan.json, reversible via
+    forensic). A ONE-OFF perfect progression keeps its severity — that is the genuinely
+    suspicious linear-fill case (and matches the golden fixture's single ap_col). Mutates in
+    place and returns report_blocks."""
+    sig_count = {}
+    progs = []
+    for b in report_blocks:
+        for f in b.get("progressions", []):
+            if f.get("kind") != "arithmetic_progression":
+                continue
+            sig = (round(float(f.get("step", 0.0)), 9), f.get("n"),
+                   round(float(f.get("first", 0.0)), 9))
+            sig_count[sig] = sig_count.get(sig, 0) + 1
+            progs.append((sig, f))
+    for sig, f in progs:
+        if sig_count.get(sig, 0) >= 2:
+            f["severity"] = "low"
+            f["reused_progression"] = True
+            f["prefilter"] = "drop"
+            f["prefilter_reason"] = "reused_progression_axis"
+            note = benign_reason(f)               # runs AFTER _attach_benign, so set it here
+            if note:
+                f["likely_benign"] = note
     return report_blocks
 
 
@@ -2526,6 +2561,7 @@ def scan_dir(in_dir, out_dir, *, write_md=False, write_html=True, paper=None,
     # Down-weight dense/correlated sheets: judged by per-sheet relation totals, so a
     # wide matrix's expected identical/linear columns don't flood high-severity output.
     _demote_dense_sheets(report_blocks)
+    _demote_reused_progressions(report_blocks)   # reused perfect progression = re-plotted axis
 
     # Unified collision pass: every (file, sheet) grid against every other —
     # covers both intra-workbook sheet pairs and cross-file duplicates.

--- a/tests/test_progression_reuse.py
+++ b/tests/test_progression_reuse.py
@@ -1,0 +1,51 @@
+"""M2-2: a perfect arithmetic progression that is REUSED — the identical (step, n, first)
+appears in >=2 numeric blocks/sheets — is an independent-variable axis re-plotted across panels
+(magnetic-field / 2-theta / time / dose sweep), not fabricated data. Real measured data is never
+a perfect progression, so a reused one is an axis and must not flood the high-severity output.
+A ONE-OFF perfect progression keeps its severity (that is the genuinely-suspicious linear-fill)."""
+from paperconan._audit import _demote_reused_progressions, benign_reason
+
+
+def _prog(step, n, first, sev="high", col_idx=2):
+    return {"kind": "arithmetic_progression", "step": step, "n": n, "first": first,
+            "severity": sev, "col_idx": col_idx}
+
+
+def _block(sheet, progs):
+    return {"file": "S.xlsx", "sheet": sheet, "progressions": progs}
+
+
+def test_reused_axis_progression_demoted_out_of_high():
+    # the same field-axis progression re-plotted across 3 figures → axis → demoted
+    blocks = [_block(f"Fig {i}", [_prog(0.0140281, 500, 0.0)]) for i in range(3)]
+    _demote_reused_progressions(blocks)
+    for b in blocks:
+        f = b["progressions"][0]
+        assert f["severity"] == "low", f
+        assert f.get("reused_progression") is True
+        assert f.get("prefilter") == "drop"
+    # and the benign note explains it as an axis re-plot
+    assert "axis" in (benign_reason(blocks[0]["progressions"][0]) or "")
+
+
+def test_one_off_non_integer_progression_keeps_high():
+    # a single non-integer progression (possible linear-fill fabrication) stays HIGH
+    blocks = [_block("Fig 1", [_prog(2.5, 6, 2.5, sev="high")])]
+    _demote_reused_progressions(blocks)
+    f = blocks[0]["progressions"][0]
+    assert f["severity"] == "high"
+    assert not f.get("reused_progression")
+
+
+def test_different_progressions_are_not_reuse():
+    # two DISTINCT progressions (different step) are not a reused axis — both keep severity
+    blocks = [_block("A", [_prog(2.5, 6, 2.5)]), _block("B", [_prog(3.5, 6, 2.5)])]
+    _demote_reused_progressions(blocks)
+    assert all(b["progressions"][0]["severity"] == "high" for b in blocks)
+
+
+def test_reuse_needs_matching_first_value_too():
+    # same step+n but DIFFERENT starting value are different series, not a reused axis
+    blocks = [_block("A", [_prog(0.1, 500, 100.0)]), _block("B", [_prog(0.1, 500, 0.0)])]
+    _demote_reused_progressions(blocks)
+    assert all(b["progressions"][0]["severity"] == "high" for b in blocks)


### PR DESCRIPTION
**Stacked on #16 (M2-1).** Base is `fix/fraction-tol-per-row`; GitHub will retarget to `main` once #16 merges. Review only the top commit.

## Problem

`arithmetic_progression` marks a perfectly equally-stepped column as HIGH when the
step is non-integer. But a perfect progression is **not** a reliable fabrication
signal — real measured data is never perfectly equally spaced, so a perfect
progression is almost always an **independent-variable axis** (magnetic field,
2θ diffraction angle, time, dose, wavelength sweep). On one superconductor paper
this produced **89 HIGH** findings, all field/angle scan axes.

## The discriminator: reuse, not decimal-messiness

An axis is **re-plotted across many panels**, so the identical `(step, n, first)`
recurs across blocks/sheets; a one-off linear-fill does not. (Instrument axes
often have *messy* non-integer steps — e.g. a 0–7 T field over 500 points steps by
`7/499 = 0.0140281` — so "messy step ⇒ fabrication" is wrong.)

## Fix

New `_demote_reused_progressions` pass: any `arithmetic_progression` whose
`(step, n, first)` signature appears in ≥2 numeric blocks/sheets is demoted to
`low` + tagged `reused_progression_axis` (kept in scan.json, reversible via
`--profile forensic`) with a "re-plotted axis" benign note. A **one-off**
progression keeps its severity — the genuinely-suspicious case, and the golden
fixture's single `ap_col` is unaffected.

## Evidence

`10.1038/s41467-024-50838-4`: all 108 `arithmetic_progression` findings were the
same scan axes replotted per panel → demoted; **total HIGH 131 → 36**.

## Tests

- 4 regression tests (`tests/test_progression_reuse.py`) — reused axis demoted,
  one-off kept HIGH, distinct/different-first not treated as reuse.
- golden / profiles / benign / smoke fixtures unchanged (34 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)