### PR TITLE
feat: round-shift + shared-fraction detector

### DIFF
--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -841,29 +841,31 @@ def detect_relations(sheet, r0, r1, c0, c1, header):
                                                f"{n_real_frac}/{n} rows ({distinct_hp} distinct high-precision "
                                                f"fractions) but differ by whole numbers")))
                     continue
-                # B5b: the same shared-fraction + integer-difference fingerprint at LOWER
-                # (2-3 decimal) precision, admitted ONLY when every non-zero integer
-                # difference is a multiple of 10. A "nudge the value by a round number,
-                # keep the decimals" edit has no benign additive transform, so the
-                # round-shift constraint compensates for the less-distinctive 2-digit
-                # fraction the high-precision B5 above requires. (Integer-only columns have
-                # no genuine fraction and are excluded by the distinct-fraction floor.)
+                # B5b: the same shared-fraction + integer-difference signal that B5 above
+                # requires >=4 fraction digits for, admitted at lower precision ONLY when
+                # every non-zero integer difference is a multiple of 10. Shifting a value
+                # by a round number while keeping its decimals has no benign additive
+                # transform, so that constraint compensates for a less-distinctive 2-digit
+                # fraction. The evidence floor counts rows that are BOTH a round-shift AND
+                # carry a genuine (non-.0) fraction — so a mostly-integer column with a few
+                # stray decimals cannot satisfy it on thin fractional evidence.
                 nz = diff_is_int & (np.abs(np.round(diff)) >= 1)
                 round10 = nz & (np.abs(np.round(diff) - np.round(diff / 10.0) * 10.0) < 0.5)
                 shared_frac = diff_is_int & (np.abs(frac_x) > 1e-6)
-                distinct_frac = len({round(float(v), 6) for v in frac_x[shared_frac]})
-                if (int(round10.sum()) >= max(5, int(round(0.7 * n)))
+                rs_frac = round10 & shared_frac
+                distinct_frac = len({round(float(v), 6) for v in frac_x[rs_frac]})
+                if (int(rs_frac.sum()) >= max(5, int(round(0.7 * n)))
                         and int(round10.sum()) == int(nz.sum())
                         and distinct_frac >= 3):
                     findings.append(dict(kind="round_shift_shared_fraction",
                                          col_a=header[ci - c0], col_b=header[cj - c0],
                                          col_a_idx=ci, col_b_idx=cj, n=n,
-                                         n_shared_fraction=int(shared_frac.sum()),
+                                         n_shared_fraction=int(rs_frac.sum()),
                                          severity="high",
                                          col_a_sample=sa, col_b_sample=sb,
                                          rule=(f"col[{cj}] and col[{ci}] share the same decimal fraction on "
-                                               f"{int(shared_frac.sum())}/{n} rows and differ only by non-zero "
-                                               f"multiples of 10 (copy-then-round-shift fingerprint)")))
+                                               f"{int(rs_frac.sum())}/{n} rows and differ only by non-zero "
+                                               f"integer multiples of 10")))
                     continue
             # small discrete diff set
             if n >= 8:

--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -841,6 +841,30 @@ def detect_relations(sheet, r0, r1, c0, c1, header):
                                                f"{n_real_frac}/{n} rows ({distinct_hp} distinct high-precision "
                                                f"fractions) but differ by whole numbers")))
                     continue
+                # B5b: the same shared-fraction + integer-difference fingerprint at LOWER
+                # (2-3 decimal) precision, admitted ONLY when every non-zero integer
+                # difference is a multiple of 10. A "nudge the value by a round number,
+                # keep the decimals" edit has no benign additive transform, so the
+                # round-shift constraint compensates for the less-distinctive 2-digit
+                # fraction the high-precision B5 above requires. (Integer-only columns have
+                # no genuine fraction and are excluded by the distinct-fraction floor.)
+                nz = diff_is_int & (np.abs(np.round(diff)) >= 1)
+                round10 = nz & (np.abs(np.round(diff) - np.round(diff / 10.0) * 10.0) < 0.5)
+                shared_frac = diff_is_int & (np.abs(frac_x) > 1e-6)
+                distinct_frac = len({round(float(v), 6) for v in frac_x[shared_frac]})
+                if (int(round10.sum()) >= max(5, int(round(0.7 * n)))
+                        and int(round10.sum()) == int(nz.sum())
+                        and distinct_frac >= 3):
+                    findings.append(dict(kind="round_shift_shared_fraction",
+                                         col_a=header[ci - c0], col_b=header[cj - c0],
+                                         col_a_idx=ci, col_b_idx=cj, n=n,
+                                         n_shared_fraction=int(shared_frac.sum()),
+                                         severity="high",
+                                         col_a_sample=sa, col_b_sample=sb,
+                                         rule=(f"col[{cj}] and col[{ci}] share the same decimal fraction on "
+                                               f"{int(shared_frac.sum())}/{n} rows and differ only by non-zero "
+                                               f"multiples of 10 (copy-then-round-shift fingerprint)")))
+                    continue
             # small discrete diff set
             if n >= 8:
                 diff_rounded = np.round(diff, 4)

--- a/tests/test_round_shift_shared_fraction.py
+++ b/tests/test_round_shift_shared_fraction.py
@@ -1,0 +1,54 @@
+"""Round-shift + shared-fraction detector (class C/D: two groups differ by multiples of 10).
+
+`integer_diff_shared_fraction` (B5) only fires at >=4 significant fraction digits. A very
+common source-data fingerprint is two groups whose cells share the SAME 2-decimal fraction
+while the integer parts differ by non-zero MULTIPLES OF 10 (a copy-then-nudge-by-round-
+numbers). At 2 decimals a bare shared fraction is less distinctive, but the "all differences
+are multiples of 10" constraint has no benign additive transform, so the pair is still a
+data-inconsistency signal worth an author's explanation — not a verdict.
+"""
+from __future__ import annotations
+
+from paperconan._audit import detect_relations
+from paperconan._sheet import Sheet
+
+
+def test_detects_round_multiple_of_ten_shift_at_two_decimals():
+    # two DIFFERENT groups: b = a + [60,-10,-20,20,70,-20] (all multiples of 10), same .xx fraction
+    a = [72.34, 127.58, 148.86, 117.91, 83.26, 95.22]
+    b = [132.34, 117.58, 128.86, 137.91, 153.26, 75.22]
+    rows = [["idx", "NEUWT", "EOSPAD4"]]
+    for i, (x, y) in enumerate(zip(a, b), 1):
+        rows.append([i, x, y])
+    sheet = Sheet.from_rows(rows)
+
+    findings = detect_relations(sheet, 1, 7, 1, 3, ["NEUWT", "EOSPAD4"])
+    rs = [f for f in findings if f["kind"] == "round_shift_shared_fraction"]
+    assert len(rs) == 1, f"expected round-shift finding, got {findings}"
+    assert rs[0]["severity"] == "high"
+
+
+def test_no_false_positive_on_independent_two_decimal_columns():
+    a = [72.34, 127.58, 148.86, 117.91, 83.26, 95.22]
+    b = [41.19, 88.63, 12.07, 155.42, 63.91, 100.28]   # unrelated fractions, non-round diffs
+    rows = [["idx", "A", "B"]]
+    for i, (x, y) in enumerate(zip(a, b), 1):
+        rows.append([i, x, y])
+    sheet = Sheet.from_rows(rows)
+
+    findings = detect_relations(sheet, 1, 7, 1, 3, ["A", "B"])
+    assert [f for f in findings if f["kind"] == "round_shift_shared_fraction"] == []
+
+
+def test_integer_only_multiple_of_ten_shift_does_not_fire():
+    # integer counts shifted by 10s (no genuine decimal fraction) must NOT fire — that is
+    # ordinary integer data, not a preserved-fraction copy fingerprint.
+    a = [70, 120, 150, 110, 80, 90]
+    b = [130, 110, 130, 130, 150, 70]
+    rows = [["idx", "A", "B"]]
+    for i, (x, y) in enumerate(zip(a, b), 1):
+        rows.append([i, x, y])
+    sheet = Sheet.from_rows(rows)
+
+    findings = detect_relations(sheet, 1, 7, 1, 3, ["A", "B"])
+    assert [f for f in findings if f["kind"] == "round_shift_shared_fraction"] == []

--- a/tests/test_round_shift_shared_fraction.py
+++ b/tests/test_round_shift_shared_fraction.py
@@ -40,6 +40,58 @@ def test_no_false_positive_on_independent_two_decimal_columns():
     assert [f for f in findings if f["kind"] == "round_shift_shared_fraction"] == []
 
 
+def _pair_findings(a, b):
+    rows = [["idx", "A", "B"]]
+    for i, (x, y) in enumerate(zip(a, b), 1):
+        rows.append([i, x, y])
+    sheet = Sheet.from_rows(rows)
+    return detect_relations(sheet, 1, 1 + len(a), 1, 3, ["A", "B"])
+
+
+def _has_round_shift(a, b):
+    return any(f["kind"] == "round_shift_shared_fraction" for f in _pair_findings(a, b))
+
+
+def test_mostly_integer_column_with_few_decimals_does_not_fire():
+    # 15 integer rows shifted by tens + only 3 fractional rows: the fractional evidence is
+    # too thin (< 0.7n) even though 'differences are multiples of 10' holds for all rows.
+    a = [70, 120, 150, 110, 80, 90, 130, 160, 40, 200, 60, 100, 30, 170, 140,
+         72.34, 127.58, 148.86]
+    b = [130, 110, 130, 130, 150, 70, 160, 120, 60, 180, 110, 60, 90, 130, 100,
+         132.34, 117.58, 128.86]
+    assert not _has_round_shift(a, b)
+
+
+def test_single_non_multiple_of_ten_diff_blocks_firing():
+    # one row shifted by 7 (not a multiple of 10) must break the pattern entirely.
+    a = [72.34, 127.58, 148.86, 117.91, 83.26, 95.22]
+    b = [132.34, 117.58, 128.86, 137.91, 153.26, 102.22]   # last diff = +7, not mult of 10
+    assert not _has_round_shift(a, b)
+
+
+def test_multiples_of_hundred_fire():
+    # 100/200 are multiples of 10 too — a coarser round shift still fires.
+    a = [72.34, 127.58, 148.86, 117.91, 83.26, 95.22]
+    b = [172.34, 227.58, 48.86, 317.91, 83.26 + 100, 95.22 - 200]
+    assert _has_round_shift(a, b)
+
+
+def test_distinct_fraction_floor_of_three():
+    # only 2 distinct fractions across the shared rows → not distinctive enough → no fire.
+    a = [10.25, 20.50, 30.25, 40.50, 50.25, 60.50]
+    b = [20.25, 30.50, 40.25, 50.50, 60.25, 70.50]   # all +10, but only .25/.50 fractions
+    assert not _has_round_shift(a, b)
+
+
+def test_constant_multiple_of_ten_offset_is_claimed_by_constant_offset():
+    # a CONSTANT +10 offset is the constant_offset case, not round_shift (ordering guard).
+    a = [72.34, 127.58, 148.86, 117.91, 83.26, 95.22]
+    b = [x + 10 for x in a]
+    kinds = {f["kind"] for f in _pair_findings(a, b)}
+    assert "constant_offset" in kinds
+    assert "round_shift_shared_fraction" not in kinds
+
+
 def test_integer_only_multiple_of_ten_shift_does_not_fire():
     # integer counts shifted by 10s (no genuine decimal fraction) must NOT fire — that is
     # ordinary integer data, not a preserved-fraction copy fingerprint.


### PR DESCRIPTION
## What

Adds a `round_shift_shared_fraction` branch to `detect_relations`: fires on a **column pair whose cells share the exact decimal fraction row-wise while their integer parts differ only by non-zero multiples of 10** — a "shift a value by a round number, keep the decimals" pattern.

This complements the existing `integer_diff_shared_fraction` (B5), which requires ≥4 significant fraction digits. Very common 2–3 significant-figure bench readouts (viability, OD, percentages) were missed by that gate; the multiple-of-10 constraint has no benign additive transform, so it compensates for the less-distinctive 2-digit fraction (two independent 2-decimal columns satisfying it by chance is ~1e-10). Findings are neutral statistical signals, not verdicts.

## FP control

Fires only when: the round-shift is evidenced on rows that both are a non-zero multiple-of-10 difference **and** carry a genuine (non-.0) fraction (`≥ max(5, 0.7·n)` such rows); **all** non-zero integer differences are multiples of 10; and ≥3 distinct genuine fractions are shared. Integer-only or mostly-integer columns cannot satisfy the fractional-evidence floor. A constant multiple-of-10 offset is claimed by `constant_offset` (fires earlier), not this branch.

## Verification

- **8 tests**: positive case; independent-column and integer-only negatives; mostly-integer FP regression; single-non-multiple-of-10 blocks firing; multiples-of-100 fire; `distinct_frac` boundary; constant-offset ordering guard.
- Subagent code review completed; both Medium findings (a mostly-integer FP path, a neutral-language slip in the report string) fixed.
- Full suite **463 passed / 1 skipped**, golden/oracle tests unchanged, determinism preserved, neutral-language rule respected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)