### PR TITLE
refactor: dispatch CLI commands through one subparser tree

### DIFF
--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -4504,43 +4504,13 @@ def write_markdown_report(out, path):
         fh.write("\n".join(lines))
 
 
-def main():
-    if len(sys.argv) > 1 and sys.argv[1] == "fetch":
-        from .fetch._cli import fetch_main
-        sys.exit(fetch_main(sys.argv[2:]))
-    if len(sys.argv) > 1 and sys.argv[1] == "report":
-        import json
-        from ._adjudicated_html import write_adjudicated_report
+# Every command lives in one subparser tree. Dispatch has a single rule: a first
+# argument that is not one of these names is the scan target, which is what keeps
+# `paperconan <dir>` working without giving any command its own argv branch.
+SUBCOMMANDS = ("scan", "fetch", "report")
 
-        rp = argparse.ArgumentParser(
-            prog="paperconan report",
-            description="Render an adjudicated HTML report from scan.json and verdict.json",
-        )
-        rp.add_argument("scan_json", help="Path to paperconan scan.json")
-        rp.add_argument("--verdict", required=True, help="Path to verdict JSON")
-        rp.add_argument("--out", required=True, help="Output HTML path")
-        rargs = rp.parse_args(sys.argv[2:])
-        try:
-            with open(rargs.scan_json, encoding="utf-8") as fh:
-                scan = json.load(fh)
-            with open(rargs.verdict, encoding="utf-8") as fh:
-                verdict = json.load(fh)
-            write_adjudicated_report(
-                scan,
-                verdict,
-                rargs.out,
-                artifact_dir=os.path.dirname(os.path.abspath(rargs.scan_json)),
-            )
-        except ValueError as exc:
-            sys.exit(str(exc))
-        print(f"wrote {rargs.out}")
-        return
-    ap = argparse.ArgumentParser(
-        description=(
-            "Scan a paper's source data (xlsx/csv/tsv, or tables inside "
-            "pdf/docx) for statistical signals and data inconsistencies"
-        )
-    )
+
+def _add_scan_arguments(ap: argparse.ArgumentParser) -> None:
     ap.add_argument("in_dir", help="Directory with the paper's source data (*.xlsx/*.csv/*.tsv, or *.pdf/*.docx supplements)")
     ap.add_argument("--out", default=None, help="Output directory (default: <in_dir>/audit)")
     ap.add_argument("--md", action="store_true",
@@ -4570,8 +4540,9 @@ def main():
         help="record wall-clock scan timestamp and elapsed times "
              "(omitted by default so scan.json stays byte-reproducible)",
     )
-    ap.add_argument("--version", action="version", version=f"paperconan {_version()}")
-    args = ap.parse_args()
+
+
+def _run_scan(ap: argparse.ArgumentParser, args: argparse.Namespace) -> None:
     if args.image_diagnostics and not args.images:
         ap.error("--image-diagnostics requires --images")
     out_dir = args.out or os.path.join(args.in_dir, "audit")
@@ -4599,6 +4570,85 @@ def main():
     print(f"  digit anomaly sheets: {len(res['digit_distribution'])}, decimal anomaly sheets: {len(res['decimal_endings'])}")
     if write_html:
         print(f"\n  → open {out_dir}/report.html in a browser to review findings")
+
+
+def _run_report(args: argparse.Namespace) -> None:
+    import json
+    from ._adjudicated_html import write_adjudicated_report
+
+    try:
+        with open(args.scan_json, encoding="utf-8") as fh:
+            scan = json.load(fh)
+        with open(args.verdict, encoding="utf-8") as fh:
+            verdict = json.load(fh)
+        write_adjudicated_report(
+            scan,
+            verdict,
+            args.out,
+            artifact_dir=os.path.dirname(os.path.abspath(args.scan_json)),
+        )
+    except ValueError as exc:
+        sys.exit(str(exc))
+    print(f"wrote {args.out}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(
+        prog="paperconan",
+        description=(
+            "Scan a paper's source data (xlsx/csv/tsv, or tables inside "
+            "pdf/docx) for statistical signals and data inconsistencies"
+        ),
+    )
+    ap.add_argument("--version", action="version", version=f"paperconan {_version()}")
+    sub = ap.add_subparsers(dest="cmd")
+
+    scan_p = sub.add_parser(
+        "scan",
+        help="scan a directory of source data (the default when no subcommand is given)",
+        description="Scan a paper's source data for statistical signals and data inconsistencies",
+    )
+    _add_scan_arguments(scan_p)
+
+    sub.add_parser(
+        "fetch",
+        help="download a paper's supplementary source data",
+        add_help=False,
+    )
+
+    report_p = sub.add_parser(
+        "report",
+        help="render an adjudicated HTML report from scan.json and verdict.json",
+        description="Render an adjudicated HTML report from scan.json and verdict.json",
+    )
+    report_p.add_argument("scan_json", help="Path to paperconan scan.json")
+    report_p.add_argument("--verdict", required=True, help="Path to verdict JSON")
+    report_p.add_argument("--out", required=True, help="Output HTML path")
+
+    return ap
+
+
+def main(argv: list[str] | None = None) -> None:
+    argv = list(sys.argv[1:] if argv is None else argv)
+
+    # `fetch` keeps its own parser: it owns a large flag surface of its own and
+    # is dispatched straight through, so it is registered above for --help only.
+    if argv and argv[0] == "fetch":
+        from .fetch._cli import fetch_main
+        sys.exit(fetch_main(argv[1:]))
+
+    # The single dispatch rule: anything that is not a subcommand is a scan
+    # target, so `paperconan <dir>` and `paperconan --no-html <dir>` still work.
+    if not argv or argv[0] not in SUBCOMMANDS:
+        if not (argv and argv[0] in ("-h", "--help", "--version")):
+            argv.insert(0, "scan")
+
+    ap = _build_parser()
+    args = ap.parse_args(argv)
+    if args.cmd == "report":
+        _run_report(args)
+        return
+    _run_scan(ap, args)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_dispatch.py
+++ b/tests/test_cli_dispatch.py
@@ -1,0 +1,128 @@
+"""CLI dispatch: one subcommand tree, with `paperconan <dir>` still the default.
+
+`main()` used to branch on `sys.argv[1]` once per subcommand, so every new
+command added another special case and `--help` never mentioned any of them.
+The commands now live in a single argparse subparser tree under one dispatch
+rule: an argument that is not a known subcommand is the scan target.
+
+That rule is what keeps `paperconan data/` working, so it is pinned here
+alongside the ambiguity it creates — a directory literally named after a
+subcommand.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from paperconan._audit import SUBCOMMANDS
+
+
+def _run(args, **kw):
+    return subprocess.run(
+        [sys.executable, "-m", "paperconan", *args],
+        text=True, capture_output=True, **kw
+    )
+
+
+def _tiny_csv(d):
+    d.mkdir(parents=True, exist_ok=True)
+    rows = ["a,b"] + [f"{i},{i}" for i in range(6)]
+    (d / "t.csv").write_text("\n".join(rows) + "\n", encoding="utf-8")
+    return d
+
+
+# ---------- the default path must not change ----------
+
+def test_bare_directory_still_scans(tmp_path):
+    data = _tiny_csv(tmp_path / "data")
+
+    res = _run([str(data), "--out", str(tmp_path / "out"), "--no-html"])
+
+    assert res.returncode == 0, res.stderr
+    assert (tmp_path / "out" / "scan.json").exists()
+
+
+def test_flags_may_precede_the_directory(tmp_path):
+    """`paperconan --no-html data/` — the target is not argv[0] here."""
+    data = _tiny_csv(tmp_path / "data")
+
+    res = _run(["--no-html", str(data), "--out", str(tmp_path / "out")])
+
+    assert res.returncode == 0, res.stderr
+    assert (tmp_path / "out" / "scan.json").exists()
+
+
+def test_version_still_works():
+    res = _run(["--version"])
+
+    assert res.returncode == 0, res.stderr
+    assert "paperconan" in res.stdout
+
+
+# ---------- the subcommand tree ----------
+
+def test_help_lists_every_subcommand():
+    res = _run(["--help"])
+
+    assert res.returncode == 0, res.stderr
+    for name in SUBCOMMANDS:
+        assert name in res.stdout, f"{name} missing from --help"
+
+
+def test_scan_is_addressable_explicitly(tmp_path):
+    """The explicit form disambiguates a directory named like a subcommand."""
+    data = _tiny_csv(tmp_path / "data")
+
+    res = _run(["scan", str(data), "--out", str(tmp_path / "out"), "--no-html"])
+
+    assert res.returncode == 0, res.stderr
+    assert (tmp_path / "out" / "scan.json").exists()
+
+
+def test_a_directory_named_like_a_subcommand_resolves_to_the_subcommand(tmp_path):
+    """Documents the ambiguity: the subcommand wins, `scan` is the way out."""
+    _tiny_csv(tmp_path / "report")
+
+    res = _run(["report"], cwd=str(tmp_path))
+
+    # parsed as `report` (which then complains about its own required args),
+    # never as a scan of ./report
+    assert res.returncode != 0
+    assert not (tmp_path / "report" / "audit").exists()
+
+
+def test_unknown_subcommand_like_argument_is_treated_as_a_scan_target(tmp_path):
+    res = _run(["definitely-not-a-command"], cwd=str(tmp_path))
+
+    assert res.returncode != 0
+    # it failed as a missing scan input, not as an argparse "invalid choice"
+    assert "invalid choice" not in (res.stderr + res.stdout)
+
+
+# ---------- existing subcommands keep working ----------
+
+def test_report_subcommand_still_renders(tmp_path):
+    scan = {"relations_blocks": [], "cross_sheet_findings": []}
+    verdict = {"verdict": "NEEDS_HUMAN", "report_md": "Requires contextual review."}
+    (tmp_path / "scan.json").write_text(json.dumps(scan), encoding="utf-8")
+    (tmp_path / "verdict.json").write_text(json.dumps(verdict), encoding="utf-8")
+    out = tmp_path / "adjudicated.html"
+
+    res = _run([
+        "report", str(tmp_path / "scan.json"),
+        "--verdict", str(tmp_path / "verdict.json"),
+        "--out", str(out),
+    ])
+
+    assert res.returncode == 0, res.stderr
+    assert out.exists()
+
+
+@pytest.mark.parametrize("name", ["fetch", "report"])
+def test_each_subcommand_has_its_own_help(name):
+    res = _run([name, "--help"])
+
+    assert res.returncode == 0, res.stderr


### PR DESCRIPTION
Phase 1, PR 2 of 6 ([plan](docs/superpowers/plans/2026-07-26-phase1-opt-in-workflow-skeleton.md)). Mechanical — no behaviour change, no new command.

## Why

`main()` branched on `sys.argv[1]` once per subcommand, so every command added another special case and `--help` described only the default scan. Phase 1 adds `workflow`, and spec §14.3 explicitly rules out letting it become a third dispatch style — it required this decision to be settled in the plan first.

## Change

`scan` / `fetch` / `report` are registered on one `add_subparsers` tree, with a single dispatch rule:

> a first argument that is not a known subcommand is the scan target

That rule is what preserves `paperconan <dir>`. It also covers `paperconan --no-html <dir>`, where the target is not `argv[0]` at all.

`fetch` still delegates to its own parser (it owns a large flag surface) but is registered on the tree so it shows up in `--help` instead of being invisible.

## Ambiguity, pinned by a test

A directory named exactly like a subcommand now resolves to the subcommand. `paperconan scan ./report` is the explicit way out. This is tested rather than left to be discovered.

## Impact

None. Verified by running a demo scan under both implementations and diffing:

- stdout — identical
- `scan.json` — byte-identical
- `report.html` — byte-identical

## Validation

- Full suite: `1335 passed, 1 skipped` (1325 baseline + 10 new)
- New tests observed RED first (`ImportError: cannot import name 'SUBCOMMANDS'`)
- Covers: bare directory, flags-before-directory, `--version`, `--help` listing every subcommand, explicit `scan`, the subcommand-name ambiguity, unknown-argument-as-scan-target, `report` still rendering, and per-subcommand `--help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)