### PR TITLE
fix(detect): dedupe redundant exact_linear when a constant_ratio covers the same pair

### DIFF
--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -675,6 +675,7 @@ def detect_relations(sheet, r0, r1, c0, c1, header):
                                      rule=f"col[{cj}] = col[{ci}] + {mean_diff:.6g}"))
                 continue
             # constant ratio
+            ratio_emitted = False
             if np.all(np.abs(x) > 1e-12):
                 ratio = y / x
                 mean_ratio = float(np.mean(ratio))
@@ -690,6 +691,7 @@ def detect_relations(sheet, r0, r1, c0, c1, header):
                                          severity="high",
                                          col_a_sample=sa, col_b_sample=sb,
                                          rule=f"col[{cj}] = col[{ci}] * {mean_ratio:.6g}"))
+                    ratio_emitted = True
             # mirror: x + y == constant
             csum = x + y
             if n >= 5 and np.std(csum) < tol:
@@ -708,7 +710,17 @@ def detect_relations(sheet, r0, r1, c0, c1, header):
                     continue
                 fitted = slope * x + intercept
                 if np.std(y) > 0 and _allclose_rowwise(y, fitted, rtol=1e-7) and abs(r) > 0.99:
-                    if not (abs(slope - 1) < 1e-9 and abs(intercept) < tol):
+                    # A scale-relatively zero intercept means the fit is y = slope*x: the
+                    # identity (slope~=1, caught by identical_column) or a pure scaling. When a
+                    # constant_ratio already captured that scaling, a second exact_linear finding
+                    # is redundant (same relationship, b==0 to round-off) and only inflates the
+                    # count — suppress it. exact_linear is reserved for a genuine non-zero
+                    # intercept (an affine offset constant_ratio cannot express), and still fires
+                    # when no constant_ratio covered the pair (e.g. a zero in x skips its guard).
+                    intercept_is_zero = abs(intercept) < tol
+                    is_identity = abs(slope - 1) < 1e-9 and intercept_is_zero
+                    redundant_scaling = intercept_is_zero and ratio_emitted
+                    if not (is_identity or redundant_scaling):
                         findings.append(dict(kind="exact_linear", col_a=header[ci - c0], col_b=header[cj - c0],
                                              col_a_idx=ci, col_b_idx=cj, n=n,
                                              slope=float(slope), intercept=float(intercept),

--- a/tests/test_relations_tolerance.py
+++ b/tests/test_relations_tolerance.py
@@ -359,3 +359,23 @@ def test_pure_scaling_with_zero_in_x_still_detected():
         "constant_ratio's zero-guard should skip this column"
     assert any(k["kind"] == "exact_linear" for k in f), \
         f"proportional relationship with a zero in x must still be caught: {f}"
+
+
+def test_ratio_emitted_flag_does_not_leak_across_column_pairs():
+    # Guard: the per-pair `ratio_emitted` flag must be re-initialized for every column
+    # pair. If it were hoisted outside the pair loop, a constant_ratio on an EARLIER pair
+    # (c0,c1) would leave the flag True and wrongly suppress the b~=0 exact_linear on a
+    # LATER pair (c2,c3) whose constant_ratio was skipped by the divide-by-zero guard —
+    # a cross-pair false negative. c2 contains a 0; c2/c3 are independent of c0/c1.
+    c0 = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+    c1 = [2.0 * v for v in c0]                      # pair (c0,c1): pure scaling -> constant_ratio
+    c2 = [0.0, 3.0, 1.0, 4.0, 1.0, 5.0, 9.0, 2.0, 6.0, 5.0]   # has a 0; irregular
+    c3 = [2.5 * v for v in c2]                      # pair (c2,c3): pure scaling with a 0 in x
+    s = _sheet([c0, c1, c2, c3])
+    f = detect_relations(s, 1, len(c0) + 1, 0, 4, ["c0", "c1", "c2", "c3"])
+    cr = {(x["col_a"], x["col_b"]) for x in f if x["kind"] == "constant_ratio"}
+    el = {(x["col_a"], x["col_b"]) for x in f if x["kind"] == "exact_linear"}
+    assert ("c0", "c1") in cr, f"pure scaling of the first pair should be a constant_ratio: {f}"
+    assert ("c0", "c1") not in el, f"first pair's redundant exact_linear must be deduped: {f}"
+    assert ("c2", "c3") in el, \
+        f"later zero-in-x pair's exact_linear must NOT be suppressed by an earlier pair's flag: {f}"

--- a/tests/test_relations_tolerance.py
+++ b/tests/test_relations_tolerance.py
@@ -317,3 +317,45 @@ def test_mixed_scale_true_exact_linear_still_flags():
     findings = detect_relations(s, 1, len(x) + 1, 0, 2, ["x", "y"])
 
     assert any(f["kind"] == "exact_linear" for f in findings), findings
+
+
+# ---------------------------------------------------------------------------
+# Dedupe: a pure proportional relationship (y = k*x, k != 1) is a constant_ratio.
+# The linear fit of the same columns yields the same slope with a zero intercept
+# (down to floating-point round-off ~ eps*scale) — an exact_linear finding that
+# carries no information beyond the constant_ratio and only inflates the count.
+# exact_linear must be reserved for a GENUINE (scale-significant) non-zero intercept.
+# ---------------------------------------------------------------------------
+
+def test_pure_scaling_not_double_reported_as_exact_linear():
+    # mirrors the paper's Fig4g columns: y = 2.39 * x row-wise, no near-zero x.
+    x = [467.61905, 453.14286, 404.38095, 364.0, 598.66667, 538.47619,
+         532.38095, 510.28571, 544.57143, 375.42857, 619.2381, 715.2381]
+    y = [2.39 * v for v in x]
+    f = _kinds(x, y)
+    assert any(k["kind"] == "constant_ratio" for k in f), f
+    assert not any(k["kind"] == "exact_linear" for k in f), \
+        f"pure scaling must not also be reported as exact_linear (redundant, b~=0): {f}"
+
+
+def test_genuine_nonzero_intercept_still_flags_exact_linear_at_normal_scale():
+    # a real affine offset (y = 3x + 7) is a DISTINCT signal constant_ratio cannot express.
+    x = [12.0, 45.0, 7.0, 88.0, 33.0, 61.0, 19.0, 50.0, 27.0, 6.0]
+    y = [3 * v + 7 for v in x]
+    f = _kinds(x, y)
+    assert any(k["kind"] == "exact_linear" for k in f), f
+    assert not any(k["kind"] == "constant_ratio" for k in f), \
+        f"an affine offset is not a pure ratio: {f}"
+
+
+def test_pure_scaling_with_zero_in_x_still_detected():
+    # edge case: constant_ratio's divide guard (all |x| > 1e-12) skips columns containing 0,
+    # so the b~=0 exact_linear is the SOLE witness of the proportional relationship — the
+    # dedupe must NOT drop it here (that would be a false negative).
+    x = [0.0, 1.5, 3.0, 4.5, 6.0, 7.5, 9.0, 10.5, 12.0, 13.5]
+    y = [2.5 * v for v in x]
+    f = _kinds(x, y)
+    assert not any(k["kind"] == "constant_ratio" for k in f), \
+        "constant_ratio's zero-guard should skip this column"
+    assert any(k["kind"] == "exact_linear" for k in f), \
+        f"proportional relationship with a zero in x must still be caught: {f}"


### PR DESCRIPTION
## What

A pure proportional relationship (`col_b = k·col_a`, `k != 1`) is reported by **constant_ratio**. The least-squares/linear fit of the same two columns returns the same slope with a **zero intercept** (down to floating-point round-off ≈ `eps·scale`), so **exact_linear** fired a *second* finding carrying no information beyond the ratio. This doubled the finding count — e.g. a sheet with 9 genuine row-wise relationships surfaced as **18** findings.

## Change

In `detect_relations` (`_audit.py`), suppress the coincident `exact_linear` **only when**:
- its intercept is zero *relative to the data scale* (reuses the existing scale-relative `tol`, **not** an absolute `1e-13` — that would misfire on fractional/count data), **and**
- a `constant_ratio` already covered the same column pair.

`exact_linear` is **kept** when:
- the intercept is a genuine, scale-significant non-zero offset (an affine `y = ax + b` a ratio cannot express), or
- no `constant_ratio` covered the pair — e.g. `constant_ratio`'s divide-by-zero guard skips a proportional pair that contains a zero in `col_a`, where the `b≈0` `exact_linear` is the sole witness. No relationship is lost.

## Tests (TDD)

Added 3 tests to `test_relations_tolerance.py` (written RED-first):
- `test_pure_scaling_not_double_reported_as_exact_linear` — pure scaling → `constant_ratio` only.
- `test_genuine_nonzero_intercept_still_flags_exact_linear_at_normal_scale` — `y=3x+7` → `exact_linear` still fires.
- `test_pure_scaling_with_zero_in_x_still_detected` — proportional pair with a zero in `x` still caught.

Full suite: `411 passed, 2 skipped` (the one unrelated `.xls` corpus-reader failure is pre-existing on `main`, an environment/dependency gap, not from this change).

## Effect

Any pure-scaling column pair's finding count roughly halves (more honest counts). End-to-end on a real source workbook, each 3-column experiment block goes from 6 findings (3 ratio + 3 linear) to 3 (ratio only); all row-wise relationships preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)