### PR TITLE
feat: add the opt-in workflow DISCOVER stage

### DIFF
--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -4507,7 +4507,7 @@ def write_markdown_report(out, path):
 # Every command lives in one subparser tree. Dispatch has a single rule: a first
 # argument that is not one of these names is the scan target, which is what keeps
 # `paperconan <dir>` working without giving any command its own argv branch.
-SUBCOMMANDS = ("scan", "fetch", "report")
+SUBCOMMANDS = ("scan", "fetch", "report", "workflow")
 
 
 def _add_scan_arguments(ap: argparse.ArgumentParser) -> None:
@@ -4592,6 +4592,31 @@ def _run_report(args: argparse.Namespace) -> None:
     print(f"wrote {args.out}")
 
 
+def _run_workflow(args: argparse.Namespace) -> None:
+    from ._workflow import WorkflowError, start_workflow, workflow_status
+
+    try:
+        if args.workflow_cmd == "start":
+            state = start_workflow(args.in_dir, args.out, profile=args.profile)
+            print(f"wrote {args.out}/scan.json, {args.out}/states/s000.json, "
+                  f"{args.out}/steps/t000/candidate_packet.json")
+            print(f"  stage: {state['workflow_stage']} · "
+                  f"next: {state['next_action']} → {state['next_artifact_path']}")
+            print(f"  clusters routed: {state['coverage']['clusters_total'] - state['coverage']['clusters_omitted']}"
+                  f" of {state['coverage']['clusters_total']}")
+            if state["coverage"]["truncated"]:
+                print(f"  coverage: {state['coverage']['omitted_reason']}")
+            return
+        status = workflow_status(args.workflow_dir)
+        print(f"stage: {status['workflow_stage']}")
+        print(f"next: {status['next_action']} → {status['next_artifact_path']}")
+        print(f"route_step: {status['route_step']}/{status['max_route_steps']} · "
+              f"expansion_round: {status['expansion_round']}/{status['max_expansion_rounds']}")
+        print(f"budget_remaining: {status['budget_remaining']}")
+    except (WorkflowError, PaperconanInputError) as exc:
+        sys.exit(str(exc))
+
+
 def _build_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(
         prog="paperconan",
@@ -4625,6 +4650,27 @@ def _build_parser() -> argparse.ArgumentParser:
     report_p.add_argument("--verdict", required=True, help="Path to verdict JSON")
     report_p.add_argument("--out", required=True, help="Output HTML path")
 
+    wf = sub.add_parser(
+        "workflow",
+        help="deterministic Agent-workflow steps (opt-in; never calls a model)",
+        description=(
+            "Run the deterministic half of the Agent review workflow. These commands "
+            "only produce and validate artifacts; model calls are the skill's job."
+        ),
+    )
+    wf_sub = wf.add_subparsers(dest="workflow_cmd", required=True)
+
+    wf_start = wf_sub.add_parser("start", help="scan and write the DISCOVER artifacts")
+    wf_start.add_argument("in_dir", help="Directory with the paper's source data")
+    wf_start.add_argument("--out", required=True, help="Workflow working directory")
+    wf_start.add_argument("--profile", choices=("review", "forensic", "triage"),
+                          default="review",
+                          help="Display profile for scan.json; workflow seeds always "
+                               "come from the raw pre-profile stream")
+
+    wf_status = wf_sub.add_parser("status", help="print the current stage and budget")
+    wf_status.add_argument("workflow_dir", help="Workflow working directory")
+
     return ap
 
 
@@ -4647,6 +4693,9 @@ def main(argv: list[str] | None = None) -> None:
     args = ap.parse_args(argv)
     if args.cmd == "report":
         _run_report(args)
+        return
+    if args.cmd == "workflow":
+        _run_workflow(args)
         return
     _run_scan(ap, args)
 

--- a/src/paperconan/_workflow.py
+++ b/src/paperconan/_workflow.py
@@ -1,0 +1,278 @@
+"""The deterministic half of the Agent workflow: DISCOVER (`start`) and `status`.
+
+paperconan never calls a model. It runs the scan, freezes a bounded candidate
+stream, and writes the artifacts an Agent reads and answers. The Agent decides
+only whether to spend expansion budget; every number here is produced by the
+existing deterministic detectors.
+
+Two properties this module is responsible for:
+
+* **Seeds come from the raw stream.** Candidates are built from `raw_severity`,
+  frozen before any profile projection, so running the CLI with `--profile
+  triage` cannot starve the workflow of candidates it would otherwise route.
+* **Fixed inputs replay.** Artifacts are content-addressed and carry no
+  wall-clock or machine-specific values, so the same source data yields the same
+  bytes. Agent free text is not covered by that guarantee and is not an input
+  to any digest.
+
+Phase 1 is a skeleton: no new detector maths lives here.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from typing import Any
+
+from ._finding_groups import BLOCK_FINDING_GROUPS
+
+SCHEMA_VERSION = 1
+MAX_EXPANSION_ROUNDS = 2
+MAX_ROUTE_STEPS = 5
+
+ALLOWED_DECISIONS = ("expand", "explained", "needs_context", "defer")
+
+DEFAULT_BUDGET = {
+    "clusters": 8,
+    "evidence_cells": 2000,
+    "context_requests": 4,
+}
+
+# Severity order for deterministic candidate ranking (raw, never projected).
+_SEVERITY_RANK = {"high": 0, "medium": 1, "low": 2}
+
+
+class WorkflowError(ValueError):
+    """A workflow directory or artifact is missing, stale or schema-incompatible."""
+
+
+# ---------- digests and envelope ----------
+
+def _canonical_json(obj: Any) -> str:
+    return json.dumps(obj, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+
+
+def _digest(obj: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(obj).encode("utf-8")).hexdigest()
+
+
+def _source_manifest(in_dir: str) -> list[dict[str, str]]:
+    """Normalized relative paths + content digests. No absolute machine paths.
+
+    Keeping the manifest content-addressed rather than path-addressed is what
+    lets the same source data replay to the same run_id on another machine.
+    """
+    entries = []
+    for root, _dirs, files in os.walk(in_dir):
+        for name in sorted(files):
+            path = os.path.join(root, name)
+            rel = os.path.relpath(path, in_dir).replace(os.sep, "/")
+            try:
+                with open(path, "rb") as fh:
+                    sha = hashlib.sha256(fh.read()).hexdigest()
+            except OSError:
+                continue
+            entries.append({"path": rel, "sha256": sha})
+    return sorted(entries, key=lambda e: e["path"])
+
+
+def _envelope(*, run_id: str, artifact_type: str, stage: str,
+              parent_refs: list[str], config_digest: str,
+              coverage: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    art = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "artifact_type": artifact_type,
+        "created_by_stage": stage,
+        "parent_refs": parent_refs,
+        "config_digest": config_digest,
+        "coverage": coverage,
+        **payload,
+    }
+    # artifact_id is derived last so it covers the whole artifact.
+    art["artifact_id"] = _digest(art)
+    return art
+
+
+def require_envelope(art: dict[str, Any], *, expected_type: str | None = None) -> None:
+    """Reject anything this version cannot interpret, rather than guessing."""
+    version = art.get("schema_version")
+    if version != SCHEMA_VERSION:
+        raise WorkflowError(
+            f"artifact schema_version {version!r} is not supported "
+            f"(this build reads {SCHEMA_VERSION})"
+        )
+    if expected_type is not None and art.get("artifact_type") != expected_type:
+        raise WorkflowError(
+            f"expected a {expected_type} artifact, got {art.get('artifact_type')!r}"
+        )
+
+
+# ---------- seeds ----------
+
+def _iter_raw_findings(scan: dict[str, Any]):
+    """Every per-block finding, read through the canonical group registry."""
+    for blk in scan.get("relations_blocks", []) or []:
+        for group in BLOCK_FINDING_GROUPS:
+            for f in blk.get(group, []) or []:
+                yield blk, group, f
+
+
+def _seed_from(blk: dict[str, Any], group: str, f: dict[str, Any], index: int) -> dict[str, Any]:
+    # raw_severity is frozen before profile projection; `severity` may already
+    # have been rewritten to "low" and must not drive routing.
+    raw = f.get("raw_severity") or f.get("severity") or "low"
+    return {
+        "seed_id": f"seed:{index:04d}",
+        "kind": f.get("kind"),
+        "group": group,
+        "file": blk.get("file"),
+        "sheet": blk.get("sheet"),
+        "block_rows": (blk.get("block") or {}).get("rows"),
+        "block_cols": (blk.get("block") or {}).get("cols"),
+        "raw_severity": raw,
+        "rule": f.get("rule"),
+        "n": f.get("n"),
+    }
+
+
+def _cluster_key(seed: dict[str, Any]) -> tuple:
+    return (seed["file"] or "", seed["sheet"] or "", seed["block_rows"] or "")
+
+
+def _build_clusters(scan: dict[str, Any], max_clusters: int) -> tuple[list[dict], dict]:
+    seeds = [
+        _seed_from(blk, group, f, i)
+        for i, (blk, group, f) in enumerate(_iter_raw_findings(scan))
+    ]
+
+    grouped: dict[tuple, list[dict]] = {}
+    for seed in seeds:
+        grouped.setdefault(_cluster_key(seed), []).append(seed)
+
+    clusters = []
+    for key, members in grouped.items():
+        members = sorted(
+            members,
+            key=lambda s: (_SEVERITY_RANK.get(s["raw_severity"], 3), s["seed_id"]),
+        )
+        clusters.append({
+            "cluster_id": "cluster:" + hashlib.sha256(
+                _canonical_json(list(key)).encode("utf-8")
+            ).hexdigest()[:16],
+            "file": key[0],
+            "sheet": key[1],
+            "block_rows": key[2],
+            "strongest_raw_severity": members[0]["raw_severity"],
+            "seeds": members,
+        })
+
+    # Deterministic order: strongest first, then by stable id.
+    clusters.sort(key=lambda c: (
+        _SEVERITY_RANK.get(c["strongest_raw_severity"], 3), c["cluster_id"]
+    ))
+
+    kept, omitted = clusters[:max_clusters], clusters[max_clusters:]
+    coverage = {
+        "seeds_total": len(seeds),
+        "clusters_total": len(clusters),
+        "clusters_omitted": len(omitted),
+        "truncated": bool(omitted),
+    }
+    if omitted:
+        # Never silently truncate: say what was dropped and why.
+        coverage["omitted_reason"] = (
+            f"cluster budget {max_clusters} reached; "
+            f"{len(omitted)} lower-ranked clusters were not routed"
+        )
+    return kept, coverage
+
+
+# ---------- start ----------
+
+def start_workflow(in_dir: str, out_dir: str, *, profile: str = "review",
+                   max_clusters: int | None = None) -> dict[str, Any]:
+    """Run DISCOVER: scan, seed, and write the immutable step-0 artifacts."""
+    from ._audit import scan_dir
+
+    max_clusters = DEFAULT_BUDGET["clusters"] if max_clusters is None else max_clusters
+    os.makedirs(out_dir, exist_ok=True)
+    scan = scan_dir(in_dir, out_dir, write_md=False, write_html=False, profile=profile)
+
+    manifest = _source_manifest(in_dir)
+    config = {
+        "schema_version": SCHEMA_VERSION,
+        "max_clusters": max_clusters,
+        "max_expansion_rounds": MAX_EXPANSION_ROUNDS,
+        "max_route_steps": MAX_ROUTE_STEPS,
+    }
+    config_digest = _digest(config)
+    # Semantic run id: same sources + same config replay to the same run.
+    run_id = "wf:" + hashlib.sha256(
+        _canonical_json({"manifest": manifest, "config": config}).encode("utf-8")
+    ).hexdigest()[:16]
+
+    clusters, coverage = _build_clusters(scan, max_clusters)
+
+    packet = _envelope(
+        run_id=run_id, artifact_type="candidate_packet", stage="DISCOVER",
+        parent_refs=[], config_digest=config_digest, coverage=coverage,
+        payload={
+            "route_step": 0,
+            "source_manifest": manifest,
+            "clusters": clusters,
+        },
+    )
+    state = _envelope(
+        run_id=run_id, artifact_type="workflow_state", stage="DISCOVER",
+        parent_refs=[packet["artifact_id"]], config_digest=config_digest,
+        coverage=coverage,
+        payload={
+            "workflow_stage": "ROUTE",
+            "next_action": "write_routing_request",
+            "next_artifact_path": "steps/t000/routing_request.json",
+            "allowed_decisions": list(ALLOWED_DECISIONS),
+            "allowed_recipes": [],
+            "route_step": 0,
+            "max_route_steps": MAX_ROUTE_STEPS,
+            "expansion_round": 0,
+            "max_expansion_rounds": MAX_EXPANSION_ROUNDS,
+            "budget_remaining": dict(DEFAULT_BUDGET, clusters=max_clusters),
+        },
+    )
+
+    _write(os.path.join(out_dir, "steps", "t000", "candidate_packet.json"), packet)
+    _write(os.path.join(out_dir, "states", "s000.json"), state)
+    _write(os.path.join(out_dir, "workflow_state.json"),
+           {"schema_version": SCHEMA_VERSION, "run_id": run_id,
+            "current_state_path": "states/s000.json",
+            "current_state_id": state["artifact_id"]})
+    return state
+
+
+def _write(path: str, art: dict[str, Any]) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(art, fh, indent=2, sort_keys=True, ensure_ascii=False)
+        fh.write("\n")
+
+
+# ---------- status ----------
+
+def workflow_status(out_dir: str) -> dict[str, Any]:
+    """Read-only view of where the workflow stands. Never mutates."""
+    index_path = os.path.join(out_dir, "workflow_state.json")
+    if not os.path.exists(index_path):
+        raise WorkflowError(
+            f"{out_dir} is not a paperconan workflow directory "
+            "(no workflow_state.json); run `paperconan workflow start` first"
+        )
+    with open(index_path, encoding="utf-8") as fh:
+        index = json.load(fh)
+    state_path = os.path.join(out_dir, index.get("current_state_path", ""))
+    if not os.path.exists(state_path):
+        raise WorkflowError(f"workflow index points at a missing state: {state_path}")
+    with open(state_path, encoding="utf-8") as fh:
+        state = json.load(fh)
+    require_envelope(state, expected_type="workflow_state")
+    return state

--- a/tests/test_workflow_start_status.py
+++ b/tests/test_workflow_start_status.py
@@ -1,0 +1,219 @@
+"""`workflow start` / `workflow status` — the DISCOVER stage.
+
+Phase 1 is a skeleton: no new detector maths runs here. `start` reuses the
+existing scan, freezes a bounded seed stream from the pre-profile raw findings,
+and writes the immutable state and candidate-packet artifacts the Agent reads.
+
+The two properties worth pinning are that the seed stream is taken before any
+profile projection (so a triage run does not starve the workflow of candidates),
+and that fixed inputs replay to identical artifacts.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from paperconan._workflow import start_workflow, workflow_status
+
+
+def _paper(d, *, boundary=True):
+    """A tiny synthetic sheet. `boundary` seeds a value the review profile demotes."""
+    d.mkdir(parents=True, exist_ok=True)
+    rows = ["gene,pvalue,logFC"]
+    for i in range(12):
+        p = 1.0 if (boundary and i < 9) else round(0.01 + i * 0.003, 4)
+        rows.append(f"g{i},{p},{round(-2 + i * 0.31, 4)}")
+    (d / "panel.csv").write_text("\n".join(rows) + "\n", encoding="utf-8")
+    return d
+
+
+def _read(p):
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+# ---------- artifacts and envelope ----------
+
+def test_start_writes_the_discover_artifacts(tmp_path):
+    out = tmp_path / "agent"
+
+    start_workflow(str(_paper(tmp_path / "data")), str(out))
+
+    assert (out / "scan.json").exists()
+    assert (out / "states" / "s000.json").exists()
+    assert (out / "steps" / "t000" / "candidate_packet.json").exists()
+
+
+@pytest.mark.parametrize("rel", [
+    "states/s000.json",
+    "steps/t000/candidate_packet.json",
+])
+def test_every_artifact_carries_the_common_envelope(tmp_path, rel):
+    out = tmp_path / "agent"
+    start_workflow(str(_paper(tmp_path / "data")), str(out))
+
+    art = _read(out / rel)
+
+    for field in ("schema_version", "run_id", "artifact_id", "parent_refs",
+                  "config_digest", "coverage", "created_by_stage"):
+        assert field in art, f"{rel} missing envelope field {field}"
+
+
+def test_initial_state_is_route_with_a_next_action(tmp_path):
+    out = tmp_path / "agent"
+    start_workflow(str(_paper(tmp_path / "data")), str(out))
+
+    state = _read(out / "states" / "s000.json")
+
+    assert state["workflow_stage"] == "ROUTE"
+    assert state["next_action"] == "write_routing_request"
+    assert state["next_artifact_path"] == "steps/t000/routing_request.json"
+    assert state["route_step"] == 0
+    assert state["expansion_round"] == 0
+    assert state["max_expansion_rounds"] == 2
+    assert set(state["allowed_decisions"]) == {"expand", "explained", "needs_context", "defer"}
+
+
+def test_budget_is_declared_up_front(tmp_path):
+    out = tmp_path / "agent"
+    start_workflow(str(_paper(tmp_path / "data")), str(out))
+
+    budget = _read(out / "states" / "s000.json")["budget_remaining"]
+
+    for k in ("clusters", "evidence_cells", "context_requests"):
+        assert isinstance(budget[k], int) and budget[k] > 0
+
+
+# ---------- the seed stream is raw, not profile-projected ----------
+
+def test_seeds_survive_a_profile_that_would_demote_them(tmp_path):
+    """spec 14.3 exit criterion: seeds must not vanish under a CLI profile.
+
+    The fixture's repeated 1.0 p-values are demoted by review and hidden by
+    triage. Seeding from the raw stream means all three profiles agree.
+    """
+    counts = {}
+    for profile in ("forensic", "review", "triage"):
+        out = tmp_path / profile
+        start_workflow(str(_paper(tmp_path / "data")), str(out), profile=profile)
+        packet = _read(out / "steps" / "t000" / "candidate_packet.json")
+        counts[profile] = len(packet["clusters"])
+
+    assert counts["review"] == counts["forensic"], counts
+    assert counts["triage"] == counts["forensic"], counts
+    assert counts["forensic"] > 0, "fixture produced no candidates at all"
+
+
+def test_seed_records_the_raw_severity_not_the_projected_one(tmp_path):
+    out = tmp_path / "agent"
+    start_workflow(str(_paper(tmp_path / "data")), str(out), profile="triage")
+
+    packet = _read(out / "steps" / "t000" / "candidate_packet.json")
+    seeds = [s for c in packet["clusters"] for s in c["seeds"]]
+
+    assert seeds, "expected at least one seed"
+    assert any(s["raw_severity"] == "high" for s in seeds)
+
+
+# ---------- coverage and determinism ----------
+
+def test_packet_records_coverage_for_what_it_left_out(tmp_path):
+    """Truncation must be stated, never silent."""
+    data = _paper(tmp_path / "data")
+    # a second sibling file so there is genuinely more than one cluster to drop
+    # (scan_dir does not recurse, so it has to live beside the first)
+    (data / "panel2.csv").write_text(
+        (data / "panel.csv").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+    uncapped = tmp_path / "uncapped"
+    start_workflow(str(data), str(uncapped))
+    total = len(_read(uncapped / "steps" / "t000" / "candidate_packet.json")["clusters"])
+    assert total > 1, "fixture must yield >1 cluster for this to test anything"
+
+    out = tmp_path / "agent"
+    start_workflow(str(data), str(out), max_clusters=1)
+    packet = _read(out / "steps" / "t000" / "candidate_packet.json")
+
+    assert len(packet["clusters"]) == 1
+    assert packet["coverage"]["clusters_omitted"] == total - 1
+    assert packet["coverage"]["truncated"] is True
+    assert packet["coverage"]["omitted_reason"]
+
+
+def test_fixed_input_replays_to_identical_artifacts(tmp_path):
+    data = _paper(tmp_path / "data")
+
+    start_workflow(str(data), str(tmp_path / "a"))
+    start_workflow(str(data), str(tmp_path / "b"))
+
+    for rel in ("states/s000.json", "steps/t000/candidate_packet.json"):
+        assert (tmp_path / "a" / rel).read_text() == (tmp_path / "b" / rel).read_text(), rel
+
+
+# ---------- status ----------
+
+def test_status_reports_the_current_stage_without_mutating(tmp_path):
+    out = tmp_path / "agent"
+    start_workflow(str(_paper(tmp_path / "data")), str(out))
+    before = (out / "states" / "s000.json").read_text()
+
+    status = workflow_status(str(out))
+
+    assert status["workflow_stage"] == "ROUTE"
+    assert status["next_action"] == "write_routing_request"
+    assert (out / "states" / "s000.json").read_text() == before
+
+
+def test_status_on_a_directory_that_is_not_a_workflow_is_rejected(tmp_path):
+    with pytest.raises(ValueError):
+        workflow_status(str(tmp_path))
+
+
+def test_status_rejects_an_artifact_from_an_unsupported_schema(tmp_path):
+    """Schema mismatch must be refused outright, not guessed at."""
+    out = tmp_path / "agent"
+    start_workflow(str(_paper(tmp_path / "data")), str(out))
+    state_path = out / "states" / "s000.json"
+    state = _read(state_path)
+    state["schema_version"] = 999
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="schema_version"):
+        workflow_status(str(out))
+
+
+# ---------- CLI surface ----------
+
+def test_cli_start_then_status(tmp_path):
+    import subprocess
+    import sys
+
+    data = _paper(tmp_path / "data")
+    out = tmp_path / "agent"
+
+    started = subprocess.run(
+        [sys.executable, "-m", "paperconan", "workflow", "start", str(data), "--out", str(out)],
+        text=True, capture_output=True,
+    )
+    assert started.returncode == 0, started.stderr
+
+    status = subprocess.run(
+        [sys.executable, "-m", "paperconan", "workflow", "status", str(out)],
+        text=True, capture_output=True,
+    )
+    assert status.returncode == 0, status.stderr
+    assert "ROUTE" in status.stdout
+
+
+def test_cli_status_on_a_plain_directory_exits_with_a_message(tmp_path):
+    import subprocess
+    import sys
+
+    res = subprocess.run(
+        [sys.executable, "-m", "paperconan", "workflow", "status", str(tmp_path)],
+        text=True, capture_output=True,
+    )
+
+    assert res.returncode != 0
+    assert "workflow" in (res.stderr + res.stdout).lower()


### PR DESCRIPTION
Phase 1, PR 3 of 6 ([plan](docs/superpowers/plans/2026-07-26-phase1-opt-in-workflow-skeleton.md)). First functional piece of the workflow skeleton.

## What lands

```bash
paperconan workflow start data/ --out audit/agent/   # DISCOVER
paperconan workflow status audit/agent/              # read-only
```

`start` reuses the existing scan, then writes `states/s000.json`, `steps/t000/candidate_packet.json` and a mutable `workflow_state.json` index. No model call, no new detector maths.

## The two properties worth reviewing

**Seeds come from the raw stream.** Candidates are built from `raw_severity` (frozen in #43 before profile projection), not the possibly-rewritten `severity`. Spec §14.3 makes this an exit criterion: a `--profile triage` run must not starve the workflow of candidates. Tested by running all three profiles over a fixture whose repeated `1.0` p-values review demotes and triage hides, and asserting the cluster counts agree.

**Fixed inputs replay.** `run_id` and `artifact_id` derive from a source manifest of normalized relative paths plus content digests — no absolute paths, no timestamps — so the same source data yields the same bytes. Agent free text is not an input to any digest, per spec §12.2.

## Also

- Common envelope on every artifact: `schema_version`, `run_id`, `artifact_id`, `parent_refs`, `config_digest`, `coverage`, `created_by_stage`.
- Truncation is stated (`coverage.omitted_reason`), never silent.
- Unsupported `schema_version` is refused outright rather than guessed at.
- `workflow` joins the subparser tree from #44 rather than getting its own dispatch branch.

## Exit criteria (spec §14.3)

| Criterion | Status |
|---|---|
| bare CLI behaviour unchanged | ✅ only a new subcommand added |
| detector golden zero change | ✅ `tests/golden/` untouched |
| workflow is opt-in | ✅ nothing runs it by default |
| seeds survive profile / packet cap | ✅ directly tested |
| requires no enabled calibration | ✅ registry arrives in P1f |

## Validation

- Full suite: `1349 passed, 1 skipped` (1335 baseline + 14 new)
- New tests observed RED first (`ModuleNotFoundError: paperconan._workflow`)
- CLI verified end to end on `examples/demo_paper`

🤖 Generated with [Claude Code](https://claude.com/claude-code)