### PR TITLE
fix(audit): cap findings per block so dense sheets can't balloon report to GB (GH #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ write_adjudicated_report(scan, verdict, "adjudication.html")  # scan/verdict 均
 | `PAPERCONAN_MAX_CELLS` | `10000000` | 单 sheet / workbook 累计 cell 预算 |
 | `PAPERCONAN_MAX_BLOCK_COLS` | `120` | 宽 block 跳过 O(col²) 关系 / equal-pair 检测 |
 | `PAPERCONAN_MAX_REPORT_BLOCKS` | `2000` | 最多收集多少个带 finding 的 block |
+| `PAPERCONAN_MAX_FINDINGS_PER_BLOCK` | `150` | 单 block 最多保留多少条 finding（密集/高相关 block 的 O(col²) 成对信号会成千上万，取 severity 最高的 N 条，其余记入 `findings_omitted`）；`0` 关闭 |
+| `PAPERCONAN_MAX_TOTAL_FINDINGS` | `5000` | 全部 block 合计 finding 上限（防病态语料把 `scan.json` / `report.html` 撑到 GB 级）；`0` 关闭 |
 | `PAPERCONAN_MAX_EVIDENCE_ROWS` | `50` | 单条 evidence 片段最多行数 |
 | `PAPERCONAN_MAX_EVIDENCE_COLS` | `30` | 单条 evidence 片段最多列数 |
 | `PAPERCONAN_MAX_PAPER_MB` | `1500` | `fetch` 下载/解压到一个 paper 目录的总量上限 |

--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -16,7 +16,7 @@ Tool repository: https://github.com/zixixr/paperconan
 1. Confirm what the user supplied:
    - Local source-data directory: run `paperconan <input-dir>`.
    - DOI or title: run `paperconan fetch "<DOI or title>"`, choose a matched tabular dataset, download it, then scan the downloaded directory.
-   - Only an existing audit: read `audit/scan.json` and point the user to `audit/report.html`.
+   - Only an existing audit: read `audit/scan.json` and use `audit/report.html` as the evidence browser to triage — then give an adjudicated answer. Do not hand the raw `report.html` over as "the result" (see Report Positioning below).
 2. Prefer the real CLI. Do not invent findings from eyeballing tables.
 3. Parse `scan.json`, then load the reference file needed for the task.
 4. Open the original table when describing a serious finding as worth follow-up. If the original data is unavailable, say the finding is unverified.
@@ -46,6 +46,26 @@ Choose the lightest mode that satisfies the user request:
 Do not write a full eight-section report for ordinary scan summaries. Use the
 full report only for Tier 1/Tier 2 KEEP, PubPeer-style drafting, formal
 research-integrity notes, or when the user explicitly asks for it.
+
+## Report Positioning
+
+The pipeline is **scan → agent triage/judgment → adjudicated report**. Keep the
+two report artifacts distinct:
+
+- `audit/report.html` (from the bare CLI) is a **deterministic detector /
+  evidence browser** — a triage worklist. It is false-positive-heavy by design
+  and represents **no judgment**. It is an intermediate artifact, not the
+  user-facing deliverable. Never present it as "the audit result".
+- The **user-facing deliverable is always agent-adjudicated**, produced only
+  after you triage `scan.json`, open the source tables for serious findings, and
+  weigh benign explanations: a short adjudicated summary for ordinary cases, or
+  the eight-section report (`paperconan report scan.json --verdict verdict.json
+  --out …`) for Tier 1/Tier 2 KEEP and formal/public writing.
+
+So the raw `report.html` is what *you* read to triage; the adjudicated summary or
+eight-section report is what the *user* receives. A plain CLI user who only runs
+`paperconan <dir>` has no agent in the loop, so they see only the raw browser —
+tell them the findings still need human/agent triage before they mean anything.
 
 ## Install And Run
 

--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -2456,6 +2456,46 @@ _MAX_REPORT_BLOCKS = int(os.environ.get("PAPERCONAN_MAX_REPORT_BLOCKS", "2000"))
 # including the highlighted cells). Small blocks are emitted whole and stay byte-identical.
 _MAX_EV_ROWS = int(os.environ.get("PAPERCONAN_MAX_EVIDENCE_ROWS", "50"))
 _MAX_EV_COLS = int(os.environ.get("PAPERCONAN_MAX_EVIDENCE_COLS", "30"))
+# Per-block finding cap: the pairwise detectors are O(col²), so a single dense, highly
+# correlated block (a correlation matrix, an expression panel with many proportional columns)
+# can emit thousands of findings. Each carries its own embedded evidence snippet, so the count —
+# not just the per-snippet size — is what balloons scan.json / report.html past 1 GB (GH #15).
+# Keep at most this many findings per block, retaining the highest-severity ones, and record how
+# many were dropped in the block's `findings_omitted` field (never a silent truncation). 0 disables.
+_MAX_FINDINGS_PER_BLOCK = int(os.environ.get("PAPERCONAN_MAX_FINDINGS_PER_BLOCK", "150"))
+# Global backstop across all blocks: MAX_REPORT_BLOCKS × MAX_FINDINGS_PER_BLOCK could still be
+# large on a pathological corpus, so stop retaining findings once this many have been kept.
+_MAX_TOTAL_FINDINGS = int(os.environ.get("PAPERCONAN_MAX_TOTAL_FINDINGS", "5000"))
+
+# Severity rank for deterministic, highest-first truncation when a block is over budget.
+_SEVERITY_RANK = {"high": 0, "medium": 1, "low": 2}
+
+
+def _cap_block_findings(groups, cap):
+    """Trim a block's findings to at most `cap`, keeping the highest-severity ones.
+
+    `groups` maps a BLOCK_FINDING_GROUPS key to its list of findings; each list is
+    trimmed IN PLACE. Selection is by severity (high > medium > low); ties keep the
+    original detector/emission order, so output stays deterministic. Returns the number
+    of findings dropped. `cap is None` means unlimited (no trimming); `cap == 0` drops all."""
+    if cap is None:
+        return 0
+    cap = max(0, cap)
+    total = sum(len(v) for v in groups.values())
+    if total <= cap:
+        return 0
+    flat = [(name, idx, f)
+            for name, lst in groups.items()
+            for idx, f in enumerate(lst)]
+    # Stable sort by severity keeps original order within a severity band.
+    flat.sort(key=lambda t: _SEVERITY_RANK.get((t[2].get("severity") or "low").lower(), 3))
+    keep = {(name, idx) for name, idx, _ in flat[:cap]}
+    omitted = 0
+    for name, lst in groups.items():
+        kept = [f for i, f in enumerate(lst) if (name, i) in keep]
+        omitted += len(lst) - len(kept)
+        lst[:] = kept
+    return omitted
 
 
 def scan_dir(in_dir, out_dir, *, write_md=False, write_html=True, paper=None,
@@ -2475,6 +2515,8 @@ def scan_dir(in_dir, out_dir, *, write_md=False, write_html=True, paper=None,
         )
 
     report_blocks = []
+    findings_omitted_total = 0   # findings dropped by the per-block / global finding caps
+    findings_kept_total = 0      # findings retained across all blocks (for the global backstop)
     per_sheet_numbers = {}
     grids = {}  # (file, sheet) -> decimal grid, for the unified collision pass
     grid_sheets = {}  # (file, sheet) -> Sheet, for local cross-sheet label context
@@ -2543,6 +2585,8 @@ def scan_dir(in_dir, out_dir, *, write_md=False, write_html=True, paper=None,
             for (r0, r1, c0, c1) in blocks:
                 if len(report_blocks) >= _MAX_REPORT_BLOCKS:   # output budget reached; stop collecting
                     break
+                if _MAX_TOTAL_FINDINGS > 0 and findings_kept_total >= _MAX_TOTAL_FINDINGS:
+                    break   # global finding budget spent; stop collecting (subsequent sheets short-circuit here too)
                 header = header_for(sheet, r0, c0, c1)
                 # On very wide blocks (dense correlation matrices) the O(col²) relation and
                 # equal-pair detectors explode in compute + output, so skip just those two; the
@@ -2557,7 +2601,32 @@ def scan_dir(in_dir, out_dir, *, write_md=False, write_html=True, paper=None,
                 gg = detect_grim_grimmer(sheet, r0, r1, c0, c1, header)
                 if rel or ap or eq or rp or wc or iar or gg:
                     sheet_context = " ".join([os.path.basename(f), sn, *[str(h) for h in header]])
-                    for group in (rel, ap, eq, rp, wc, iar, gg):
+                    # Bound this block's finding count BEFORE attaching evidence, so trimmed
+                    # findings never pay the (large) embedded-snippet cost. The per-block cap is
+                    # further clamped by the remaining global budget; keep highest severity first.
+                    # NOTE: this precedes the count-based demotion passes below
+                    # (_demote_reused_progressions / _demote_dense_relations / _demote_within_col_flood),
+                    # which judge floods by cross-block counts. Trimming can lower those counts, so a
+                    # benign finding may keep an elevated severity that demotion would have lowered —
+                    # an over-report only (never drops a genuine high; keeping highest-severity first
+                    # protects exactly the findings demotion targets). Capping after demotion would
+                    # require attaching evidence to every finding first, re-introducing the GH#15 OOM.
+                    groups = {"relations": rel, "progressions": ap, "equal_pairs": eq,
+                              "row_pairs": rp, "within_col": wc,
+                              "identical_after_rounding": iar, "grim": gg}
+                    # Effective cap = the tighter of the per-block limit and the remaining global
+                    # budget; None means unlimited (both caps disabled). A spent global budget
+                    # yields 0, which drops the whole block (recorded via `omitted`).
+                    per_block = _MAX_FINDINGS_PER_BLOCK if _MAX_FINDINGS_PER_BLOCK > 0 else None
+                    if _MAX_TOTAL_FINDINGS > 0:
+                        remaining = max(0, _MAX_TOTAL_FINDINGS - findings_kept_total)
+                        block_cap = remaining if per_block is None else min(per_block, remaining)
+                    else:
+                        block_cap = per_block
+                    omitted = _cap_block_findings(groups, block_cap)
+                    findings_omitted_total += omitted
+                    findings_kept_total += sum(len(v) for v in groups.values())
+                    for group in groups.values():
                         if evidence:
                             _attach_evidence(group, sheet, r0, r1, c0, c1, header)
                         _attach_benign(group)
@@ -2565,10 +2634,13 @@ def scan_dir(in_dir, out_dir, *, write_md=False, write_html=True, paper=None,
                                                   sheet_context=sheet_context)
                     report_blocks.append(dict(file=os.path.basename(f), sheet=sn,
                                               block=dict(rows=f"{r0+1}-{r1}", cols=f"{c0+1}-{c1}", header=header),
-                                              relations=rel, progressions=ap, equal_pairs=eq,
-                                              row_pairs=rp,
-                                              within_col=wc, identical_after_rounding=iar,
-                                              grim=gg))
+                                              relations=groups["relations"], progressions=groups["progressions"],
+                                              equal_pairs=groups["equal_pairs"],
+                                              row_pairs=groups["row_pairs"],
+                                              within_col=groups["within_col"],
+                                              identical_after_rounding=groups["identical_after_rounding"],
+                                              grim=groups["grim"],
+                                              findings_omitted=omitted))
 
     # Down-weight dense/correlated sheets: judged by per-sheet relation totals, so a
     # wide matrix's expected identical/linear columns don't flood high-severity output.
@@ -2612,6 +2684,7 @@ def scan_dir(in_dir, out_dir, *, write_md=False, write_html=True, paper=None,
                paper=_load_provenance(in_dir, paper),
                n_files=len(files),
                n_blocks_with_findings=len(report_blocks),
+               findings_omitted=findings_omitted_total,
                scan_errors=scan_errors,
                scan_stats={**scan_stats,
                            "elapsed_ms": round((time.perf_counter() - scan_start) * 1000, 3)},

--- a/src/paperconan/_html.py
+++ b/src/paperconan/_html.py
@@ -191,8 +191,10 @@ def _render_finding_card(item: dict) -> str:
 
     open_attr = " open" if sev == "high" else ""
     hidden_style = ' style="display:none"' if profile_action == "hidden" else ""
+    scope = item.get("scope", "block")
     return (
-        f'<details class="finding" data-severity="{sev}" data-kind="{_esc(kind)}" '
+        f'<details class="finding" data-severity="{sev}" data-scope="{_esc(scope)}" '
+        f'data-kind="{_esc(kind)}" '
         f'data-file="{_esc(file_)}" data-profile-action="{_esc(profile_action)}" '
         f'data-searchable="{_esc(searchable)}"{open_attr}{hidden_style}>'
         '<summary>'
@@ -212,13 +214,17 @@ def _render_filter_sidebar(findings: list[dict]) -> str:
     kinds = sorted({item["finding"].get("kind", "?") for item in findings})
     files = sorted({item["file"] for item in findings if item["file"]})
 
-    def cb(cls: str, value: str, label: str) -> str:
+    def cb(cls: str, value: str, label: str, checked: bool = True) -> str:
+        checked_attr = " checked" if checked else ""
         return (
-            f'<label><input type="checkbox" class="{cls}" value="{_esc(value)}" checked>'
+            f'<label><input type="checkbox" class="{cls}" value="{_esc(value)}"{checked_attr}>'
             f' {_esc(label)}</label>'
         )
 
-    sev_box = "".join(cb("f-sev", s, s) for s in ("high", "medium", "low"))
+    # low-severity is false-positive-heavy (within-column repeats, derived columns, rounded
+    # grids…), so it is hidden by default to keep the initial view triage-worthy. The "How to
+    # read" banner tells the reader it is one click away.
+    sev_box = "".join(cb("f-sev", s, s, checked=(s != "low")) for s in ("high", "medium", "low"))
     kind_box = "".join(cb("f-kind", k, k) for k in kinds) or '<span class="muted">none</span>'
     file_box = "".join(cb("f-file", f, f) for f in files) or '<span class="muted">none</span>'
 
@@ -334,6 +340,12 @@ header.top { padding:18px 24px; border-bottom:1px solid var(--border); backgroun
 .stat.sev-low strong { color:var(--low); }
 .warn { margin-top:10px; font-size:12px; color:var(--muted); }
 .warn::before { content:"⚠ "; color:var(--medium); }
+.how-to-read { background:var(--panel-2); border:1px solid var(--border); border-left:3px solid var(--accent);
+  border-radius:6px; padding:12px 16px; margin:0 0 22px; font-size:13px; line-height:1.6; color:var(--text); }
+.how-to-read h3 { margin:0 0 6px; font-size:13.5px; color:var(--accent); font-weight:600; }
+.how-to-read p { margin:0 0 6px; color:var(--muted); }
+.how-to-read strong { color:var(--text); }
+.how-to-read code { background:var(--panel); padding:1px 5px; border-radius:3px; }
 .layout { display:grid; grid-template-columns:240px 1fr; min-height:calc(100vh - 110px); }
 aside.filters { border-right:1px solid var(--border); padding:16px;
   background:var(--panel); position:sticky; top:0; align-self:start;
@@ -437,7 +449,10 @@ _JS = """
     const files = getChecked('f-file');
     const q = (search.value || '').trim().toLowerCase();
     findings.forEach(el => {
-      const matchSev = sev.has(el.dataset.severity);
+      // Cross-sheet collisions are the flagship section and stay visible regardless of the
+      // severity filter — otherwise a low/blank-severity collision would hide the whole
+      // "most worth reviewing" section on load (low is unchecked by default).
+      const matchSev = el.dataset.scope === 'cross_sheet' || sev.has(el.dataset.severity);
       const matchKind = kinds.has(el.dataset.kind);
       const matchFile = files.has(el.dataset.file);
       const matchQ = !q || (el.dataset.searchable || '').indexOf(q) !== -1;
@@ -457,8 +472,12 @@ _JS = """
   search.addEventListener('input', applyFilters);
   showNoisy.addEventListener('change', applyFilters);
   reset.addEventListener('click', () => {
-    document.querySelectorAll('input.f-sev, input.f-kind, input.f-file')
+    document.querySelectorAll('input.f-kind, input.f-file')
             .forEach(i => i.checked = true);
+    // Restore the initial triage view exactly: low severity stays unchecked on reset
+    // (it is hidden by default), so reset matches a fresh page load rather than showing more.
+    document.querySelectorAll('input.f-sev')
+            .forEach(i => i.checked = (i.value !== 'low'));
     showNoisy.checked = false;
     search.value = '';
     applyFilters();
@@ -504,6 +523,19 @@ def write_html_report(scan: dict, out_path: str) -> None:
     if not sections:
         sections = '<p class="empty">no findings — nothing flagged in this dataset.</p>'
 
+    how_to_read = (
+        '<div class="how-to-read">'
+        '<h3>如何阅读本报告 · How to read this</h3>'
+        '<p>这是 paperconan 检测器的<strong>原始信号</strong>,不是结论,也不是经过人工/AI 判定的报告。'
+        '每条 finding 只是一个统计异常,<strong>大多数都有良性解释</strong>'
+        '(共享对照、重绘坐标轴、单位换算、派生列、固定分母比值、边界值、四舍五入网格…)。</p>'
+        '<p>请把它当作<strong>待逐条人工复核的线索清单</strong>:对照原始表格、图注与 Methods 之后再判断,'
+        '不要据此对论文或作者下任何结论。经判定的正式报告(含逐条裁决)是另一份单独产物。</p>'
+        '<p>为便于分诊,<strong>low 级信号默认隐藏</strong>(误报偏多);在左侧勾选 <code>low</code> 可显示。'
+        '优先看 cross-sheet 与 high。</p>'
+        '</div>'
+    )
+
     sidebar = _render_filter_sidebar(findings) if findings else \
         '<aside class="filters"><p class="muted">no findings</p></aside>'
 
@@ -514,6 +546,17 @@ def write_html_report(scan: dict, out_path: str) -> None:
         f'<span class="stat sev-medium"><strong>{sev["medium"]}</strong> medium</span>',
         f'<span class="stat sev-low"><strong>{sev["low"]}</strong> low</span>',
     ])
+
+    omitted = int(scan.get("findings_omitted") or 0)
+    omitted_html = ""
+    if omitted:
+        omitted_html = (
+            f'<div class="warn">{omitted:,} lower-severity findings were omitted to bound '
+            'report size (dense/correlated blocks emit thousands of near-duplicate pairwise '
+            'signals). The highest-severity findings per block are kept; raise '
+            '<code>PAPERCONAN_MAX_FINDINGS_PER_BLOCK</code> / '
+            '<code>PAPERCONAN_MAX_TOTAL_FINDINGS</code> to see more.</div>'
+        )
 
     ver = scan.get("tool_version", "")
     ts = scan.get("scanned_at", "")
@@ -541,10 +584,11 @@ def write_html_report(scan: dict, out_path: str) -> None:
   <div class="brand">paperconan<span class="brand-sub">paper data audit · {_esc(input_label)}</span></div>
   <div class="stats">{stats}</div>
   <div class="warn">Statistical anomalies — signal, not verdict. Take findings to PubPeer / journal editor / research integrity office, not social media.</div>
+  {omitted_html}
 </header>
 <div class="layout">
   {sidebar}
-  <main>{sections}</main>
+  <main>{how_to_read}{sections}</main>
   {footer}
 </div>
 <script>{_JS}</script>

--- a/tests/test_findings_cap.py
+++ b/tests/test_findings_cap.py
@@ -1,0 +1,101 @@
+"""Output-size guard: a single dense, highly-correlated block must not emit an
+unbounded number of findings.
+
+Regression for GitHub issue #15: a modestly sized but dense sheet (many mutually
+proportional columns) makes the O(col^2) pairwise detectors emit thousands of
+findings, each carrying an embedded evidence snippet, so scan.json / report.html
+balloon to > 1 GB and the browser cannot open them. scan_dir must cap the number
+of findings retained per block (keeping the highest-severity ones) and record how
+many were omitted, so the report stays bounded and honest about the truncation.
+"""
+from __future__ import annotations
+
+import csv
+
+from paperconan._audit import (
+    BLOCK_FINDING_GROUPS,
+    _MAX_FINDINGS_PER_BLOCK,
+    _cap_block_findings,
+    scan_dir,
+)
+
+
+def _write_dense_csv(path, n_rows=40, n_cols=60):
+    """A block where every column is a fixed scalar multiple of the first, so the
+    linear/ratio/equal-pair detectors fire on ~every one of the O(col^2) pairs."""
+    base = [round(1.0 + i * 0.7, 4) for i in range(n_rows)]
+    header = [f"c{c}" for c in range(n_cols)]
+    rows = []
+    for r in range(n_rows):
+        rows.append([round(base[r] * (c + 1), 4) for c in range(n_cols)])
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = csv.writer(fh)
+        w.writerow(header)
+        w.writerows(rows)
+
+
+def _block_finding_count(blk):
+    return sum(len(blk.get(g) or []) for g in BLOCK_FINDING_GROUPS)
+
+
+def test_dense_block_findings_are_capped(tmp_path):
+    data = tmp_path / "dense"
+    data.mkdir()
+    _write_dense_csv(str(data / "dense.csv"))
+
+    scan = scan_dir(str(data), str(tmp_path / "out"), write_html=False)
+
+    blocks = scan.get("relations_blocks") or []
+    assert blocks, "expected the dense block to produce findings"
+    for blk in blocks:
+        n = _block_finding_count(blk)
+        assert n <= _MAX_FINDINGS_PER_BLOCK, (
+            f"block {blk['file']}::{blk['sheet']} kept {n} findings, "
+            f"exceeds cap {_MAX_FINDINGS_PER_BLOCK}"
+        )
+
+    # The truncation must be recorded, not silent: this dense fixture generates far
+    # more than the cap, so at least one block reports omitted findings.
+    total_omitted = sum(int(blk.get("findings_omitted") or 0) for blk in blocks)
+    assert total_omitted > 0, "dense block exceeded the cap but omission was not recorded"
+
+
+def test_cap_keeps_highest_severity_first():
+    """`_cap_block_findings` must drop the LEAST-severe findings first, so no dropped
+    finding outranks a kept one. Tested directly on the helper because the e2e path runs
+    `_demote_dense_sheets` afterwards, which flattens a dense sheet's severities to 'low'
+    and would mask whether the cap itself selected by severity."""
+    groups = {
+        "relations": [{"severity": "low", "i": i} for i in range(100)]
+                     + [{"severity": "high", "i": i} for i in range(20)],
+        "grim": [{"severity": "medium", "i": i} for i in range(30)],
+    }
+    omitted = _cap_block_findings(groups, 40)
+
+    kept = [f for lst in groups.values() for f in lst]
+    assert len(kept) == 40
+    assert omitted == 110
+    counts = {s: sum(1 for f in kept if f["severity"] == s) for s in ("high", "medium", "low")}
+    # 20 high + 30 medium = 50 > cap 40, so all 40 kept are high/medium and NO low survives.
+    assert counts == {"high": 20, "medium": 20, "low": 0}, counts
+
+
+def test_cap_is_deterministic_and_stable():
+    """Ties within a severity band keep original order, so two identical inputs cap to the
+    same findings (the scan output must stay byte-identical across runs)."""
+    def fresh():
+        return {"relations": [{"severity": "high", "i": i} for i in range(10)],
+                "grim": [{"severity": "high", "i": i} for i in range(10)]}
+    a, b = fresh(), fresh()
+    _cap_block_findings(a, 5)
+    _cap_block_findings(b, 5)
+    assert a == b
+    # Stable = the first-emitted findings win the ties.
+    assert [f["i"] for f in a["relations"]] == [0, 1, 2, 3, 4]
+    assert a["grim"] == []
+
+
+def test_cap_none_is_unlimited():
+    groups = {"relations": [{"severity": "low"}] * 500}
+    assert _cap_block_findings(groups, None) == 0
+    assert len(groups["relations"]) == 500


### PR DESCRIPTION
Fixes #15.

## Problem
A modestly sized but **dense / highly-correlated** sheet makes the O(col²) pairwise detectors emit thousands of findings in a **single block**, each embedding an evidence snippet, so `scan.json` / `report.html` grow past 1 GB and the browser cannot open them. The existing guards (`_MAX_BLOCK_COLS`, `_MAX_EVIDENCE_ROWS/COLS`, `_MAX_REPORT_BLOCKS`) bounded column width, snippet size, and block count — but never the number of findings **within** a block.

## Fix
- **`_cap_block_findings`**: keep at most `PAPERCONAN_MAX_FINDINGS_PER_BLOCK` (default 150) findings per block, **highest-severity first** (deterministic, stable ties), applied **before** evidence attachment so trimmed findings never pay the snippet cost. Global backstop `PAPERCONAN_MAX_TOTAL_FINDINGS` (default 5000). Both `0` = disabled → old behavior.
- Drops are recorded in per-block `findings_omitted` and top-level `findings_omitted`; the HTML report shows a notice — **never a silent truncation**.
- **Repro** (60×100 dense sheet): `report.html` **128 MB → 6.2 MB**, byte-identical across runs.

## report.html triage framing
- "如何阅读本报告 / How to read this" banner: raw detector signal, not a verdict, most findings have benign explanations.
- Low-severity hidden by default (FP-heavy). Cross-sheet findings stay visible regardless of the severity filter (else the flagship section could vanish on load), and reset restores the true default view.

## SKILL.md
- New "Report Positioning" section: the raw `report.html` is an internal triage artifact; the user-facing deliverable is always agent-adjudicated (short summary, or the eight-section report for Tier 1/2 KEEP).

## Tests
- New `tests/test_findings_cap.py`: e2e cap + omission recording, plus direct unit tests of `_cap_block_findings` (highest-severity-first, deterministic ties, `None` = unlimited).
- Full suite: **420 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)