### PR TITLE
fix: keep scan flags discoverable from the bare --help

### DIFF
--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -4617,6 +4617,24 @@ def _run_workflow(args: argparse.Namespace) -> None:
         sys.exit(str(exc))
 
 
+def _scan_options_section(scan_p: argparse.ArgumentParser) -> str:
+    """The scan parser's own options block, lifted verbatim.
+
+    `paperconan <dir>` is the documented default invocation, so its flags have to
+    stay discoverable from the bare `--help`. Deriving the text from the parser
+    rather than restating it keeps the two from drifting apart.
+    """
+    help_text = scan_p.format_help()
+    marker = "options:"
+    idx = help_text.find(marker)
+    if idx < 0:  # pragma: no cover - argparse always emits an options section
+        return ""
+    body = help_text[idx + len(marker):].rstrip()
+    # -h is already documented on the top-level parser; don't list it twice.
+    kept = [ln for ln in body.split("\n") if not ln.lstrip().startswith("-h, --help")]
+    return "scan options (for `paperconan <in_dir>`):" + "\n".join(kept)
+
+
 def _build_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(
         prog="paperconan",
@@ -4624,6 +4642,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "Scan a paper's source data (xlsx/csv/tsv, or tables inside "
             "pdf/docx) for statistical signals and data inconsistencies"
         ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     ap.add_argument("--version", action="version", version=f"paperconan {_version()}")
     sub = ap.add_subparsers(dest="cmd")
@@ -4634,6 +4653,8 @@ def _build_parser() -> argparse.ArgumentParser:
         description="Scan a paper's source data for statistical signals and data inconsistencies",
     )
     _add_scan_arguments(scan_p)
+    # Route usage errors back to the parser the flags actually belong to.
+    scan_p.set_defaults(_parser=scan_p)
 
     sub.add_parser(
         "fetch",
@@ -4671,6 +4692,11 @@ def _build_parser() -> argparse.ArgumentParser:
     wf_status = wf_sub.add_parser("status", help="print the current stage and budget")
     wf_status.add_argument("workflow_dir", help="Workflow working directory")
 
+    ap.epilog = (
+        "default invocation:\n"
+        "  paperconan <in_dir> [options]   equivalent to `paperconan scan <in_dir>`\n\n"
+        + _scan_options_section(scan_p)
+    )
     return ap
 
 
@@ -4697,7 +4723,7 @@ def main(argv: list[str] | None = None) -> None:
     if args.cmd == "workflow":
         _run_workflow(args)
         return
-    _run_scan(ap, args)
+    _run_scan(getattr(args, "_parser", ap), args)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_dispatch.py
+++ b/tests/test_cli_dispatch.py
@@ -72,6 +72,42 @@ def test_help_lists_every_subcommand():
         assert name in res.stdout, f"{name} missing from --help"
 
 
+# `paperconan <dir>` is the documented default invocation, so the bare help has
+# to keep documenting its flags. Asserting only on subcommand names passed even
+# when every scan flag had vanished from the help.
+SCAN_FLAGS = ("--out", "--profile", "--md", "--no-html", "--doi", "--images")
+
+
+@pytest.mark.parametrize("flag", SCAN_FLAGS)
+def test_bare_help_still_documents_the_scan_flags(flag):
+    res = _run(["--help"])
+
+    assert res.returncode == 0, res.stderr
+    assert flag in res.stdout, f"{flag} is undiscoverable from `paperconan --help`"
+
+
+@pytest.mark.parametrize("flag", SCAN_FLAGS)
+def test_scan_subcommand_help_documents_the_scan_flags(flag):
+    res = _run(["scan", "--help"])
+
+    assert res.returncode == 0, res.stderr
+    assert flag in res.stdout
+
+
+def test_scan_usage_errors_point_at_the_scan_parser(tmp_path):
+    """`--image-diagnostics requires --images` must show scan usage, not the top level."""
+    data = _tiny_csv(tmp_path / "data")
+
+    res = _run([str(data), "--image-diagnostics"])
+
+    assert res.returncode != 0
+    combined = res.stderr + res.stdout
+    assert "--image-diagnostics requires --images" in combined
+    assert "{scan,fetch,report,workflow}" not in combined, (
+        "error reported against the top-level parser instead of the scan parser"
+    )
+
+
 def test_scan_is_addressable_explicitly(tmp_path):
     """The explicit form disambiguates a directory named like a subcommand."""
     data = _tiny_csv(tmp_path / "data")


### PR DESCRIPTION
Post-merge review follow-up for #44 (issue I1).

## The regression

#44 claimed "mechanical, no behaviour change" and verified that by diffing scan output — stdout, `scan.json` and `report.html` were byte-identical. The verification never covered the help surface, which is exactly where the change landed:

```
$ paperconan --help
usage: paperconan [-h] [--version] {scan,fetch,report,workflow} ...
# --out --profile --md --no-html --doi --images : all gone
```

`paperconan <in_dir> [--profile ...]` is the documented default invocation in README, so those flags became undiscoverable from the tool itself. That breaks Phase 1 exit criterion 1 ("bare CLI default behaviour unchanged").

## Why the test didn't catch it

```python
for name in SUBCOMMANDS:
    assert name in res.stdout
```

Asserting on subcommand *names* passes with every flag missing. Same weak-assertion shape as the one caught during #41: the test was written from the implementation rather than from what the CLI promises.

## Fix

- Top-level epilog now carries the scan options block, **derived from the scan subparser** via `_scan_options_section()` rather than restated, so the two cannot drift.
- `_run_scan` receives the scan subparser (via `set_defaults(_parser=...)`), so `--image-diagnostics requires --images` prints the scan usage line again instead of the top-level one.
- Help test is parametrised over the six flags; added a test pinning the usage-error parser.

## Validation

- Full suite: `1362 passed, 1 skipped` (1349 baseline + 13 new)
- All 7 new assertions observed RED first
- Scan output re-diffed after the change: `scan.json` still byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)