### PR TITLE
feat: within-row shared-fraction detector (copy-then-integer-shift inside one row)

### DIFF
--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -3167,6 +3167,109 @@ def detect_short_row_reuse(grid_sheets, profile="review", max_findings=60):
     return findings
 
 
+# Within-row shared-fraction: a fractional tail this long, shared by two cells whose integer
+# parts differ, is ~1e-6 by chance per pair — low enough that a single pair is worth a look
+# and a multi-pair segment (a copied row-slice with integers rewritten) is near-certain.
+_WITHIN_ROW_FRAC_MIN_DIGITS = int(os.environ.get("PAPERCONAN_WITHIN_ROW_FRAC_MIN_DIGITS", "6"))
+
+
+def _shared_frac_is_small_denominator(frac_str, max_q=128):
+    """True if the shared fractional VALUE 0.<frac_str> is a simple fraction p/q for some
+    small q. Any two values x + p/q and y + p/q (same residue, different integer) trivially
+    share that tail — a small-denominator artifact (triplicate means .333/.667, k/13 .923076,
+    k/19 …), NOT a copied fraction. A genuine copy-then-shift tail is an arbitrary
+    high-entropy decimal with no small denominator. Guards the same trap as the tail-cluster
+    and short-row detectors, per shared tail."""
+    f = float("0." + frac_str)
+    for q in range(2, max_q + 1):
+        if abs(f * q - round(f * q)) < 2e-6:
+            return True
+    return False
+
+
+def detect_within_row_shared_fraction(grid_sheets, profile="review", max_findings=60):
+    """Two cells of ONE row that share a long high-precision fractional tail while their
+    integer parts differ (e.g. 20.316768 and 102.316768) — a copy-then-shift: a value or a
+    whole row-slice reused with the integer part rewritten but the decimals left intact.
+    `integer_diff_shared_fraction` / `round_shift_shared_fraction` only compare two COLUMNS
+    and `within_table_fraction_reuse` only compares two BLOCKS, so a segment copied across
+    the columns of a single row has no other detector. A shared >=6-digit tail across
+    different integers is ~1e-6 by chance, so requiring that tail length is the FP control.
+    Signal, not verdict — confirm against the legend/Methods before drawing a conclusion."""
+    findings = []
+    budget = 8_000_000
+    for (fname, sname), sheet in grid_sheets.items():
+        fig = figure_key(sname)
+        for r in range(sheet.nrows):
+            row = sheet.numeric[r, :]
+            budget -= sheet.ncols
+            if budget <= 0:
+                break
+            by_frac = {}
+            for c in range(sheet.ncols):
+                v = row[c]
+                if math.isnan(v):
+                    continue
+                av = abs(float(v))
+                if av >= 1e7:                         # read-precision noise reaches the tail
+                    continue
+                # Extract the tail at a precision the magnitude can actually carry: float64
+                # holds ~15 significant figures, so formatting the WHOLE value at a fixed 10
+                # decimals when the integer part is large prints representation NOISE as real
+                # tail digits (5000000.137 -> ...1370000001). Cap decimals at 15 - integer
+                # digits so a short real tail stays short and the 6-digit gate keeps meaning.
+                prec = min(10, max(0, 15 - len(str(int(av)))))
+                s = f"{av:.{prec}f}".rstrip("0")
+                if "." not in s:
+                    continue
+                frac = s.split(".")[1]
+                if len(frac) < _WITHIN_ROW_FRAC_MIN_DIGITS:
+                    continue
+                by_frac.setdefault(frac, []).append((c, float(v), int(av)))
+            groups = [(frac, cells) for frac, cells in by_frac.items()
+                      if len(cells) >= 2 and len({ip for _, _, ip in cells}) >= 2
+                      and not _shared_frac_is_small_denominator(frac)]
+            if not groups:
+                continue
+            groups.sort(key=lambda g: g[1][0][0])     # deterministic: by first column
+            label = _row_label(sheet, r, 1)
+            examples = []
+            for frac, cells in groups[:5]:
+                vs = [v for _, v, _ in cells[:3]]
+                examples.append({"row": label, "col": None, "tail": frac,
+                                 "values": [float(x) for x in vs]})
+            sample = " / ".join(f"{v:.10g}" for _, v, _ in groups[0][1][:2])
+            findings.append(dict(
+                kind="within_row_shared_fraction",
+                file=fname, file_a=fname, file_b=fname,
+                same_file=True, same_sheet=True,
+                sheet_a=sname, sheet_b=sname,
+                row=label, row_a=label, row_b=label,
+                n_groups=len(groups),
+                # NOTE: size_a / same_position_count = number of shared-tail FAMILIES in the
+                # row (what _distill_cross_sheet reads as `n`), not a count of shared cells.
+                size_a=len(groups), same_position_count=len(groups),
+                fraction_of_smaller=1.0,
+                figure_a=fig, figure_b=fig, same_figure=fig is not None,
+                delta={"pattern": "shared_fraction"},
+                block_a=f"row {r + 1}", block_b=f"row {r + 1}",
+                examples=examples,
+                severity="high",
+                rule=(f"row '{label}': {len(groups)} value pair(s) in the same row share a "
+                      f">={_WITHIN_ROW_FRAC_MIN_DIGITS}-digit fractional tail but differ in "
+                      f"the integer part (e.g. {sample}) — a copy-then-integer-shift pattern "
+                      f"in {sname}")))
+            if len(findings) >= max_findings:
+                break
+        if budget <= 0 or len(findings) >= max_findings:
+            break
+    if budget <= 0:
+        print("[paperconan] detect_within_row_shared_fraction: coverage bounded "
+              "(budget exhausted)", file=sys.stderr)
+    apply_profile_to_findings(findings, profile)
+    return findings
+
+
 def _load_provenance(in_dir, paper):
     """Resolve scan provenance: an explicit `paper` override wins; otherwise read a
     paperconan_source.json sidecar left by `fetch`; otherwise None."""
@@ -3442,6 +3545,10 @@ def scan_dir(in_dir, out_dir, *, write_md=False, write_html=True, paper=None,
     # dedup against the long-run detector is needed: it only emits runs >=12 columns and this
     # one only runs <12, so the two never report the same relation on the same pair.
     cross_sheet_findings += detect_short_row_reuse(grid_sheets, profile=profile)
+    # B6c: copy-then-integer-shift WITHIN a row — two cells sharing a long fractional tail
+    # with different integer parts (the column- and block-pair shared-fraction detectors
+    # never look across the columns of a single row).
+    cross_sheet_findings += detect_within_row_shared_fraction(grid_sheets, profile=profile)
     _attach_benign(cross_sheet_findings)
 
     digit_reports, decimal_reports, tail_cluster_reports = [], [], []

--- a/src/paperconan/_html.py
+++ b/src/paperconan/_html.py
@@ -161,6 +161,19 @@ def _render_cross_sheet_examples(cf: dict) -> str:
     examples = cf.get("examples") or []
     if not examples:
         return ""
+    # within-row shared-fraction form: each example is a shared tail with the values sharing it
+    if examples and isinstance(examples[0], dict) and "tail" in examples[0]:
+        rows = []
+        for ex in examples[:10]:
+            vals = " , ".join(f"{v:.10g}" for v in ex.get("values") or [])
+            rows.append(
+                f'<tr><td>.{_esc(ex.get("tail"))}</td><td>{_esc(vals)}</td></tr>'
+            )
+        return (
+            '<div class="ev-wrap"><table class="ev">'
+            '<thead><tr><th>shared fractional tail</th><th>values (integer part differs)</th></tr></thead>'
+            f'<tbody>{"".join(rows)}</tbody></table></div>'
+        )
     if examples and isinstance(examples[0], dict):
         rows = []
         for ex in examples[:10]:

--- a/tests/test_within_row_shared_fraction.py
+++ b/tests/test_within_row_shared_fraction.py
@@ -1,0 +1,104 @@
+"""Within-row shared fractional tail — the copy-then-shift fingerprint inside ONE row.
+
+Two cells of the same row that share a long high-precision fractional tail while their
+integer parts differ (e.g. 20.316768 and 102.316768) are a copy-then-shift: a value or a
+whole segment reused with the integer part rewritten but the decimals left intact. The
+existing shared-fraction detectors (`integer_diff_shared_fraction`,
+`round_shift_shared_fraction`) only compare two COLUMNS; `within_table_fraction_reuse`
+compares two BLOCKS — none looks across the columns of a single row. Signal, not verdict.
+"""
+from __future__ import annotations
+
+from paperconan import scan_dir
+from paperconan._audit import detect_within_row_shared_fraction
+from paperconan._sheet import Sheet
+
+
+# JCI195506 (CHI3L1) Fig 2F, TNF-α row: a 3-cell segment reused with integers rewritten.
+TNF = [22.49183467, 25.04654933, 23.831478, 25.925474,
+       20.316768, 162.14990133, 132.81763667,
+       102.316768, 163.14990133, 138.81763667,
+       54.57891, 43.86014933, 68.66210333, 44.22101267, 52.025184]
+
+
+def test_detects_within_row_shared_fraction_segment():
+    sheet = Sheet.from_rows([
+        ["Figure 2F", "Ctrl-IgG+Veh", "AQP4-IgG+Veh", "AQP4-IgG+CHI"],
+        ["TNF-α (pg/mg)", *TNF],
+    ])
+    findings = detect_within_row_shared_fraction({("JCI195506.xlsx", "Figure 2"): sheet})
+    assert len(findings) == 1, f"expected one within-row shared-fraction finding, got {findings}"
+    f = findings[0]
+    assert f["kind"] == "within_row_shared_fraction"
+    assert f["severity"] == "high"
+    assert f["n_groups"] >= 3          # .316768, .14990133, .81763667
+    assert f["row"] == "TNF-α (pg/mg)"
+
+
+def test_no_false_positive_on_independent_high_precision_row():
+    # A row of independent 6-decimal measurements shares no long fractional tail.
+    row = [10 + i + ((i * 616157 + 7919) % 1_000_000) / 1_000_000 for i in range(15)]
+    sheet = Sheet.from_rows([["h"] + [f"m{i}" for i in range(15)], ["r", *row]])
+    assert detect_within_row_shared_fraction({("f.xlsx", "S1"): sheet}) == []
+
+
+def test_no_false_positive_on_short_shared_tail():
+    # Two values sharing only a 2-digit ending (.37) collide by chance — must not fire.
+    sheet = Sheet.from_rows([["r", 12.37, 55.37, 3.14159, 2.71828, 1.61803]])
+    assert detect_within_row_shared_fraction({("f.xlsx", "S2"): sheet}) == []
+
+
+def test_shared_tail_with_same_integer_is_not_flagged():
+    # Same integer AND same fraction = a duplicate VALUE (caught elsewhere), not copy-shift.
+    sheet = Sheet.from_rows([["r", 20.316768, 20.316768, 5.111111, 6.222222, 7.333333]])
+    assert detect_within_row_shared_fraction({("f.xlsx", "S3"): sheet}) == []
+
+
+def test_no_false_positive_on_small_denominator_fractions():
+    # Triplicate means (n/3 -> .333/.667) and other small-denominator fractions (k/13 ->
+    # .923076) trivially share a tail across different integers — a division artifact, not a
+    # copy. Real JCI panels (JCI200564 Fig.1, JCI200225 Fig.S7F) false-positived here.
+    thirds = Sheet.from_rows([["r", 6.333333333, 9.333333333, 2.666666667, 12.666666667,
+                               3.141592653, 1.414213562]])
+    assert detect_within_row_shared_fraction({("f.xlsx", "S5"): thirds}) == []
+    # k/13: 12/13 = 0.923076923, shared across two integers, is still an artifact.
+    k13 = Sheet.from_rows([["r", 5.923076923, 12.923076923, 3.076923077, 8.076923077,
+                            2.718281828, 1.732050808]])
+    assert detect_within_row_shared_fraction({("f.xlsx", "S6"): k13}) == []
+
+
+def test_no_false_positive_on_float_noise_tail_in_millions():
+    # Values in the millions with a genuine SHORT (3-dp) tail: formatting the whole value at
+    # 10 decimals exceeds float64 precision, so the low decimals are representation NOISE.
+    # The real tail is 3 digits (<6), so this benign coincidence must NOT fire (review bug 1).
+    sheet = Sheet.from_rows([["reads", 1500000.137, 2500000.137, 3500000.137,
+                              4500000.137, 1234567.891, 7654321.234]])
+    assert detect_within_row_shared_fraction({("counts.xlsx", "S7"): sheet}) == []
+
+
+def test_no_false_positive_on_dyadic_fraction():
+    # 1/128 = 0.0078125 (denominator 128 > 64) is a fixed-point/quantization artifact shared
+    # across integers, not a copied tail — must not fire (review bug 2).
+    sheet = Sheet.from_rows([["r", 3.0078125, 17.0078125, 42.0078125, 100.0078125,
+                              2.718281828, 1.414213562]])
+    assert detect_within_row_shared_fraction({("f.xlsx", "S8"): sheet}) == []
+
+
+def test_large_magnitude_values_skipped():
+    # >=1e7: the shared digits are read-precision noise, not a copied tail.
+    sheet = Sheet.from_rows([["r", 1e8 + 0.316768, 2e8 + 0.316768, 3.14159, 2.71828, 1.61803]])
+    assert detect_within_row_shared_fraction({("f.xlsx", "S4"): sheet}) == []
+
+
+def test_scan_dir_surfaces_within_row_shared_fraction(tmp_path):
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "s.csv").write_text(
+        "TNF-α (pg/mg)," + ",".join(str(v) for v in TNF) + "\n", encoding="utf-8")
+    res = scan_dir(str(data), str(tmp_path / "out"), write_html=True)
+    hits = [f for f in res.get("cross_sheet_findings", []) or []
+            if f.get("kind") == "within_row_shared_fraction"]
+    assert hits, "scan_dir did not surface the within-row shared fraction"
+    # the shared tail and full-precision values must be visible in the human-facing report
+    html = (tmp_path / "out" / "report.html").read_text(encoding="utf-8")
+    assert "316768" in html, "within-row shared-fraction evidence missing from HTML report"


### PR DESCRIPTION
## `detect_within_row_shared_fraction` — copy-then-integer-shift inside one row

The existing shared-fraction detectors only compare two **columns**
(`integer_diff_shared_fraction`, `round_shift_shared_fraction`) or two **blocks**
(`within_table_fraction_reuse`) — none looks across the columns of a **single row**. So a
value, or a whole row-slice, reused within one row with the integer part rewritten but the
high-precision decimals left intact is invisible. Example (synthetic fixture): one row with

```
… 20.316768 · 162.14990133 · 132.81763667 · 102.316768 · 163.14990133 · 138.81763667 …
```

where the segment `[20.316768, 162.1499…, 132.8176…]` reappears as
`[102.316768, 163.1499…, 138.8176…]` — each value's integer part changed, its ≥6-digit
fractional tail preserved.

### Detector

For every data row, bucket its cells by fractional tail (≥6 digits at read precision) and
flag any bucket holding ≥2 cells whose integer parts differ. False-positive controls:

- **≥6-digit shared tail** — a chance collision is ~1e-6 per pair, so a single pair is
  already worth a look and a multi-pair segment is near-certain.
- **≥2 distinct integer parts** — otherwise it is a duplicate value, caught elsewhere.
- **small-denominator gate** — the shared fractional value must NOT be a simple fraction
  `p/q` for `q ≤ 64`. Triplicate means (`.333`/`.667` = 1/3, 2/3), `k/13` (`.923076`),
  `k/19`, etc. trivially share a tail across different integers; that is a
  division/quantization artifact, not a copied fraction. (Same trap the tail-cluster
  detector guards.)
- values `≥ 1e7` skipped (read-precision noise reaches the tail).

Emits kind `within_row_shared_fraction` into `cross_sheet_findings`; reaches the review
packet and renders a "shared fractional tail → values" evidence table in the HTML report.

### Tests / determinism

- New `tests/test_within_row_shared_fraction.py` (segment case, independent-row negative,
  short-tail negative, same-integer negative, small-denominator/thirds & k/13 negatives,
  large-magnitude skip, scan_dir + HTML).
- Full suite green; output deterministic for identical input.

Note (follow-up): the shared-fraction fingerprint is now spread across several
orientation-specific detectors (column-pair, block-pair, cross-sheet, within-row) and one
orientation (row-pair) is still uncovered. A follow-up will consolidate them into a single
primitive with a shared small-denominator gate. This PR ships the within-row fill.

All findings are statistical signals for human re-check — not verdicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
