### PR TITLE
fix: label fallback evidence when a finding_ref misses

### DIFF
--- a/src/paperconan/_adjudicated_html.py
+++ b/src/paperconan/_adjudicated_html.py
@@ -723,6 +723,8 @@ table.ev th { background:#f8fafc; color:var(--muted); text-align:left; }
 .hi-col { background:#fff6d6; }
 .hi-row { background:#fffaf0; }
 .no-evidence { color:var(--muted); padding:0 12px; }
+.fallback-evidence { margin:0 12px 8px; padding:8px 12px; background:#fff6d6;
+  border-left:3px solid #d9a441; border-radius:4px; color:#5c4708; font-size:13px; }
 .scope-note { margin:0 0 12px; padding:8px 12px; background:var(--panel); border-radius:6px;
   color:#344054; font-size:13px; }
 footer { margin-top:20px; color:var(--muted); font-size:12px; }
@@ -920,10 +922,18 @@ def _render_finding_block(
         if matched is not None:
             evidence += _render_key_finding(matched, idx)
     else:
+        fallback_notice = ""
         if legacy_fallback and matched is None and scan_findings:
             matched = scan_findings[0]
+            # The narrative above describes the cited signal; this card is the
+            # strongest scan signal instead. Say so, or the two read as one.
+            if ref:
+                fallback_notice = (
+                    '<p class="fallback-evidence">finding_ref 未命中扫描结果；'
+                    "以下展示本次扫描中最强的统计信号，供定位参考。</p>"
+                )
         evidence = (
-            _render_key_finding(matched, idx)
+            fallback_notice + _render_key_finding(matched, idx)
             if matched is not None
             else '<p class="no-evidence">无匹配证据（finding_ref 未命中扫描结果）</p>'
         )

--- a/tests/test_adjudicated_report.py
+++ b/tests/test_adjudicated_report.py
@@ -679,6 +679,37 @@ def test_finding_refs_with_no_match_falls_back_to_strongest_finding():
     assert "constant_offset" in html
 
 
+def test_unmatched_ref_fallback_evidence_is_labeled_as_a_fallback():
+    """An unmatched ref still falls back, but the card must say so.
+
+    The fallback keeps a legacy single-finding report useful, yet the narrative
+    in report_md describes the cited signal while the rendered evidence is the
+    strongest scan signal. Without a label a reader cannot tell the two apart.
+    """
+    scan = _scan_two_findings()
+    verdict = {"verdict": "KEEP", "report_md": "## t", "finding_refs": [{"sheet": "Nonexistent"}]}
+
+    html = render_adjudicated_report(scan, verdict)
+
+    assert 'class="fallback-evidence"' in html
+    # the intended fallback behaviour is unchanged
+    assert html.count('class="finding-card"') == 1
+    assert "constant_offset" in html
+
+
+def test_matched_ref_evidence_is_not_labeled_as_a_fallback():
+    scan = _scan_two_findings()
+    verdict = {
+        "verdict": "KEEP",
+        "report_md": "## t",
+        "finding_refs": [{"sheet": "Alpha", "kind": "constant_offset"}],
+    }
+
+    html = render_adjudicated_report(scan, verdict)
+
+    assert 'class="fallback-evidence"' not in html
+
+
 def test_legacy_null_finding_refs_preserves_strongest_finding_fallback():
     html = render_adjudicated_report(
         _scan_two_findings(),


### PR DESCRIPTION
## Summary

When a legacy-shape verdict's `finding_ref` matches nothing, the adjudicated report falls back to the strongest scan signal. This PR keeps that behaviour and adds a neutral notice above the fallback card so a reviewer can tell the evidence apart from the cited finding.

## Why

The fallback is intentional and covered by `test_finding_refs_with_no_match_falls_back_to_strongest_finding` — it keeps a single-finding legacy report useful. But it rendered silently: `report_md` describes the cited signal while the evidence card shows a different one, and nothing on the page distinguished them. In a report used to decide whether a numeric signal needs author clarification, that gap invites misattribution.

This surfaced while reviewing #40. `block_dups` findings are currently invisible to `_all_findings()`, so a verdict citing `block_value_duplication` always takes this fallback path — the narrative discusses value duplication while the card shows an unrelated relation. Making the report chain consistent (P0b) removes that particular mismatch; labelling the fallback fixes the general case.

## Impact

- Unmatched ref + legacy fallback: a neutral notice now precedes the evidence card.
- Matched refs, the no-ref fallback, modern multi-finding verdicts, and image evidence: unchanged.
- Detector math, severity, profiles, `scan.json`, Markdown, and packet behaviour: unchanged.

## Validation

- Full suite: `1298 passed, 1 skipped` (1296 baseline + 2 new tests)
- Both new tests observed RED before the production change
- Added notice checked against `contains_blocked_language` → clean
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)