### PR TITLE
feat: freeze raw_severity before any profile rewrite

### DIFF
--- a/src/paperconan/_profiles.py
+++ b/src/paperconan/_profiles.py
@@ -66,6 +66,9 @@ def normalize_profile(profile: str | None) -> Profile:
 
 def initialize_profile_fields(findings: Iterable[dict]) -> None:
     for f in findings:
+        # Freeze what the detector produced before any profile rewrites `severity`
+        # in place. setdefault keeps it authoritative across repeated passes.
+        f.setdefault("raw_severity", f.get("severity"))
         f.setdefault("profile_action", "kept")
         f.setdefault("false_positive_context", [])
 

--- a/tests/golden/tiny_paper.json
+++ b/tests/golden/tiny_paper.json
@@ -13,6 +13,7 @@
         "kind": "arithmetic_progression",
         "n": 10,
         "profile_action": "kept",
+        "raw_severity": "high",
         "rule": "col[3] = arithmetic progression, step=0.1",
         "severity": "high",
         "step": 0.09999999999999432
@@ -39,6 +40,7 @@
         "kind": "arithmetic_progression",
         "n": 10,
         "profile_action": "kept",
+        "raw_severity": "high",
         "rule": "col[3] = arithmetic progression, step=2.5",
         "severity": "high",
         "step": 2.5
@@ -65,6 +67,7 @@
         "likely_benign": "values ending in .0/.5 are common for derived or instrument-rounded quantities (cell counts, scores, calibrated readouts)",
         "n": 10,
         "profile_action": "kept",
+        "raw_severity": "medium",
         "rule": "col[3]: 10/10 values end in 0 or 5",
         "severity": "medium"
       },
@@ -90,6 +93,7 @@
         "kind": "identical_column",
         "n": 10,
         "profile_action": "kept",
+        "raw_severity": "high",
         "rule": "col[2] == col[0]",
         "severity": "high"
       },
@@ -115,6 +119,7 @@
         "kind": "identical_column",
         "n": 10,
         "profile_action": "kept",
+        "raw_severity": "high",
         "rule": "col[2] == col[0]",
         "severity": "high"
       },
@@ -158,6 +163,7 @@
         "n_failed": 1,
         "n_rows_checked": 1,
         "profile_action": "kept",
+        "raw_severity": "high",
         "rule": "1/1 rows report a mean impossible for integer data at the stated n (GRIM): col 'cell count mean'",
         "sd_col": "sd",
         "severity": "high"
@@ -246,6 +252,7 @@
         "text": "mass(kg) vol(mL) copy_of_mass mass(kg) vol(mL) copy_of_mass ap_col"
       },
       "profile_action": "kept",
+      "raw_severity": "high",
       "rule": "Sheet1 and Sheet2 share 29/29 (100%) decimal values at SAME (row,col) across 2 sheets",
       "same_figure": false,
       "same_file": true,

--- a/tests/test_raw_severity_freeze.py
+++ b/tests/test_raw_severity_freeze.py
@@ -1,0 +1,74 @@
+"""`raw_severity` is frozen before any profile rewrite touches `severity`.
+
+The review/triage profiles demote a finding by overwriting `severity` in place,
+which loses what the detector actually produced. The Agent workflow has to seed
+from the pre-profile raw stream, so the detector's own severity must survive
+the projection. Freezing it here — the single entry point every profile path
+goes through — keeps one value authoritative instead of asking each consumer to
+guess whether it is looking at a raw or a projected severity.
+"""
+from __future__ import annotations
+
+import pytest
+
+from paperconan._profiles import apply_profile_to_findings
+
+
+def _boundary_dup_finding() -> dict:
+    """A finding the review profile is known to demote (a 0/1/100 boundary dup)."""
+    return {
+        "kind": "within_col_value_duplication",
+        "severity": "high",
+        "dup_value": 1.0,
+        "col": "pvalue",
+        "n": 12,
+    }
+
+
+@pytest.mark.parametrize("profile", ["review", "triage"])
+def test_demoting_profile_keeps_the_detector_severity_in_raw_severity(profile):
+    findings = [_boundary_dup_finding()]
+
+    apply_profile_to_findings(findings, profile)
+
+    assert findings[0]["severity"] == "low", "expected this fixture to be demoted"
+    assert findings[0]["raw_severity"] == "high"
+
+
+def test_forensic_profile_also_records_raw_severity():
+    """forensic returns early, before any demotion — it must still be frozen."""
+    findings = [_boundary_dup_finding()]
+
+    apply_profile_to_findings(findings, "forensic")
+
+    assert findings[0]["severity"] == "high"
+    assert findings[0]["raw_severity"] == "high"
+
+
+def test_reapplying_a_profile_does_not_overwrite_the_frozen_value():
+    """Idempotent: a second pass must not capture the already-demoted severity."""
+    findings = [_boundary_dup_finding()]
+
+    apply_profile_to_findings(findings, "review")
+    apply_profile_to_findings(findings, "review")
+
+    assert findings[0]["severity"] == "low"
+    assert findings[0]["raw_severity"] == "high"
+
+
+def test_hidden_findings_still_carry_raw_severity():
+    findings = [_boundary_dup_finding()]
+
+    apply_profile_to_findings(findings, "triage")
+
+    assert findings[0]["profile_action"] == "hidden"
+    assert findings[0]["raw_severity"] == "high"
+
+
+def test_undemoted_findings_report_the_same_raw_and_effective_severity():
+    findings = [{"kind": "identical_column", "severity": "high", "n": 20}]
+
+    apply_profile_to_findings(findings, "review")
+
+    assert findings[0]["severity"] == "high"
+    assert findings[0]["raw_severity"] == "high"


### PR DESCRIPTION
First PR of Phase 1 ([plan](docs/superpowers/plans/2026-07-26-phase1-opt-in-workflow-skeleton.md)). Groundwork only — no workflow code yet.

## Why

`_profiles._demote_or_hide()` sets `f["severity"] = "low"` in place, so the detector's own severity is gone by the time anything reads the scan. Spec §14.3 requires workflow seeds to come from the pre-profile raw stream ("不得把已被 profile 改写的 severity 当作 raw"), and §8.1 requires `raw_severity` to be immutable once produced. Every later Phase 1 PR builds on this.

## Change

One line in `initialize_profile_fields()`, which is the single entry point every profile path goes through — called before the early `forensic` return and before any demotion:

```python
f.setdefault("raw_severity", f.get("severity"))
```

`setdefault` makes it idempotent: a second `apply_profile_to_findings` pass cannot capture an already-demoted `low`.

## Impact

No behaviour change. Verified structurally rather than by eyeballing: a walk over the golden snapshot reports `added_keys=['raw_severity']` and `other_diffs=[]` — no value changed, nothing removed, no list length moved. The golden diff is 7 added lines, 0 deletions.

## Validation

- Full suite: `1325 passed, 1 skipped` (1319 baseline + 6 new)
- All 6 new tests observed RED (`KeyError: 'raw_severity'`) first
- Covers: review/triage demotion, the forensic early return, idempotency on re-apply, `profile_action=hidden`, and the undemoted case
- `git diff --check`

## Follow-up noted, not included

`tests/test_profiles.py::_all_block_findings` hardcodes its own group list and is missing `row_pairs`, `row_relations` and `block_dups` — the same drift P0b fixed on the production side. Left out to keep this PR single-purpose; it does not affect these tests, which unit-test `apply_profile_to_findings` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)