### PR TITLE
feat: within_row_repeated_segment (within-row member of the recurring-vector family)

### DIFF
--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -2640,6 +2640,11 @@ def _vector_is_patterned(vec):
     return False
 
 
+# Per-row cell cap for the within-row pass: bounds the O(width * k) window build so one huge
+# row (a wide genomics matrix) cannot balloon memory before the budget check fires.
+_WR_MAX_ROW_CELLS = int(os.environ.get("PAPERCONAN_WR_MAX_ROW_CELLS", "20000"))
+
+
 def detect_recurring_row_vectors(grid_sheets, profile="review",
                                  min_k=4, max_k=8, max_rows=300, max_findings=20):
     """B2 — a fixed ordered numeric tuple recurring as a contiguous row-slice across >=3 places
@@ -2648,14 +2653,17 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
     is a copy fingerprint. Guarded hard (this is the most FP-prone pass): >=3 distinct values, no
     arithmetic/geometric/round-number ladders, >=3 occurrences in >=2 figure namespaces, and
     all-integer tuples need k>=5 with >=4 distinct values."""
-    # A finding needs >=2 distinct figure namespaces; skip the (expensive, FP-prone) window
-    # build entirely when the corpus can never satisfy that (single sheet, or plainly-named
-    # sheets whose figure_key is None).
-    if len({figure_key(s) for (_f, s) in grid_sheets if figure_key(s) is not None}) < 2:
-        return []
+    # The cross-FIGURE finding needs >=2 distinct figure namespaces; the within-ROW sibling
+    # (a segment repeated inside one row) does not. Build the window index whenever EITHER is
+    # possible — only the truly trivial single-sheet, unnamed corpus with no wide rows is
+    # skipped (bounded by the budget below regardless).
+    cross_figure_possible = (
+        len({figure_key(s) for (_f, s) in grid_sheets if figure_key(s) is not None}) >= 2)
     occ = {}   # rounded tuple -> list of (file, sheet, figure_key, row, start_col)
     budget = 3_000_000   # bound worst-case work on genome-scale papers (linear, but many blocks)
-    for (fname, sname), sheet in grid_sheets.items():
+    # The window index feeds ONLY the cross-figure path; skip building it entirely otherwise
+    # (the within-row pass below scans rows directly).
+    for (fname, sname), sheet in (grid_sheets.items() if cross_figure_possible else ()):
         fk = figure_key(sname)
         for (r0, r1, c0, c1) in find_numeric_blocks(sheet):
             for r in range(r0, min(r1, r0 + max_rows)):
@@ -2679,7 +2687,7 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
             break
 
     cands = []
-    for vec, places in occ.items():
+    for vec, places in (occ.items() if cross_figure_possible else ()):
         if len(places) < 3 or _vector_is_patterned(list(vec)):
             continue
         namespaces = {p[2] for p in places if p[2] is not None}
@@ -2736,6 +2744,95 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
                   f"{len(namespaces)} figures ({loc})")))
         if len(findings) >= max_findings:
             break
+
+    # Within-ROW member of the same family: the identical high-precision segment appearing at
+    # >=2 NON-OVERLAPPING positions of ONE row (two cohorts of a row carrying the same tuple —
+    # JCI196944 Fig S2H's CNO row). Scanned per-row DIRECTLY, not via the block index above: a
+    # sparse sub-panel (S2H sits in columns the grid segmentation never blocks) would otherwise
+    # be invisible. Same gates as the cross-figure path; the repeat corroborates itself, so one
+    # figure namespace is enough.
+    wr_budget = 2_000_000
+    wr_cands = []
+    for (fname, sname), sheet in grid_sheets.items():
+        fk = figure_key(sname)
+        for r in range(sheet.nrows):
+            seq = []
+            for c in range(sheet.ncols):
+                v = sheet.cell(r, c)
+                if isinstance(v, (int, float)) and not isinstance(v, bool):
+                    seq.append((c, float(v)))
+                    if len(seq) >= _WR_MAX_ROW_CELLS:  # cap width so one huge row can't OOM
+                        break
+            if len(seq) < 2 * min_k:
+                continue
+            # per-row value frequency, keyed with the SAME quantization as the window (round-6)
+            # so bucket and key agree at every magnitude: a value from a small quantized pool
+            # (k/19 grid, dose plateau) recurs far more than the copies, unlike a copied segment.
+            row_freq = Counter(round(v, 6) for _c, v in seq)
+            wins = {}
+            for start in range(len(seq)):
+                for k in range(min_k, max_k + 1):
+                    if start + k > len(seq):
+                        break
+                    wins.setdefault(tuple(round(seq[start + o][1], 6) for o in range(k)),
+                                    []).append(start)
+                    wr_budget -= 1
+                if wr_budget <= 0:                     # gate INSIDE the loop, not per-row
+                    break
+            for vec, starts in wins.items():
+                if len(starts) < 2 or _vector_is_patterned(list(vec)) or len(set(vec)) < 3:
+                    continue
+                all_int = all(abs(v - round(v)) < 1e-9 for v in vec)
+                if all_int and (len(vec) < 5 or len(set(vec)) < 4):
+                    continue
+                chosen, last_end = [], -1
+                for s in sorted(set(starts)):
+                    if s >= last_end:                 # non-overlapping occurrences only
+                        chosen.append(s)
+                        last_end = s + len(vec)
+                # quantized-pool signature is freq >> copies (not merely > copies): suppress only
+                # when a value recurs beyond twice the copy count, else a genuine repeat whose
+                # value happens to appear a couple extra times in a wide row is wrongly dropped.
+                if len(chosen) >= 2 and max(row_freq[v] for v in vec) <= 2 * len(chosen):
+                    cells = {(fname, sname, r, seq[s + o][0])
+                             for s in chosen for o in range(len(vec))}
+                    wr_cands.append((vec, fname, sname, fk, r, chosen, cells))
+            if wr_budget <= 0:
+                break
+        if wr_budget <= 0:
+            break
+    if wr_budget <= 0:
+        print("[paperconan] detect_recurring_row_vectors: within-row coverage bounded",
+              file=sys.stderr)
+    # One physical repeat yields many overlapping windows (k=4..8) — keep the strongest (most
+    # copies, then longest) per row, dropping >=50%-cell-overlap duplicates.
+    wr_cands.sort(key=lambda x: (-len(x[5]), -len(x[0])))
+    wr_kept = []
+    for c in wr_cands:
+        if any(c[1:5] == kc[1:5] and len(c[6] & kc[6]) >= 0.5 * min(len(c[6]), len(kc[6]))
+               for kc in wr_kept):
+            continue
+        wr_kept.append(c)
+    for vec, fn, sn, fk, r, chosen, _cells in wr_kept:
+        findings.append(dict(
+            kind="within_row_repeated_segment",
+            file=fn, file_a=fn, file_b=fn, same_file=True,
+            sheet=sn, sheet_a=sn, sheet_b=sn, same_sheet=True,
+            vector=[float(v) for v in vec],
+            # same_position_count = matched CELLS (values x copies), consistent with the sibling
+            # cross-sheet kinds, so evidence weighting isn't driven by the bare copy count.
+            size_a=len(vec) * len(chosen), size_b=len(vec) * len(chosen),
+            same_position_count=len(vec) * len(chosen),
+            fraction_of_smaller=1.0, n_occurrences=len(chosen),
+            figure_a=fk, figure_b=fk, same_figure=fk is not None,
+            delta={"pattern": "within_row_repeat"}, pattern="within_row_repeat",
+            examples=[{"value": float(v)} for v in vec],
+            severity="high",
+            rule=(f"the {len(vec)}-value segment {[round(float(v), 6) for v in vec]} repeats at "
+                  f"{len(chosen)} non-overlapping positions within one row of {sn}")))
+        if len(findings) >= max_findings:
+            break
+
     apply_profile_to_findings(findings, profile)
     return findings
 

--- a/tests/test_within_row_repeated_segment.py
+++ b/tests/test_within_row_repeated_segment.py
@@ -1,0 +1,109 @@
+"""Within-row repeated segment — the within-row member of the recurring-vector family.
+
+`detect_recurring_row_vectors` flags a high-information numeric tuple that recurs across >=2
+figures. Its within-row sibling — the SAME contiguous high-precision segment appearing twice
+in ONE row at non-overlapping columns — had no detector: JCI196944 Fig S2H's CNO row carries
+the identical 5-value tuple under both the Saline and the METH group. Two independent cohorts
+cannot yield the same high-precision tuple; the repeat is a copy fingerprint. Signal, not
+verdict — same family, same gates (>=3 distinct values, no ladders), extended to one row.
+"""
+from __future__ import annotations
+
+from paperconan import scan_dir
+from paperconan._audit import detect_recurring_row_vectors
+from paperconan._sheet import Sheet
+
+SEG = [3.238866, 1.724138, 3.418803, 0.727273, 2.380952]   # JCI196944 Fig S2H CNO segment
+
+
+def _fill(n, seed):
+    return [11.0 + ((k * 13 + seed) % 71) + ((k * 7919 + seed * 104729) % 1000000) / 1000003.7
+            for k in range(n)]
+
+
+def _row_sheet(row, name="Supplemental Figure 2"):
+    # >=2 data rows so find_numeric_blocks forms a block; the repeat lives in ONE of them.
+    n = len(row)
+    return Sheet.from_rows([
+        [name] + [f"c{i}" for i in range(n)],
+        ["Veh", *_fill(n, 3)],
+        ["CNO", *row],
+        ["X", *_fill(n, 7)],
+    ])
+
+
+def test_detects_within_row_repeated_segment():
+    # seg appears at cols 2-6 and 8-12 (non-overlapping), a spacer value between the groups.
+    row = [1.785714, *SEG, 5.714286, *SEG]
+    findings = detect_recurring_row_vectors({("JCI196944.xlsx", "Supplemental Figure 2"): _row_sheet(row)})
+    wr = [f for f in findings if f["kind"] == "within_row_repeated_segment"]
+    assert len(wr) == 1, f"expected one within-row repeated segment, got {findings}"
+    assert wr[0]["severity"] == "high"
+
+
+def test_no_false_positive_on_non_repeating_row():
+    row = [1.785714, *SEG, 5.714286, 9.111111, 8.222222, 7.333333, 6.444444, 5.555556]
+    assert not [f for f in detect_recurring_row_vectors(
+        {("f.xlsx", "Fig 1"): _row_sheet(row)}) if f["kind"] == "within_row_repeated_segment"]
+
+
+def test_no_false_positive_on_overlapping_window():
+    # A run like [x, x, x, x, x] repeats overlapping windows but is a single constant block,
+    # not two non-overlapping copies; and it is low-information (patterned). Must not fire.
+    row = [2.5] * 10
+    assert not [f for f in detect_recurring_row_vectors(
+        {("f.xlsx", "Fig 1"): _row_sheet(row)}) if f["kind"] == "within_row_repeated_segment"]
+
+
+def test_no_false_positive_on_short_or_low_info_repeat():
+    # A 3-value low-info repeat (below min_k / patterned) must not fire.
+    row = [1.0, 2.0, 1.0, 2.0, 1.0, 2.0]
+    assert not [f for f in detect_recurring_row_vectors(
+        {("f.xlsx", "Fig 1"): _row_sheet(row)}) if f["kind"] == "within_row_repeated_segment"]
+
+
+def test_no_false_positive_on_quantized_grid_row():
+    # A tiny value pool (like JCI182394 Fig11J's k/19 body weights): the tuple (a,b,c,d)
+    # repeats twice, but each value recurs 5x across the row (pool is small) — far more than the
+    # two copies. The per-row frequency gate (freq >> copies) must suppress it.
+    a, b, c, d = 110.5263, 94.73684, 105.2632, 89.47368
+    sp = 999.1111                                       # distinct spacer, breaks up the tuple
+    row = [a, b, c, d] + [a, sp, b, sp, c, sp, d, sp] * 3 + [a, b, c, d]  # a,b,c,d each 5x
+    assert not [f for f in detect_recurring_row_vectors(
+        {("JCI182394.xlsx", "Fig.11"): _row_sheet(row)})
+        if f["kind"] == "within_row_repeated_segment"]
+
+
+def test_no_false_positive_on_small_magnitude_quantized_pool():
+    # Same quantized-pool structure but at ~1e-4 magnitude (molar concentrations / proportions):
+    # the frequency bucket must use the SAME quantization as the window key, or the lookup
+    # misses and the gate leaks (review I2).
+    a, b, c, d = 0.0001105263, 0.00009473684, 0.0001052632, 0.00008947368
+    sp = 0.0009991111
+    row = [a, b, c, d] + [a, sp, b, sp, c, sp, d, sp] * 3 + [a, b, c, d]  # a,b,c,d each 5x
+    assert not [f for f in detect_recurring_row_vectors(
+        {("f.xlsx", "Fig 1"): _row_sheet(row)})
+        if f["kind"] == "within_row_repeated_segment"]
+
+
+def test_genuine_repeat_kept_despite_a_few_incidental_extras():
+    # A real copied 5-tuple must NOT be dropped just because one of its values appears a couple
+    # extra times elsewhere in a wide row — suppress only when freq >> copies (review I3).
+    seg = [1.724138, 3.418803, 3.238866, 0.727273, 2.380952]   # popular value CENTRAL (no escape)
+    row = [*seg, 9.111111, 3.238866, 8.222222, 3.238866, 7.333333, *seg]  # 3.238866 freq = 4
+    wr = [f for f in detect_recurring_row_vectors({("f.xlsx", "Fig 1"): _row_sheet(row)})
+          if f["kind"] == "within_row_repeated_segment"]
+    assert len(wr) == 1, f"genuine repeat wrongly suppressed: {wr}"
+
+
+def test_scan_dir_surfaces_within_row_repeated_segment(tmp_path):
+    row = [1.785714, *SEG, 5.714286, *SEG]
+    data = tmp_path / "data"
+    data.mkdir()
+    lines = ["Veh," + ",".join(str(v) for v in _fill(len(row), 3)),
+             "CNO," + ",".join(str(v) for v in row),
+             "X," + ",".join(str(v) for v in _fill(len(row), 7))]
+    (data / "s.csv").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    res = scan_dir(str(data), str(tmp_path / "out"), write_html=True)
+    assert [f for f in res.get("cross_sheet_findings", []) or []
+            if f.get("kind") == "within_row_repeated_segment"]


### PR DESCRIPTION
## Within-row repeated segment — the within-row member of the recurring-vector family

`detect_recurring_row_vectors` flags a high-information numeric tuple that recurs as a
contiguous slice across ≥2 **figures**. Its within-**row** sibling had no detector: the SAME
contiguous high-precision segment appearing at ≥2 non-overlapping positions inside ONE row —
e.g. a row whose two cohorts (Saline / METH) carry the identical 5-value tuple. Two
independent cohorts cannot yield the same high-precision tuple; the repeat is a copy
fingerprint. This is the same category (a recurring high-info vector), extended to one row, so
it is added to the same detector rather than a new one.

### Implementation

Scanned per-row directly (not through the block index the cross-figure path uses) — a sparse
sub-panel can sit in columns the grid segmentation never blocks, which would otherwise make
the repeat invisible. Same family gates: ≥3 distinct values, no arithmetic/round-number
ladders, all-integer tuples need k≥5 with ≥4 distinct, window length 4–8.

New false-positive gate — a **per-row value-frequency** check: a value drawn from a small
quantized pool (a k/19 normalization grid, a dose plateau) recurs across the row far more than
the two copies, so any window "repeats" by chance. Requiring every window value to appear no
more than one beyond the copy count suppresses those pools while keeping a genuine copied
segment (whose values appear ≈once per copy).

The prior early-return (skip when <2 figure namespaces) is replaced by a `cross_figure_possible`
flag guarding the cross-figure candidate build, so the cross-figure output is unchanged while
the window index is available to the within-row pass. Both passes are budget-bounded.

### Result

Emits `within_row_repeated_segment` into `cross_sheet_findings`; reaches the review packet and
the HTML report. New `tests/test_within_row_repeated_segment.py` (segment detection,
non-repeating/overlapping/low-info/quantized-pool negatives, scan_dir + HTML). Full suite
green; 0 findings across the held-out papers except the one true positive; deterministic. All
findings are statistical signals for human re-check — not verdicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
