### PR TITLE
feat: complete the row-relation family with offset_row_reuse (B=A+c)

### DIFF
--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -3048,6 +3048,41 @@ def _longest_hp_ratio_run(a, b):
     return k, best_len, x_run
 
 
+def _longest_hp_offset_run(a, b):
+    """Longest contiguous run where b[c] == a[c] + c for a fixed NON-zero constant c, every
+    cell high-precision, c held to a tight absolute tolerance (a genuine copy+shift is exact).
+    The row twin of `constant_offset`. Returns (c, run_len, x_run) or None."""
+    best_len, best_start, best_c = 0, 0, None
+    cur_len, cur_c, cur_start, cur_scale = 0, None, 0, 1.0
+    for i in range(len(a)):
+        av, bv = a[i], b[i]
+        if not _is_short_hp(av) or not _is_short_hp(bv):
+            cur_len, cur_c = 0, None
+            continue
+        d = bv - av
+        # membership tolerance scales with the CELL magnitude (no fixed floor): for near-zero
+        # rows a fixed 1e-4 floor is huge relative to the values, so unrelated small rows read
+        # as a constant difference; a genuine copy+shift matches to read precision (~1e-9).
+        tol = _SHORT_ROW_RTOL * max(abs(av), abs(bv), 1e-300)
+        if cur_c is None or abs(d - cur_c) > tol:
+            cur_c, cur_len, cur_start = d, 1, i
+            cur_scale = max(abs(av), abs(bv), 1e-300)    # anchor magnitude, fixed for the run
+        else:
+            cur_len += 1
+        # non-triviality is anchored to the run START magnitude, not the current cell — a
+        # per-cell threshold flips as the run crosses magnitudes and truncates genuine runs
+        # when a large cell lands at the tail.
+        if cur_len > best_len and abs(cur_c) > _SHORT_ROW_RTOL * cur_scale:
+            best_len, best_start, best_c = cur_len, cur_start, cur_c
+    if best_len == 0 or best_c is None:
+        return None
+    x_run = a[best_start:best_start + best_len].astype(float)
+    c = float(np.mean(b[best_start:best_start + best_len].astype(float) - x_run))
+    if abs(c) <= 1e-9:
+        return None
+    return c, best_len, x_run
+
+
 def _short_row_candidates(grid_sheets):
     """Every data row carrying >=_SHORT_ROW_MIN_COLS high-precision values with >=3
     DISTINCT such values — including ISOLATED single rows that `_scaled_row_candidates`
@@ -3124,6 +3159,7 @@ def detect_short_row_reuse(grid_sheets, profile="review", max_findings=60):
                     break
                 ident = _longest_hp_identical_run(a[:m], b[:m])
                 ratio = _longest_hp_ratio_run(a[:m], b[:m])
+                offset = _longest_hp_offset_run(a[:m], b[:m])
                 ident_ok = (ident is not None
                             and _SHORT_ROW_MIN_COLS <= ident[0] < _ROW_REL_MIN_COLS
                             and len(np.unique(ident[1])) >= 3
@@ -3134,14 +3170,28 @@ def detect_short_row_reuse(grid_sheets, profile="review", max_findings=60):
                             and _rare(ratio[2])
                             and not _same_band(A["row"], B["row"])
                             and not _near_power_of_ten(ratio[0]))
-                if ident_ok and (not ratio_ok or ident[0] >= ratio[1]):
+                # Constant additive offset (B = A + c) — the row twin of constant_offset. Like
+                # the scaled case, an adjacent same-band offset is a smooth-curve step (a linear
+                # stretch of a curve), so it is suppressed.
+                offset_ok = (offset is not None
+                             and _SHORT_ROW_MIN_COLS <= offset[1] < _ROW_REL_MIN_COLS
+                             and len(np.unique(offset[2])) >= 3
+                             and _rare(offset[2])
+                             and not _same_band(A["row"], B["row"]))
+                # Prefer identical; among the two one-parameter relations pick the longer run.
+                if ident_ok and ident[0] >= max(ratio[1] if ratio_ok else 0,
+                                                offset[1] if offset_ok else 0):
                     kind, k, run_len, x_run = "identical_row_reuse", 1.0, ident[0], ident[1]
+                elif offset_ok and (not ratio_ok or offset[1] >= ratio[1]):
+                    kind, k, run_len, x_run = "offset_row_reuse", offset[0], offset[1], offset[2]
                 elif ratio_ok:
                     kind, k, run_len, x_run = "scaled_row_reuse", ratio[0], ratio[1], ratio[2]
                 else:
                     continue
-                rel = (f"== row '{B['label']}'" if kind == "identical_row_reuse"
-                       else f"= row '{B['label']}' * {k:.6g}")
+                rel = ("== row '{}'".format(B["label"]) if kind == "identical_row_reuse"
+                       else "= row '{}' + {:.6g}".format(B["label"], k)
+                       if kind == "offset_row_reuse"
+                       else "= row '{}' * {:.6g}".format(B["label"], k))
                 findings.append(dict(
                     kind=kind, short_run=True,
                     file=fname, file_a=fname, file_b=fname,
@@ -3149,10 +3199,13 @@ def detect_short_row_reuse(grid_sheets, profile="review", max_findings=60):
                     sheet_a=sname, sheet_b=sname,
                     row_a=A["label"], row_b=B["label"],
                     size_a=run_len, size_b=run_len, same_position_count=run_len,
-                    fraction_of_smaller=1.0, ratio=k, run_length=run_len,
+                    fraction_of_smaller=1.0, run_length=run_len,
+                    ratio=(k if kind == "scaled_row_reuse" else None),
+                    offset=(k if kind == "offset_row_reuse" else None),
                     figure_a=fig, figure_b=fig, same_figure=fig is not None,
-                    delta={"pattern": "identical_row" if kind == "identical_row_reuse"
-                           else "scaled_row"},
+                    delta={"pattern": {"identical_row_reuse": "identical_row",
+                                       "offset_row_reuse": "offset_row",
+                                       "scaled_row_reuse": "scaled_row"}[kind]},
                     block_a=f"row {A['row'] + 1}", block_b=f"row {B['row'] + 1}",
                     examples=[{"row": A["label"], "col": None, "value": float(v)}
                               for v in x_run[:5]],

--- a/src/paperconan/_profiles.py
+++ b/src/paperconan/_profiles.py
@@ -128,13 +128,13 @@ def _is_axis_finding(f: dict) -> bool:
 
 def _is_derived_relation(f: dict) -> bool:
     if f.get("kind") not in {"constant_ratio", "exact_linear", "sum_constant",
-                             "constant_ratio_row", "scaled_row_reuse"}:
+                             "constant_ratio_row", "scaled_row_reuse", "offset_row_reuse"}:
         return False
-    # Two rows carrying the SAME label related by an arbitrary scalar is a duplicate, not a
-    # unit/normalization derivation: a real unit conversion or %-restatement RELABELS the row
-    # (e.g. "ng/mL" -> "µg/mL"). A unit token in a shared label (e.g. "TNF-α (pg/mL)" in two
+    # Two rows carrying the SAME label related by an arbitrary scalar or offset is a duplicate,
+    # not a unit/normalization derivation: a real unit conversion or %-restatement RELABELS the
+    # row (e.g. "ng/mL" -> "µg/mL"). A unit token in a shared label (e.g. "TNF-α (pg/mL)" in two
     # panels) must not be read as evidence of derivation and must not downgrade the finding.
-    if f.get("kind") in {"constant_ratio_row", "scaled_row_reuse"}:
+    if f.get("kind") in {"constant_ratio_row", "scaled_row_reuse", "offset_row_reuse"}:
         a = " ".join(str(f.get("row_a") or "").split()).casefold()
         b = " ".join(str(f.get("row_b") or "").split()).casefold()
         if a and a == b:

--- a/tests/test_offset_row_reuse.py
+++ b/tests/test_offset_row_reuse.py
@@ -1,0 +1,107 @@
+"""Constant-offset row reuse — the row twin of `constant_offset` (B = A + c).
+
+`detect_short_row_reuse` already finds identical (B = A) and scaled (B = k·A) runs between
+two rows, mirroring `identical_column` and `constant_ratio`. The linear family had no
+row-oriented OFFSET member, though columns have had `constant_offset` all along: a row
+reused at another cohort with a constant added (a baseline shift / additive copy, e.g.
+B = A + 0.589) was invisible. This completes the family. Signal, not verdict.
+"""
+from __future__ import annotations
+
+from paperconan import scan_dir
+from paperconan._audit import detect_short_row_reuse
+from paperconan._sheet import Sheet
+
+RA = [10.316768, 22.849559, 34.647899, 15.173653, 28.508241, 19.930517]
+
+
+def _two_panel(rb, ncols=6):
+    return Sheet.from_rows([
+        ["panel1", *([None] * ncols)],
+        ["cond", *RA],
+        ["panel2", *([None] * ncols)],
+        ["cond", *rb],
+    ])
+
+
+def test_detects_constant_offset_between_panels():
+    sheet = _two_panel([v + 0.589 for v in RA])
+    findings = detect_short_row_reuse({("f.xlsx", "S1"): sheet})
+    off = [f for f in findings if f["kind"] == "offset_row_reuse"]
+    assert len(off) == 1, f"expected one offset-row finding, got {findings}"
+    assert abs(off[0]["offset"] - 0.589) < 1e-4 or abs(off[0]["offset"] + 0.589) < 1e-4
+    assert off[0]["run_length"] >= 3
+    assert off[0]["severity"] == "high"
+
+
+def test_identical_rows_are_identical_not_offset():
+    # c == 0 is the identical case, not an offset.
+    sheet = _two_panel(list(RA))
+    findings = detect_short_row_reuse({("f.xlsx", "S2"): sheet})
+    assert not [f for f in findings if f["kind"] == "offset_row_reuse"]
+    assert [f for f in findings if f["kind"] == "identical_row_reuse"]
+
+
+def test_no_false_positive_on_independent_rows():
+    sheet = _two_panel([13.221417, 41.55238, 7.918263, 29.104772, 33.870915, 2.446181])
+    assert detect_short_row_reuse({("f.xlsx", "S3"): sheet}) == []
+
+
+def test_same_band_offset_suppressed_as_curve_step():
+    # Two ADJACENT rows (no header between) differing by a constant is a smooth-curve step,
+    # not a copied panel — suppressed like the scaled same-band case.
+    sheet = Sheet.from_rows([["a", *RA], ["b", *[v + 0.589 for v in RA]]])
+    assert not [f for f in detect_short_row_reuse({("f.xlsx", "S4"): sheet})
+                if f["kind"] == "offset_row_reuse"]
+
+
+def test_no_false_positive_on_near_zero_rows():
+    # Two rows of tiny (~1e-4) high-precision values: a fixed-floor tolerance made unrelated
+    # near-zero rows read as a constant difference larger than the values (JCI182394 Fig.S7).
+    a = [0.000549444, 0.000210289, 0.000277287, 0.000418122, 0.000133905, 0.000391044]
+    b = [0.001883333, 0.001546122, 0.001611240, 0.001101765, 0.002049881, 0.000904611]
+    sheet = _two_panel(b)  # RA replaced below
+    sheet = Sheet.from_rows([["panel1", *([None] * 6)], ["cond", *a],
+                             ["panel2", *([None] * 6)], ["cond", *b]])
+    assert not [f for f in detect_short_row_reuse({("f.xlsx", "S5"): sheet})
+                if f["kind"] == "offset_row_reuse"]
+
+
+def test_offset_run_not_truncated_by_large_tail_cell():
+    # A small constant offset over cells that include a LARGE-magnitude cell at the run tail:
+    # the non-triviality check must be anchored to the run, not the current cell, or the run
+    # is truncated below the 3-column minimum and the finding is dropped (review #1).
+    a = [10.316768, 22.849559, 1000.647899]
+    b = [v + 0.05 for v in a]
+    sheet = Sheet.from_rows([["panel1", None, None, None], ["cond", *a],
+                             ["panel2", None, None, None], ["cond", *b]])
+    off = [f for f in detect_short_row_reuse({("f.xlsx", "S6"): sheet})
+           if f["kind"] == "offset_row_reuse"]
+    assert len(off) == 1 and off[0]["run_length"] == 3, f"large-tail run truncated: {off}"
+
+
+def test_offset_row_reuse_is_derived_relation_symmetric_with_scaled():
+    # An additive constant is a common benign derivation (baseline subtraction) — offset must
+    # be demotable like its scaled twin, with the same same-label guard (review #2).
+    from paperconan._profiles import _is_derived_relation
+    assert _is_derived_relation(
+        {"kind": "offset_row_reuse", "row_a": "conc (ng/mL)", "row_b": "OD (a.u.)"})
+    assert not _is_derived_relation(
+        {"kind": "offset_row_reuse", "row_a": "TNF (pg/mL)", "row_b": "TNF (pg/mL)"})
+
+
+def test_scan_dir_surfaces_offset_row_reuse(tmp_path):
+    rows = [
+        ["panel1", "", "", "", "", "", ""],
+        ["cond", *RA],
+        ["panel2", "", "", "", "", "", ""],
+        ["cond", *[v + 0.589 for v in RA]],
+    ]
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "s.csv").write_text(
+        "\n".join(",".join("" if x == "" else str(x) for x in r) for r in rows) + "\n",
+        encoding="utf-8")
+    res = scan_dir(str(data), str(tmp_path / "out"), write_html=False)
+    assert [f for f in res.get("cross_sheet_findings", []) or []
+            if f.get("kind") == "offset_row_reuse"]


### PR DESCRIPTION
## Complete the row-relation family: constant-offset row reuse (B = A + c)

The linear-relation detectors are asymmetric between orientations. **Columns** have the full
complement — `identical_column` (B=A), `constant_offset` (B=A+c), `constant_ratio` (B=k·A),
`exact_linear` (affine). **Rows** had only identical and ratio (`identical_row_reuse` /
`scaled_row_reuse` in `detect_short_row_reuse`, and `identical_row` / `constant_ratio_row` in
`detect_row_relations`) — the OFFSET member was missing. A row reused at another cohort with
a constant added (a baseline shift / additive copy, e.g. `B = A + 0.589`) had no detector.

This completes the family by adding `offset_row_reuse` to the existing row-reuse detector —
the row twin of the long-standing column `constant_offset`.

### `_longest_hp_offset_run`

Longest contiguous run where `b[c] - a[c]` is a fixed non-zero constant, every cell
high-precision. Reuses the family's existing gates: run 3–11 columns, ≥3 distinct values,
the per-sheet frequency gate (quantized-grid / fitted-curve-plateau exclusion), and same-band
suppression (an adjacent same-band constant difference is a smooth-curve step, not a copy).

Membership tolerance scales with cell magnitude with **no fixed floor** — a fixed `1e-4`
floor made unrelated near-zero rows (~1e-4 values) read as a constant difference larger than
the values themselves (a real false positive; see `test_no_false_positive_on_near_zero_rows`).

### Choice logic

Prefer identical (B=A); among the two one-parameter relations (offset, scaled) pick the
longer run. A row pair is still reported as exactly one relation. A constant *integer* offset
stays distinct from `shared_fraction_row_pair` (which requires ≥2 *distinct* integer
differences, i.e. a varied copy-then-shift, not a constant offset).

### Result

Row linear relations now cover identical / offset / ratio, matching the column side. Emits
`offset_row_reuse` (with an `offset` field, `delta.pattern="offset_row"`); reaches the review
packet and HTML. New `tests/test_offset_row_reuse.py`; full suite green; 0 findings across the
real held-out papers (well-gated). All findings are statistical signals for human re-check —
not verdicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
