### PR TITLE
feat: model scan coverage/status explicitly in scan.json

### DIFF
--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -38,6 +38,7 @@ import openpyxl
 import numpy as np
 from scipy import stats
 
+from ._coverage import ScanCoverage
 from ._profiles import apply_profile_to_findings, normalize_profile
 from ._sheet import Sheet
 from .schema import PaperconanInputError
@@ -3699,6 +3700,7 @@ def scan_dir(in_dir, out_dir, *, write_md=False, write_html=True, paper=None,
     grid_sheets = {}  # (file, sheet) -> Sheet, for local cross-sheet label context
     scan_errors = []
     scan_stats = {"files": [], "sheets": []}
+    coverage = ScanCoverage(files_discovered=len(table_files))
     scan_start = time.perf_counter() if runtime_metadata else None
 
     for f in table_files:
@@ -3720,6 +3722,7 @@ def scan_dir(in_dir, out_dir, *, write_md=False, write_html=True, paper=None,
             file_stat["oversized"] = True
             file_stat["elapsed_ms"] = _elapsed_ms(file_start)
             scan_stats["files"].append(file_stat)
+            coverage.mark_file_failed(os.path.basename(f), "file_too_large")
             continue
         try:
             sheets = load_table(f)
@@ -3729,10 +3732,12 @@ def scan_dir(in_dir, out_dir, *, write_md=False, write_html=True, paper=None,
             file_stat["error"] = str(e)
             file_stat["elapsed_ms"] = _elapsed_ms(file_start)
             scan_stats["files"].append(file_stat)
+            coverage.mark_file_failed(os.path.basename(f), "unreadable")
             continue
         file_stat["n_sheets"] = len(sheets)
         file_stat["elapsed_ms"] = _elapsed_ms(file_start)
         scan_stats["files"].append(file_stat)
+        coverage.mark_file_succeeded()
         for sn, rows in sheets.items():
             sheet_start = time.perf_counter() if runtime_metadata else None
             if rows is None:        # oversized sheet (>_MAX_CELLS): recorded, never audited
@@ -3742,6 +3747,8 @@ def scan_dir(in_dir, out_dir, *, write_md=False, write_html=True, paper=None,
                 scan_stats["sheets"].append({
                     "file": os.path.basename(f), "sheet": sn, "oversized": True,
                     "elapsed_ms": _elapsed_ms(sheet_start)})
+                coverage.mark_sheet_skipped(
+                    os.path.basename(f), sn, "sheet_too_large")
                 continue
             sheet = rows if isinstance(rows, Sheet) else Sheet.from_rows(rows)
             grids[(os.path.basename(f), sn)] = _grid_from_rows(sheet)
@@ -3759,11 +3766,13 @@ def scan_dir(in_dir, out_dir, *, write_md=False, write_html=True, paper=None,
                 "n_blocks": len(blocks),
                 "elapsed_ms": _elapsed_ms(sheet_start),
             })
+            blocks_analyzed_here = 0
             for (r0, r1, c0, c1) in blocks:
                 if len(report_blocks) >= _MAX_REPORT_BLOCKS:   # output budget reached; stop collecting
                     break
                 if _MAX_TOTAL_FINDINGS > 0 and findings_kept_total >= _MAX_TOTAL_FINDINGS:
                     break   # global finding budget spent; stop collecting (subsequent sheets short-circuit here too)
+                blocks_analyzed_here += 1
                 header = header_for(sheet, r0, c0, c1)
                 # On very wide blocks (dense correlation matrices) the O(col²) relation and
                 # equal-pair detectors explode in compute + output, so skip just those two; the
@@ -3824,6 +3833,16 @@ def scan_dir(in_dir, out_dir, *, write_md=False, write_html=True, paper=None,
                                               identical_after_rounding=groups["identical_after_rounding"],
                                               grim=groups["grim"],
                                               findings_omitted=omitted))
+            coverage.mark_sheet_succeeded()
+            coverage.mark_block_analyzed(blocks_analyzed_here)
+            if blocks_analyzed_here < len(blocks):
+                # An output/finding budget stopped block collection for this sheet;
+                # record the shortfall so a truncated scan is not read as complete.
+                coverage.mark_blocks_skipped(
+                    len(blocks) - blocks_analyzed_here,
+                    scope="sheet", reason="report_block_limit",
+                    file=os.path.basename(f), sheet=sn,
+                )
 
     # Down-weight dense/correlated sheets: judged by per-sheet relation totals, so a
     # wide matrix's expected identical/linear columns don't flood high-severity output.
@@ -3938,6 +3957,9 @@ def scan_dir(in_dir, out_dir, *, write_md=False, write_html=True, paper=None,
 
     out = dict(tool="paperconan",
                tool_version=_version(),
+               schema_version=2,
+               scan_status=coverage.status,
+               coverage=coverage.to_dict(),
                scanned_at=(
                    datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
                    if runtime_metadata else None),

--- a/src/paperconan/_coverage.py
+++ b/src/paperconan/_coverage.py
@@ -1,0 +1,129 @@
+"""Explicit scan-coverage accounting.
+
+A scan can legitimately leave work undone — an oversized file skipped to bound
+memory, an unreadable workbook, an oversized sheet, or output/finding budgets
+that truncate block analysis. Without an explicit record, a *partial* scan reads
+as a *clean* one, which silently understates what was and was not examined.
+
+``ScanCoverage`` accumulates those events from the orchestration control flow and
+serialises a compact, bounded summary into ``scan.json`` so reports (and the
+downstream corpus pipeline) can tell ``complete`` from ``partial`` from
+``failed``. It records only what the scanner reached — never a judgement about
+the data or its authors.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+
+ScanStatus = Literal["complete", "partial", "failed"]
+
+
+def _limitations_cap() -> int:
+    """Upper bound on retained limitation records (env-tunable, deterministic).
+
+    Bounds ``scan.json`` / report size on pathological inputs (tens of thousands
+    of skipped sheets), consistent with the other ``PAPERCONAN_MAX_*`` guards.
+    """
+    raw = os.environ.get("PAPERCONAN_MAX_LIMITATIONS", "500")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return 500
+    return value if value > 0 else 500
+
+
+@dataclass
+class ScanCoverage:
+    files_discovered: int
+    files_succeeded: int = 0
+    files_failed: int = 0
+    sheets_succeeded: int = 0
+    sheets_skipped: int = 0
+    blocks_analyzed: int = 0
+    blocks_skipped: int = 0
+    limitations: list[dict[str, Any]] = field(default_factory=list)
+    _limitation_keys: set[tuple] = field(default_factory=set, repr=False)
+    _limitations_dropped: int = field(default=0, repr=False)
+
+    def add_limitation(self, scope: str, reason: str, **details: Any) -> None:
+        item = {"scope": scope, "reason": reason}
+        item.update({k: v for k, v in details.items() if v is not None})
+        # Deduplicate identical (scope, reason, file, sheet) events so a repeated
+        # cause records once, and cap the retained list so a pathological input
+        # cannot balloon the report (GH#15-class size guard).
+        key = (scope, reason, item.get("file"), item.get("sheet"))
+        if key in self._limitation_keys:
+            return
+        if len(self.limitations) >= _limitations_cap():
+            self._limitations_dropped += 1
+            return
+        self._limitation_keys.add(key)
+        self.limitations.append(item)
+
+    def mark_file_succeeded(self) -> None:
+        self.files_succeeded += 1
+
+    def mark_file_failed(self, file: str, reason: str, **details: Any) -> None:
+        self.files_failed += 1
+        self.add_limitation("file", reason, file=file, **details)
+
+    def mark_sheet_succeeded(self) -> None:
+        self.sheets_succeeded += 1
+
+    def mark_sheet_skipped(
+        self, file: str, sheet: str, reason: str, **details: Any
+    ) -> None:
+        self.sheets_skipped += 1
+        self.add_limitation("sheet", reason, file=file, sheet=sheet, **details)
+
+    def mark_block_analyzed(self, count: int = 1) -> None:
+        if count > 0:
+            self.blocks_analyzed += count
+
+    def mark_blocks_skipped(
+        self, count: int, *, scope: str, reason: str, **details: Any
+    ) -> None:
+        if count <= 0:
+            return
+        self.blocks_skipped += count
+        self.add_limitation(scope, reason, count=count, **details)
+
+    @property
+    def status(self) -> ScanStatus:
+        if self.files_discovered and self.files_succeeded == 0:
+            return "failed"
+        if (
+            self.files_failed
+            or self.sheets_skipped
+            or self.blocks_skipped
+            or self.limitations
+        ):
+            return "partial"
+        return "complete"
+
+    def to_dict(self) -> dict[str, Any]:
+        truncated = bool(
+            self.blocks_skipped
+            or any(
+                str(item.get("reason") or "").endswith("_limit")
+                for item in self.limitations
+            )
+        )
+        payload = {
+            "files_discovered": self.files_discovered,
+            "files_succeeded": self.files_succeeded,
+            "files_failed": self.files_failed,
+            "sheets_succeeded": self.sheets_succeeded,
+            "sheets_skipped": self.sheets_skipped,
+            "blocks_analyzed": self.blocks_analyzed,
+            "blocks_skipped": self.blocks_skipped,
+            "truncated": truncated,
+            "limitations": list(self.limitations),
+        }
+        if self._limitations_dropped:
+            payload["limitations_omitted"] = self._limitations_dropped
+        return payload

--- a/src/paperconan/_html.py
+++ b/src/paperconan/_html.py
@@ -565,6 +565,9 @@ header.top { padding:18px 24px; border-bottom:1px solid var(--border); backgroun
 .stat.sev-medium strong { color:var(--medium); }
 .stat.sev-low strong { color:var(--low); }
 .warn { margin-top:10px; font-size:12px; color:var(--muted); }
+.coverage-status { margin-top:10px; font-size:12px; }
+.coverage-list { margin:6px 0 0; padding-left:18px; max-height:180px; overflow-y:auto; }
+.coverage-list li { font-size:11px; color:var(--muted); }
 .warn::before { content:"⚠ "; color:var(--medium); }
 .how-to-read { background:var(--panel-2); border:1px solid var(--border); border-left:3px solid var(--accent);
   border-radius:6px; padding:12px 16px; margin:0 0 22px; font-size:13px; line-height:1.6; color:var(--text); }
@@ -715,6 +718,55 @@ _JS = """
 """
 
 
+_STATUS_LABELS = {
+    "complete": ("ok", "全部输入均已检测 · full coverage"),
+    "partial": ("warn", "部分输入未检测(见下)· partial coverage"),
+    "failed": ("warn", "没有可检测的输入 · no input analyzed"),
+}
+_MAX_RENDERED_LIMITATIONS = 50
+
+
+def _render_scan_status(scan: dict) -> str:
+    """A bounded coverage banner: what the scan did and did not examine.
+
+    Rendered only when a scan is not fully complete, so a partial or failed run
+    is never read as a clean one. Purely descriptive of scanner reach — no
+    judgement about the data.
+    """
+    coverage = scan.get("coverage")
+    status = scan.get("scan_status")
+    if not isinstance(coverage, dict) or status not in _STATUS_LABELS:
+        return ""
+    if status == "complete":
+        return ""
+    tone, label = _STATUS_LABELS[status]
+    counts = (
+        f'{coverage.get("files_succeeded", 0)}/{coverage.get("files_discovered", 0)} files, '
+        f'{coverage.get("sheets_succeeded", 0)} sheets analyzed, '
+        f'{coverage.get("sheets_skipped", 0)} sheets skipped, '
+        f'{coverage.get("blocks_skipped", 0)} blocks truncated'
+    )
+    limitations = coverage.get("limitations") or []
+    rows = "".join(
+        f'<li>{_esc(item.get("scope"))} · {_esc(item.get("reason"))}'
+        + (f' · <code>{_esc(item.get("file"))}</code>' if item.get("file") else "")
+        + (f' · {_esc(item.get("sheet"))}' if item.get("sheet") else "")
+        + (f' · ×{_esc(item.get("count"))}' if item.get("count") else "")
+        + "</li>"
+        for item in limitations[:_MAX_RENDERED_LIMITATIONS]
+    )
+    hidden = max(0, len(limitations) - _MAX_RENDERED_LIMITATIONS)
+    omitted = int(coverage.get("limitations_omitted") or 0)
+    more = hidden + omitted
+    more_html = f'<li class="muted">… and {more:,} more</li>' if more else ""
+    detail = f'<ul class="coverage-list">{rows}{more_html}</ul>' if rows else ""
+    return (
+        f'<div class="{tone} coverage-status">'
+        f'<strong>Scan coverage: {_esc(label)}</strong> — {_esc(counts)}.'
+        f'{detail}</div>'
+    )
+
+
 def write_html_report(scan: dict, out_path: str) -> None:
     input_dir = scan.get("input_dir", "")
     input_label = os.path.basename(os.path.normpath(input_dir)) or input_dir or "audit"
@@ -799,6 +851,8 @@ def write_html_report(scan: dict, out_path: str) -> None:
             '<code>PAPERCONAN_MAX_TOTAL_FINDINGS</code> to see more.</div>'
         )
 
+    status_html = _render_scan_status(scan)
+
     ver = scan.get("tool_version", "")
     ts = scan.get("scanned_at", "")
     prov = " · ".join(p for p in [
@@ -826,6 +880,7 @@ def write_html_report(scan: dict, out_path: str) -> None:
   <div class="stats">{stats}</div>
   <div class="warn">Statistical anomalies — signal, not verdict. Take findings to PubPeer / journal editor / research integrity office, not social media.</div>
   {omitted_html}
+  {status_html}
 </header>
 <div class="layout">
   {sidebar}

--- a/tests/test_scan_coverage.py
+++ b/tests/test_scan_coverage.py
@@ -1,0 +1,93 @@
+"""Unit coverage for the ``ScanCoverage`` accounting model."""
+
+import pytest
+
+from paperconan._coverage import ScanCoverage
+
+
+def test_all_files_succeed_is_complete():
+    cov = ScanCoverage(files_discovered=2)
+    cov.mark_file_succeeded()
+    cov.mark_sheet_succeeded()
+    cov.mark_block_analyzed(3)
+    cov.mark_file_succeeded()
+    cov.mark_sheet_succeeded()
+    assert cov.status == "complete"
+    d = cov.to_dict()
+    assert d["files_succeeded"] == 2
+    assert d["blocks_analyzed"] == 3
+    assert d["truncated"] is False
+    assert d["limitations"] == []
+
+
+def test_any_skip_is_partial():
+    cov = ScanCoverage(files_discovered=1)
+    cov.mark_file_succeeded()
+    cov.mark_sheet_succeeded()
+    cov.mark_sheet_skipped("book.xlsx", "huge", "sheet_too_large")
+    assert cov.status == "partial"
+    d = cov.to_dict()
+    assert d["sheets_skipped"] == 1
+    assert d["limitations"] == [
+        {"scope": "sheet", "reason": "sheet_too_large",
+         "file": "book.xlsx", "sheet": "huge"}
+    ]
+
+
+def test_no_file_succeeds_is_failed():
+    cov = ScanCoverage(files_discovered=1)
+    cov.mark_file_failed("bad.xlsx", "unreadable", detail="boom")
+    assert cov.status == "failed"
+    assert cov.to_dict()["files_failed"] == 1
+
+
+def test_empty_input_is_complete_not_failed():
+    # No discovered files at all is a caller-level condition, not a failed scan.
+    assert ScanCoverage(files_discovered=0).status == "complete"
+
+
+def test_block_truncation_sets_truncated_flag():
+    cov = ScanCoverage(files_discovered=1)
+    cov.mark_file_succeeded()
+    cov.mark_sheet_succeeded()
+    cov.mark_block_analyzed(10)
+    cov.mark_blocks_skipped(
+        5, scope="sheet", reason="report_block_limit",
+        file="book.xlsx", sheet="s1",
+    )
+    d = cov.to_dict()
+    assert d["blocks_skipped"] == 5
+    assert d["truncated"] is True
+
+
+def test_duplicate_limitations_are_deduped():
+    cov = ScanCoverage(files_discovered=1)
+    cov.mark_file_succeeded()
+    cov.mark_sheet_succeeded()
+    for _ in range(4):
+        cov.mark_sheet_skipped("b.xlsx", "s", "sheet_too_large")
+    assert len(cov.to_dict()["limitations"]) == 1
+    # but the counter still reflects every skip event
+    assert cov.sheets_skipped == 4
+
+
+def test_limitations_are_capped(monkeypatch):
+    monkeypatch.setenv("PAPERCONAN_MAX_LIMITATIONS", "3")
+    cov = ScanCoverage(files_discovered=1)
+    cov.mark_file_succeeded()
+    cov.mark_sheet_succeeded()
+    for i in range(10):
+        cov.mark_sheet_skipped("b.xlsx", f"sheet{i}", "sheet_too_large")
+    d = cov.to_dict()
+    assert len(d["limitations"]) == 3
+    assert d["limitations_omitted"] == 7
+    assert cov.sheets_skipped == 10
+
+
+def test_bad_cap_env_falls_back(monkeypatch):
+    monkeypatch.setenv("PAPERCONAN_MAX_LIMITATIONS", "not-an-int")
+    cov = ScanCoverage(files_discovered=1)
+    cov.mark_file_succeeded()
+    cov.mark_sheet_succeeded()
+    cov.mark_sheet_skipped("b.xlsx", "s", "sheet_too_large")
+    assert len(cov.to_dict()["limitations"]) == 1

--- a/tests/test_scan_status.py
+++ b/tests/test_scan_status.py
@@ -1,0 +1,92 @@
+"""End-to-end coverage/status accounting through ``scan_dir`` and reports.
+
+Drives real inputs (no loader stubs) so the wiring between the orchestration
+control flow and ``ScanCoverage`` is exercised as shipped.
+"""
+
+import json
+
+from paperconan._audit import scan_dir
+from paperconan._html import write_html_report
+
+
+_GOOD = "a,b,c\n1.11,2.22,3.33\n4.44,5.55,6.66\n7.77,8.88,9.99\n10.1,11.2,12.3\n"
+
+
+def _scan(tmp_path, **kwargs):
+    out = tmp_path / "audit"
+    res = scan_dir(str(tmp_path), str(out), write_html=False, write_json=True, **kwargs)
+    on_disk = json.loads((out / "scan.json").read_text())
+    return res, on_disk
+
+
+def test_clean_scan_is_complete(tmp_path):
+    (tmp_path / "data.csv").write_text(_GOOD)
+    res, disk = _scan(tmp_path)
+    assert res["schema_version"] == 2
+    assert res["scan_status"] == "complete"
+    cov = res["coverage"]
+    assert cov["files_discovered"] == 1
+    assert cov["files_succeeded"] == 1
+    assert cov["files_failed"] == 0
+    assert cov["sheets_skipped"] == 0
+    assert cov["truncated"] is False
+    assert cov["limitations"] == []
+    # persisted identically
+    assert disk["scan_status"] == "complete"
+    assert disk["coverage"] == cov
+
+
+def test_unreadable_file_is_partial_with_limitation(tmp_path):
+    (tmp_path / "data.csv").write_text(_GOOD)
+    # A .xlsx that is not a valid workbook fails the loader, not discovery.
+    (tmp_path / "broken.xlsx").write_text("this is not a real xlsx")
+    res, _ = _scan(tmp_path)
+    assert res["scan_status"] == "partial"
+    cov = res["coverage"]
+    assert cov["files_discovered"] == 2
+    assert cov["files_succeeded"] == 1
+    assert cov["files_failed"] == 1
+    reasons = {(l["scope"], l["reason"]) for l in cov["limitations"]}
+    assert ("file", "unreadable") in reasons
+    # no raw exception text leaks into the (deterministic) limitation payload
+    assert all("error" not in l and "detail" not in l for l in cov["limitations"])
+
+
+def test_oversized_file_is_recorded(tmp_path, monkeypatch):
+    import paperconan._audit as audit
+    # Every non-empty file is now "too large" (restored at teardown, no reload).
+    monkeypatch.setattr(audit, "_MAX_FILE_BYTES", 0)
+    (tmp_path / "data.csv").write_text(_GOOD)
+    out = tmp_path / "audit"
+    res = audit.scan_dir(str(tmp_path), str(out), write_html=False, write_json=True)
+    assert res["scan_status"] == "failed"
+    cov = res["coverage"]
+    assert cov["files_failed"] == 1
+    assert any(l["reason"] == "file_too_large" for l in cov["limitations"])
+
+
+def test_status_persisted_and_deterministic(tmp_path):
+    (tmp_path / "data.csv").write_text(_GOOD)
+    _, disk1 = _scan(tmp_path)
+    _, disk2 = _scan(tmp_path)
+    assert json.dumps(disk1["coverage"]) == json.dumps(disk2["coverage"])
+
+
+def test_html_report_shows_partial_banner(tmp_path):
+    (tmp_path / "data.csv").write_text(_GOOD)
+    (tmp_path / "broken.xlsx").write_text("nope")
+    res, _ = _scan(tmp_path)
+    html_path = tmp_path / "report.html"
+    write_html_report(res, str(html_path))
+    html = html_path.read_text()
+    assert "Scan coverage" in html
+    assert "unreadable" in html
+
+
+def test_html_report_hides_banner_when_complete(tmp_path):
+    (tmp_path / "data.csv").write_text(_GOOD)
+    res, _ = _scan(tmp_path)
+    html_path = tmp_path / "report.html"
+    write_html_report(res, str(html_path))
+    assert "Scan coverage" not in html_path.read_text()


### PR DESCRIPTION
## Summary

Second increment extracted from `codex/project-hardening` (#32), rebuilt cleanly on current `main`. Makes scan *coverage* explicit so a partial scan is never read as a clean one.

A scan can legitimately leave work undone (oversized file skipped to bound memory, unreadable workbook, oversized sheet, output/finding budget truncating block analysis). Previously that lived only in scattered `scan_errors`/`scan_stats` entries with no top-level roll-up. This adds a self-contained `ScanCoverage` model and three **additive** scan.json keys:

- `schema_version` = `2`
- `scan_status`: `complete` | `partial` | `failed`
- `coverage`: file/sheet/block success+skip counts, a `truncated` flag, and a bounded de-duplicated `limitations` list.

The HTML report gains a bounded coverage banner, shown **only** when a scan is not fully complete.

## Scope discipline (why this is small)

- New logic lives in its own module `_coverage.py` (128 lines). `_audit.py` grows by **22 lines of wiring only** — no single-file bloat.
- Coverage is derived **only** from skip/failure signals the scanner already produces. `load_table` is untouched; **no new read path**. So findings and statistical-signal content are byte-for-byte unchanged.
- **Deferred to a follow-up PR (PR-C):** the origin branch's OOXML formula-cache inspection (`inspect_ooxml_formula_cache`) is a new always-on read of every xlsx and a distinct signal. It plugs into this coverage model later, but is isolated so it can be reviewed and perf-validated on its own.
- Also noted for later: a pure `_audit.py` module-split refactor (it is ~4.1k lines) — kept out of this feature PR on purpose.

## Size guard (GH#15-class)

`limitations` are de-duplicated by `(scope, reason, file, sheet)` and capped via `PAPERCONAN_MAX_LIMITATIONS` (default 500), with a `limitations_omitted` counter and a bounded render (max 50 rows + "… and N more"). No raw exception text enters the payload, keeping output deterministic.

## Validation

- Full suite green: `1222 passed, 1 skipped` (live-network) via `python -m pytest`. Golden fixtures unchanged.
- Empirical on `examples/demo_paper`: two default runs **byte-identical**; vs `main` only `coverage`/`scan_status`/`schema_version` are **added**, every other key unchanged (findings identical). Demo scans as `complete`.

## Backward-compat

Purely additive keys; existing scan.json consumers are unaffected. Downstream consumers that want to distinguish partial/failed scans can gate on `schema_version >= 2` and read `scan_status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)