### PR TITLE
fix: read per-block finding groups from one canonical registry

### DIFF
--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -52,10 +52,9 @@ from .schema import PaperconanInputError
 # SINGLE SOURCE OF TRUTH: the markdown report, the packet distiller, and the
 # paperconan-watch severity counters / triage gate all iterate this set, so a
 # HIGH finding in ANY group (notably row_pairs) is counted and can reach review.
-BLOCK_FINDING_GROUPS = (
-    "relations", "equal_pairs", "progressions", "row_pairs", "row_relations",
-    "within_col", "identical_after_rounding", "grim", "block_dups",
-)
+# Canonical registry lives in a leaf module so _html/packet can read it without
+# pulling this one in; re-exported here for the existing public import path.
+from ._finding_groups import BLOCK_FINDING_GROUPS  # noqa: E402,F401
 
 
 def _version():

--- a/src/paperconan/_finding_groups.py
+++ b/src/paperconan/_finding_groups.py
@@ -1,0 +1,18 @@
+"""Canonical registry of the per-block finding groups carried by a scan.
+
+Single source of truth for the keys under which `relations_blocks[*]` stores its
+findings. This lives in a leaf module with no paperconan imports so every
+consumer — the scanner, the default HTML renderer, the adjudicated renderer and
+the review packet — can read the same set without an import cycle.
+
+Consumers must recognise every registered key. A consumer may then apply its own
+explicit eligibility filter (a high-only packet, a profile projection), but it
+must not silently drop a whole group: that is how `block_dups` stayed out of the
+default HTML report while being present in scan.json and the Markdown summary.
+"""
+from __future__ import annotations
+
+BLOCK_FINDING_GROUPS: tuple[str, ...] = (
+    "relations", "equal_pairs", "progressions", "row_pairs", "row_relations",
+    "within_col", "identical_after_rounding", "grim", "block_dups",
+)

--- a/src/paperconan/_html.py
+++ b/src/paperconan/_html.py
@@ -10,6 +10,7 @@ import html
 import os
 from typing import Any, Iterable
 
+from ._finding_groups import BLOCK_FINDING_GROUPS
 from .image._budget import report_image_evidence_bytes
 from .image._evidence import (
     _BoundedBytesIO,
@@ -49,15 +50,15 @@ def _esc(s: Any) -> str:
 
 # ---------- finding extraction ----------
 
-_PER_BLOCK_GROUPS = ("relations", "progressions", "equal_pairs", "row_pairs",
-                     "row_relations", "within_col", "identical_after_rounding", "grim")
-_DEFAULT_HTML_PER_BLOCK_GROUPS = _PER_BLOCK_GROUPS + ("block_dups",)
+def canonical_block_groups() -> tuple[str, ...]:
+    """The registered per-block group keys every consumer must recognise."""
+    return BLOCK_FINDING_GROUPS
 
 
 def _iter_block_findings(
     scan: dict,
     *,
-    per_block_groups: tuple[str, ...] = _PER_BLOCK_GROUPS,
+    per_block_groups: tuple[str, ...] = BLOCK_FINDING_GROUPS,
 ) -> Iterable[tuple[dict, dict]]:
     for blk in scan.get("relations_blocks", []) or []:
         for group in per_block_groups:
@@ -68,7 +69,7 @@ def _iter_block_findings(
 def _all_findings(
     scan: dict,
     *,
-    per_block_groups: tuple[str, ...] = _PER_BLOCK_GROUPS,
+    per_block_groups: tuple[str, ...] = BLOCK_FINDING_GROUPS,
 ) -> list[dict]:
     out = []
     for blk, f in _iter_block_findings(scan, per_block_groups=per_block_groups):
@@ -790,10 +791,7 @@ def write_html_report(scan: dict, out_path: str) -> None:
     input_label = os.path.basename(os.path.normpath(input_dir)) or input_dir or "audit"
     artifact_dir = os.path.dirname(os.path.abspath(out_path))
     image_budget = EvidenceBudget(report_image_evidence_bytes())
-    findings = _all_findings(
-        scan,
-        per_block_groups=_DEFAULT_HTML_PER_BLOCK_GROUPS,
-    )
+    findings = _all_findings(scan)
     n_sheets = len({(it["file"], it["sheet"]) for it in findings if it["scope"] == "block"})
     sev = _severity_counts(findings)
 

--- a/src/paperconan/packet.py
+++ b/src/paperconan/packet.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ._audit import BLOCK_FINDING_GROUPS
+from ._finding_groups import BLOCK_FINDING_GROUPS
 from ._prefilter import evidence_confidence
 from ._profiles import _is_axis_finding
 from .detectors import prefilter_relation_finding

--- a/tests/test_adjudicated_report.py
+++ b/tests/test_adjudicated_report.py
@@ -828,7 +828,13 @@ def test_findings_array_renders_per_finding_blocks_with_own_evidence():
     assert "findings-index" in html
 
 
-def test_modern_block_duplication_ref_remains_unmatched_in_adjudicated_report():
+def test_adjudicated_report_resolves_a_block_duplication_finding_ref():
+    """A verdict may cite any canonical per-block group, block_dups included.
+
+    P0a deliberately scoped its fix to default HTML and left this reference
+    unmatched. P0b makes every consumer read the same canonical group set, so
+    the adjudicated report — the deliverable — can now render the cited card.
+    """
     scan = {
         "relations_blocks": [{
             "file": "synthetic.xlsx",
@@ -845,7 +851,7 @@ def test_modern_block_duplication_ref_remains_unmatched_in_adjudicated_report():
     verdict = {
         "verdict": "NEEDS_HUMAN",
         "findings": [{
-            "title": "Unmatched synthetic signal",
+            "title": "Cited synthetic signal",
             "finding_ref": {"kind": "block_value_duplication"},
             "report_md": "This signal requires contextual review.",
         }],
@@ -853,9 +859,9 @@ def test_modern_block_duplication_ref_remains_unmatched_in_adjudicated_report():
 
     html = render_adjudicated_report(scan, verdict)
 
-    assert "block_value_duplication" not in html
-    assert "synthetic block duplication signal" not in html
-    assert "无匹配证据（finding_ref 未命中扫描结果）" in html
+    assert "block_value_duplication" in html
+    assert "synthetic block duplication signal" in html
+    assert "无匹配证据（finding_ref 未命中扫描结果）" not in html
 
 
 @pytest.mark.parametrize("selector", ["sheet", "file", "rows", "kind"])

--- a/tests/test_finding_group_report_chain.py
+++ b/tests/test_finding_group_report_chain.py
@@ -1,0 +1,79 @@
+"""Report-chain consistency for the canonical per-block finding groups.
+
+Every consumer of a scan — default HTML, the adjudicated report, and the review
+packet — must recognise the same registered group keys. Each may then apply its
+own explicit eligibility filter, but none may silently drop a whole group.
+
+This is the regression that `block_dups` needed: it was persisted in scan output
+and summarised in Markdown, yet the default HTML renderer kept its own private
+tuple of groups and so never selected it.
+"""
+from __future__ import annotations
+
+import pytest
+
+from paperconan import BLOCK_FINDING_GROUPS
+from paperconan._adjudicated_html import render_adjudicated_report
+from paperconan._html import write_html_report
+
+
+def _rule_for(group: str) -> str:
+    return f"synthetic {group} signal"
+
+
+def _scan_with_group(group: str) -> dict:
+    """A minimal scan carrying exactly one finding, stored under `group`."""
+    return {
+        "tool_version": "0.test",
+        "profile": "review",
+        "input_dir": "synthetic",
+        "n_files": 1,
+        "relations_blocks": [{
+            "file": "synthetic.xlsx",
+            "sheet": "Panel",
+            "block": {"rows": "2-6", "cols": "1-3", "header": ["a", "b", "c"]},
+            group: [{
+                "kind": f"synthetic_{group}",
+                "severity": "high",
+                "rule": _rule_for(group),
+                "profile_action": "kept",
+            }],
+        }],
+        "cross_sheet_findings": [],
+        "digit_distribution": [],
+        "decimal_endings": [],
+        "decimal_tail_clusters": [],
+    }
+
+
+@pytest.mark.parametrize("group", BLOCK_FINDING_GROUPS)
+def test_default_html_surfaces_every_canonical_block_group(group, tmp_path):
+    report = tmp_path / "report.html"
+
+    write_html_report(_scan_with_group(group), str(report))
+
+    assert _rule_for(group) in report.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("group", BLOCK_FINDING_GROUPS)
+def test_adjudicated_report_resolves_a_ref_into_every_canonical_block_group(group):
+    verdict = {
+        "verdict": "NEEDS_HUMAN",
+        "findings": [{
+            "title": "Cited synthetic signal",
+            "finding_ref": {"kind": f"synthetic_{group}"},
+            "report_md": "This signal requires contextual review.",
+        }],
+    }
+
+    html = render_adjudicated_report(_scan_with_group(group), verdict)
+
+    assert _rule_for(group) in html
+    assert "无匹配证据（finding_ref 未命中扫描结果）" not in html
+
+
+def test_html_does_not_keep_a_private_copy_of_the_canonical_group_set():
+    """A newly registered group must reach HTML without editing the renderer."""
+    from paperconan import _html
+
+    assert set(_html.canonical_block_groups()) == set(BLOCK_FINDING_GROUPS)


### PR DESCRIPTION
## Summary

Move the canonical per-block finding-group keys into a leaf module and have every consumer — scanner, default HTML, adjudicated report, review packet — read that one set. Removes the two private tuples `_html.py` was carrying.

## Why

#40 fixed `block_dups` visibility in the default HTML by giving that renderer its own group tuple, and deliberately left the shared `_all_findings()` default on a set that omits `block_dups`. The adjudicated report reads the same helper, so a verdict citing `block_value_duplication` resolved to nothing:

- modern multi-finding shape → rendered `无匹配证据（finding_ref 未命中扫描结果）`
- legacy shape → fell back to an unrelated finding's evidence card

So the newest detector's signals could be seen in the internal triage report but never cited as evidence in the adjudicated report, which is the actual deliverable. This is the P0b half that #40's plan called out as separate work.

Per spec §11.1: all consumers recognise the same registered group keys, then each applies its own explicit eligibility filter. A consumer may filter; it may not silently drop a whole group.

## Changes

- Add `_finding_groups.py` — a leaf module with no paperconan imports, so `_html.py` can read the registry without a top-level dependency on the 4.5k-line `_audit.py` (which imports `_html` back, lazily).
- `_audit.py`, `_html.py`, `packet.py` all derive from it. `paperconan.BLOCK_FINDING_GROUPS` and `paperconan._audit.BLOCK_FINDING_GROUPS` still resolve to the same object — no public-path break.
- Drop `_PER_BLOCK_GROUPS` / `_DEFAULT_HTML_PER_BLOCK_GROUPS`; `_all_findings()` keeps its `per_block_groups` selector for consumers that need an explicit narrower view.
- Flip #40's negative test to a positive one, with the reasoning recorded in its docstring.
- New `tests/test_finding_group_report_chain.py`: parametrised over the registry so a newly registered group cannot vanish from a consumer unnoticed.

## Impact

Adjudicated reports can now resolve a ref into any registered group, `block_dups` included. Detector math, severity, profiles, `scan.json` serialization, Markdown, and packet distillation are unchanged.

## Validation

- Full suite: `1319 passed, 1 skipped` (1300 baseline + 19 new)
- All three new tests observed RED first
- `_finding_groups.py` verified loadable standalone; `_html.py` confirmed to have no top-level `_audit` import
- CLI smoke run on `examples/demo_paper` writes scan.json + report.html
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)