### PR TITLE
feat: read a scan in layers with overview / drill / explain

### DIFF
--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -65,10 +65,14 @@ Three things to hold onto while reading:
   a dense block or a repeated axis is often a fair call, but an exactly duplicated
   column can be demoted merely for sharing a block with many other relations.
   Do not skip a finding because its displayed severity is low.
-- **Read `coverage` at every layer.** It states what was not shown and why —
-  locations beyond the listed count, findings beyond a listing limit, families the
-  layer does not route, and detector-level caps that are not reported at all.
-  Raise `--max-locations` / `--max-findings` to reach the remainder.
+- **Read `coverage` — it is printed after the table, as lines starting with `!`.**
+  `overview` and both `drill` forms carry it; `explain` describes a single
+  finding and has none. It states what was not shown and why: locations beyond
+  the listed count, findings beyond a listing limit, families this layer does not
+  route (digit distributions, decimal endings, image findings), findings the scan's
+  own caps dropped before the layers saw them, and detector-level caps that are
+  reported nowhere at all. Raise `--max-locations` / `--max-findings` to reach the
+  remainder; the rest are limits of the scan, not of the view.
 - **A quiet overview is not a clean paper.** It means these detectors found
   nothing at these thresholds in the data that was supplied.
 

--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -65,9 +65,10 @@ Three things to hold onto while reading:
   a dense block or a repeated axis is often a fair call, but an exactly duplicated
   column can be demoted merely for sharing a block with many other relations.
   Do not skip a finding because its displayed severity is low.
-- **Read `coverage` — it is printed after the table, as lines starting with `!`.**
-  `overview` and both `drill` forms carry it; `explain` describes a single
-  finding and has none. It states what was not shown and why: locations beyond
+- **Read the `!` lines — every layer has them.** `overview` and both `drill`
+  forms carry a `coverage` block; `explain` states its own limits inline (an
+  evidence window the scan trimmed, structured parameters only `--json` shows).
+  They state what was not shown and why: locations beyond
   the listed count, findings beyond a listing limit, families this layer does not
   route (digit distributions, decimal endings, image findings), findings the scan's
   own caps dropped before the layers saw them, and detector-level caps that are

--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -22,9 +22,55 @@ Tool repository: https://github.com/zixixr/paperconan
    - DOI or title: run `paperconan fetch "<DOI or title>"`, choose a matched tabular dataset, download it, then scan the downloaded directory.
    - Only an existing audit: read `audit/scan.json` and use `audit/report.html` as the evidence browser to triage — then give an adjudicated answer. Do not hand the raw `report.html` over as "the result" (see Report Positioning below).
 2. Prefer the real CLI. Do not invent findings from eyeballing tables.
-3. Parse `scan.json`, then load the reference file needed for the task.
+3. Read the scan in layers — start with `paperconan overview`, not by parsing the
+   whole `scan.json` (see Reading A Scan In Layers below). Load the reference file
+   needed for the task.
 4. Open the original table when describing a serious finding as worth follow-up. If the original data is unavailable, say the finding is unverified.
 5. Answer cautiously: explain the anomaly, plausible benign explanations, and what human context is needed.
+
+## Reading A Scan In Layers
+
+One paper's supplement routinely produces hundreds to thousands of findings and a
+multi-megabyte `scan.json`. Reading all of it wastes the attention you need for
+judgement, and the few signals worth acting on get buried among many routine ones.
+
+Detectors deliberately run wide so real signals are not lost to a threshold, so
+the narrowing happens here, in how you read — not in what was detected. Nothing is
+filtered; you reach it in stages.
+
+```bash
+paperconan overview audit/scan.json                    # which locations carry signal
+paperconan drill    audit/scan.json 2                  # that location, grouped by kind
+paperconan drill    audit/scan.json 2 --kind identical_column
+paperconan explain  audit/scan.json seed:17942ad206854a66
+```
+
+Add `--json` to any of them when you need the structure rather than the text.
+
+Work down, and stop at the shallowest layer that answers the question:
+
+1. **overview** — which locations, how strong, what families. Often enough to see
+   that a location is one derived relation restated many times.
+2. **drill \<n\>** — the kinds at that location, with one concrete example each.
+   A kind with a large `n` and a formulaic example is usually one structure
+   expressed repeatedly; a kind with `n=1` may still be the strongest signal there.
+3. **drill \<n\> --kind \<kind\>** — the individual findings, each with an id.
+4. **explain \<id\>** — one finding with its parameters and evidence table. Open
+   the original table before calling anything worth follow-up.
+
+Three things to hold onto while reading:
+
+- **`detector=high  displayed=low` means a display profile down-weighted it, not
+  that it is benign.** `explain` prints the recorded reason. Judge that reason —
+  a dense block or a repeated axis is often a fair call, but an exactly duplicated
+  column can be demoted merely for sharing a block with many other relations.
+  Do not skip a finding because its displayed severity is low.
+- **Read `coverage` at every layer.** It states what was not shown and why —
+  locations beyond the listed count, findings beyond a listing limit, families the
+  layer does not route, and detector-level caps that are not reported at all.
+  Raise `--max-locations` / `--max-findings` to reach the remainder.
+- **A quiet overview is not a clean paper.** It means these detectors found
+  nothing at these thresholds in the data that was supplied.
 
 ## Adaptive Image Review
 

--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -4680,14 +4680,20 @@ def _run_drill_command(args: argparse.Namespace) -> None:
 
     # Valid JSON that is not a scan would otherwise surface as an AttributeError
     # traceback, or — worse — render as "0 signals", which reads as a clean paper.
-    if not isinstance(scan, dict) or not (
-        "relations_blocks" in scan or "tool" in scan or "schema_version" in scan
-    ):
+    # `relations_blocks` is required rather than one-of: the workflow artifacts
+    # that sit beside scan.json all carry schema_version, so a looser gate let
+    # `overview states/s000.json` report a quiet paper for a file never scanned.
+    if not isinstance(scan, dict) or not isinstance(scan.get("relations_blocks"), list):
+        detail = ""
+        if isinstance(scan, dict) and scan.get("artifact_type"):
+            detail = f" (this is a workflow {scan['artifact_type']} artifact)"
         sys.exit(
-            f"{args.scan_json} does not look like a paperconan scan.json "
-            "(no relations_blocks/tool/schema_version); point at the file written "
-            "by `paperconan <dir>`"
+            f"{args.scan_json} does not look like a paperconan scan.json"
+            f"{detail}; point at the scan.json written by `paperconan <dir>`"
         )
+    for key in ("cross_sheet_findings", "image_findings"):
+        if key in scan and not isinstance(scan[key], list):
+            sys.exit(f"{args.scan_json} is malformed: {key} is not a list")
 
     try:
         if args.cmd == "overview":

--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -4535,7 +4535,7 @@ def write_markdown_report(out, path):
 # Every command lives in one subparser tree. Dispatch has a single rule: a first
 # argument that is not one of these names is the scan target, which is what keeps
 # `paperconan <dir>` working without giving any command its own argv branch.
-SUBCOMMANDS = ("scan", "fetch", "report", "workflow")
+SUBCOMMANDS = ("scan", "fetch", "report", "workflow", "overview", "drill", "explain")
 
 
 def _add_scan_arguments(ap: argparse.ArgumentParser) -> None:
@@ -4664,6 +4664,37 @@ def _scan_options_section(scan_p: argparse.ArgumentParser) -> str:
     return "scan options (for `paperconan <in_dir>`):" + "\n".join(kept)
 
 
+def _run_drill_command(args: argparse.Namespace) -> None:
+    import json
+
+    from ._drill import drill, explain, overview
+    from ._drill_render import render_drill, render_explain, render_overview
+
+    try:
+        with open(args.scan_json, encoding="utf-8") as fh:
+            scan = json.load(fh)
+    except OSError as exc:
+        sys.exit(f"could not read {args.scan_json}: {exc}")
+    except json.JSONDecodeError as exc:
+        sys.exit(f"{args.scan_json} is not valid JSON: {exc}")
+
+    try:
+        if args.cmd == "overview":
+            view = overview(scan, max_locations=args.max_locations)
+            text = render_overview(view)
+        elif args.cmd == "drill":
+            location = int(args.location) if args.location.isdigit() else args.location
+            view = drill(scan, location, kind=args.kind, max_findings=args.max_findings)
+            text = render_drill(view)
+        else:
+            view = explain(scan, args.finding_id)
+            text = render_explain(view)
+    except ValueError as exc:
+        sys.exit(str(exc))
+
+    print(json.dumps(view, ensure_ascii=False, indent=2) if args.json else text)
+
+
 def _build_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(
         prog="paperconan",
@@ -4723,6 +4754,29 @@ def _build_parser() -> argparse.ArgumentParser:
     wf_status = wf_sub.add_parser("status", help="print the current stage and budget")
     wf_status.add_argument("workflow_dir", help="Workflow working directory")
 
+    # Layered read-only views: read a scan one screenful at a time instead of
+    # loading all of it. See skills/paperconan/SKILL.md for the drill protocol.
+    ov = sub.add_parser("overview", help="list the locations carrying signal (start here)")
+    ov.add_argument("scan_json", help="Path to paperconan scan.json")
+    ov.add_argument("--max-locations", type=int, default=20,
+                    help="Locations to list (default 20; the rest are reported in coverage)")
+
+    dr = sub.add_parser("drill", help="open one location, or one kind within it")
+    dr.add_argument("scan_json", help="Path to paperconan scan.json")
+    dr.add_argument("location", help="Location number from `overview`, or a cluster id")
+    dr.add_argument("--kind", default=None,
+                    help="List the individual findings of this kind")
+    dr.add_argument("--max-findings", type=int, default=50,
+                    help="Findings to list (default 50; the rest are reported in coverage)")
+
+    ex = sub.add_parser("explain", help="one finding in full, with its evidence table")
+    ex.add_argument("scan_json", help="Path to paperconan scan.json")
+    ex.add_argument("finding_id", help="Finding id from `drill --kind`")
+
+    for parser in (ov, dr, ex):
+        parser.add_argument("--json", action="store_true",
+                            help="Emit the raw structure instead of formatted text")
+
     ap.epilog = (
         "default invocation:\n"
         "  paperconan <in_dir> [options]   equivalent to `paperconan scan <in_dir>`\n\n"
@@ -4753,6 +4807,9 @@ def main(argv: list[str] | None = None) -> None:
         return
     if args.cmd == "workflow":
         _run_workflow(args)
+        return
+    if args.cmd in ("overview", "drill", "explain"):
+        _run_drill_command(args)
         return
     _run_scan(getattr(args, "_parser", ap), args)
 

--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -4678,6 +4678,17 @@ def _run_drill_command(args: argparse.Namespace) -> None:
     except json.JSONDecodeError as exc:
         sys.exit(f"{args.scan_json} is not valid JSON: {exc}")
 
+    # Valid JSON that is not a scan would otherwise surface as an AttributeError
+    # traceback, or — worse — render as "0 signals", which reads as a clean paper.
+    if not isinstance(scan, dict) or not (
+        "relations_blocks" in scan or "tool" in scan or "schema_version" in scan
+    ):
+        sys.exit(
+            f"{args.scan_json} does not look like a paperconan scan.json "
+            "(no relations_blocks/tool/schema_version); point at the file written "
+            "by `paperconan <dir>`"
+        )
+
     try:
         if args.cmd == "overview":
             view = overview(scan, max_locations=args.max_locations)

--- a/src/paperconan/_drill.py
+++ b/src/paperconan/_drill.py
@@ -1,0 +1,265 @@
+"""Layered read-only views over a scan, for reading a paper one layer at a time.
+
+A single supplement can yield thousands of findings and a multi-MB scan.json.
+Handing that to a reviewer — human or agent — buries the few signals worth
+acting on. The tempting fix is to tighten the detectors, but that trades a
+presentation problem for a detection problem: the real signals go too.
+
+So nothing is filtered here. The same findings are reached in stages, each
+costing about a screenful:
+
+    overview(scan)                        which locations carry signal, how strong
+    drill(scan, location)                 that location, grouped by finding kind
+    drill(scan, location, kind=...)       the individual findings of one kind
+    explain(scan, finding_id)             one finding, with its evidence table
+
+The contract that makes this safe is reachability: every finding is reachable
+through those layers, or named in the view's own `coverage`. A signal that is
+silently unreachable is no better than one that was never detected.
+
+These functions are pure reads — they never write, and never mutate the scan.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from ._workflow import _build_clusters
+
+# Kept generous: these are read straight into a reviewer's context, and the
+# limit exists to bound a pathological scan, not to curate.
+DEFAULT_MAX_LOCATIONS = 20
+DEFAULT_MAX_FINDINGS = 50
+
+
+def _location_label(cluster: dict[str, Any]) -> str:
+    if cluster["scope"] == "cross_sheet":
+        return f'{cluster["file"]} :: {cluster["sheet"]}'
+    where = f'{cluster["file"]} :: {cluster["sheet"]}'
+    if cluster.get("block_rows"):
+        where += f' rows {cluster["block_rows"]}'
+    if cluster.get("block_cols"):
+        where += f' cols {cluster["block_cols"]}'
+    return where
+
+
+def _clusters_of(scan: dict[str, Any]) -> list[dict[str, Any]]:
+    """Every cluster, unbounded. Truncation is a presentation choice made by the
+    caller, so it can be reported — not something baked into the grouping."""
+    clusters, _ = _build_clusters(scan, max_clusters=10**9)
+    return clusters
+
+
+def _families(cluster: dict[str, Any]) -> list[str]:
+    seen: list[str] = []
+    for seed in cluster["seeds"]:
+        if seed["kind"] and seed["kind"] not in seen:
+            seen.append(seed["kind"])
+    return seen
+
+
+# ---------- L1 ----------
+
+def overview(scan: dict[str, Any], *,
+             max_locations: int = DEFAULT_MAX_LOCATIONS) -> dict[str, Any]:
+    """Which locations carry signal, how strong, and of what kinds."""
+    clusters = _clusters_of(scan)
+    shown, hidden = clusters[:max_locations], clusters[max_locations:]
+
+    locations = []
+    for i, cluster in enumerate(shown, 1):
+        locations.append({
+            "n": i,
+            "cluster_id": cluster["cluster_id"],
+            "scope": cluster["scope"],
+            "location": _location_label(cluster),
+            "strongest": cluster["strongest_raw_severity"],
+            "signals": len(cluster["seeds"]),
+            "high": cluster["n_high_seeds"],
+            "families": _families(cluster),
+        })
+
+    hidden_signals = sum(len(c["seeds"]) for c in hidden)
+    limitations = []
+    if hidden:
+        limitations.append(
+            f"{len(hidden)} lower-ranked locations ({hidden_signals} signals) are not "
+            f"listed; raise max_locations above {max_locations} to see them"
+        )
+
+    return {
+        "files": scan.get("n_files"),
+        "locations": locations,
+        "signals_total": sum(len(c["seeds"]) for c in clusters),
+        "coverage": {
+            "locations_total": len(clusters),
+            "locations_not_shown": len(hidden),
+            "signals_not_shown": hidden_signals,
+            "limitations": limitations,
+        },
+    }
+
+
+# ---------- L2 / L3 ----------
+
+def _resolve(clusters: list[dict[str, Any]], location: int | str) -> dict[str, Any]:
+    if isinstance(location, int):
+        if 1 <= location <= len(clusters):
+            return clusters[location - 1]
+    else:
+        for cluster in clusters:
+            if cluster["cluster_id"] == location:
+                return cluster
+    raise ValueError(
+        f"no such location: {location!r}; run overview() to list them"
+    )
+
+
+def drill(scan: dict[str, Any], location: int | str, *, kind: str | None = None,
+          max_findings: int = DEFAULT_MAX_FINDINGS) -> dict[str, Any]:
+    """One location — grouped by kind, or listing the findings of a single kind."""
+    cluster = _resolve(_clusters_of(scan), location)
+    label = _location_label(cluster)
+
+    if kind is None:
+        groups: dict[str, list[dict[str, Any]]] = {}
+        for seed in cluster["seeds"]:
+            groups.setdefault(seed["kind"] or "?", []).append(seed)
+        by_kind = [
+            {
+                "kind": k,
+                "n": len(v),
+                "high": sum(1 for s in v if s["raw_severity"] == "high"),
+                # a concrete instance, so the group can be judged without opening it
+                "example": v[0].get("rule") or "",
+            }
+            for k, v in sorted(groups.items(), key=lambda kv: (-len(kv[1]), kv[0]))
+        ]
+        return {
+            "cluster_id": cluster["cluster_id"],
+            "location": label,
+            "scope": cluster["scope"],
+            "signals": len(cluster["seeds"]),
+            "by_kind": by_kind,
+        }
+
+    matching = [s for s in cluster["seeds"] if (s["kind"] or "?") == kind]
+    shown = matching[:max_findings]
+    limitations = []
+    if len(shown) < len(matching):
+        limitations.append(
+            f"showing {len(shown)} of {len(matching)}; raise max_findings to see the rest"
+        )
+    return {
+        "cluster_id": cluster["cluster_id"],
+        "location": label,
+        "kind": kind,
+        "findings": [
+            {
+                "finding_id": s["seed_id"],
+                "kind": s["kind"],
+                "severity": s["raw_severity"],
+                "rule": s.get("rule"),
+                "n": s.get("n"),
+            }
+            for s in shown
+        ],
+        "coverage": {
+            "total": len(matching),
+            "shown": len(shown),
+            "limitations": limitations,
+        },
+    }
+
+
+# ---------- L4 ----------
+
+def _iter_findings_with_seeds(scan: dict[str, Any]):
+    for cluster in _clusters_of(scan):
+        for seed in cluster["seeds"]:
+            yield cluster, seed
+
+
+def _match_raw_finding(scan: dict[str, Any], seed: dict[str, Any]) -> dict[str, Any] | None:
+    """Find the scan finding a seed was derived from, to recover its evidence."""
+    from ._finding_groups import BLOCK_FINDING_GROUPS
+
+    if seed["scope"] == "cross_sheet":
+        for f in scan.get("cross_sheet_findings") or []:
+            if f.get("kind") == seed["kind"] and f.get("rule") == seed.get("rule"):
+                return f
+        return None
+    for blk in scan.get("relations_blocks") or []:
+        if blk.get("file") != seed["file"] or blk.get("sheet") != seed["sheet"]:
+            continue
+        if (blk.get("block") or {}).get("rows") != seed["block_rows"]:
+            continue
+        for group in BLOCK_FINDING_GROUPS:
+            for f in blk.get(group) or []:
+                if f.get("kind") == seed["kind"] and f.get("rule") == seed.get("rule"):
+                    return f
+    return None
+
+
+# Fields that are presentation or bookkeeping rather than the finding's own
+# numbers; everything else is surfaced as a parameter so nothing is hidden.
+_NON_PARAMETER_KEYS = {
+    "kind", "rule", "severity", "raw_severity", "profile_action",
+    "false_positive_context", "evidence", "likely_benign",
+}
+
+# A demotion can come from four places and each leaves a different trace:
+# the profile guards write false_positive_context, two flood demoters write
+# prefilter_reason, and the dense-relation demoter writes only a bare flag.
+# Reading one field would silently lose three of them — and a finding shown as
+# demoted with no reason is exactly the shape a real signal disappears in.
+_FLAG_REASONS = {
+    "dense_block": "one of many pairwise relations in a dense block; "
+                   "down-weighted so a dense matrix does not dominate",
+    "reused_progression": "this progression repeats elsewhere, so it reads as a "
+                          "shared axis rather than measured data",
+    "within_col_flood_sheet": "one of many within-column findings on this sheet",
+}
+
+
+def _demotion_reasons(raw: dict[str, Any]) -> list[str]:
+    """Every recorded reason this finding was down-weighted, from any source."""
+    reasons: list[str] = []
+    for ctx in raw.get("false_positive_context") or []:
+        reasons.append(str(ctx))
+    for flag, text in _FLAG_REASONS.items():
+        if raw.get(flag):
+            reasons.append(text)
+    reason = raw.get("prefilter_reason")
+    if reason and str(reason) not in reasons:
+        reasons.append(str(reason))
+    return reasons
+
+
+def explain(scan: dict[str, Any], finding_id: str) -> dict[str, Any]:
+    """One finding in full: parameters, evidence, and how a profile treated it."""
+    for cluster, seed in _iter_findings_with_seeds(scan):
+        if seed["seed_id"] != finding_id:
+            continue
+        raw = _match_raw_finding(scan, seed) or {}
+        return {
+            "finding_id": finding_id,
+            "kind": seed["kind"],
+            "location": _location_label(cluster),
+            "cluster_id": cluster["cluster_id"],
+            "rule": seed.get("rule") or raw.get("rule"),
+            "severity": {
+                # raw is what the detector produced; effective is what the
+                # display profile projected. Showing both means a demotion can
+                # be reviewed rather than silently taken on trust.
+                "raw": seed["raw_severity"],
+                "effective": raw.get("severity", seed["raw_severity"]),
+                "profile_action": raw.get("profile_action", "kept"),
+                "context": _demotion_reasons(raw),
+                "likely_benign": raw.get("likely_benign"),
+            },
+            "parameters": {
+                k: v for k, v in raw.items() if k not in _NON_PARAMETER_KEYS
+            },
+            "evidence": raw.get("evidence"),
+        }
+    raise ValueError(f"no such finding: {finding_id!r}; run drill() to list them")

--- a/src/paperconan/_drill.py
+++ b/src/paperconan/_drill.py
@@ -195,7 +195,10 @@ def drill(scan: dict[str, Any], location: int | str, *, kind: str | None = None,
         "coverage": {
             "total": len(matching),
             "shown": len(shown),
-            "limitations": limitations,
+            # scan-wide caveats belong here too: this is the layer where a
+            # reader concludes "that is all of them", so it is where a silently
+            # capped detector or an unrouted family matters most.
+            "limitations": limitations + list(_seeding.get("limitations") or []),
         },
     }
 

--- a/src/paperconan/_drill.py
+++ b/src/paperconan/_drill.py
@@ -23,7 +23,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from ._workflow import _build_clusters
+from ._finding_groups import BLOCK_FINDING_GROUPS
+from ._workflow import _block_seed, _build_clusters, _cross_sheet_seed
 
 # Kept generous: these are read straight into a reviewer's context, and the
 # limit exists to bound a pathological scan, not to curate.
@@ -42,11 +43,16 @@ def _location_label(cluster: dict[str, Any]) -> str:
     return where
 
 
-def _clusters_of(scan: dict[str, Any]) -> list[dict[str, Any]]:
-    """Every cluster, unbounded. Truncation is a presentation choice made by the
-    caller, so it can be reported — not something baked into the grouping."""
-    clusters, _ = _build_clusters(scan, max_clusters=10**9)
-    return clusters
+def _clusters_of(scan: dict[str, Any]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Every cluster plus what the seeding layer already knows it could not cover.
+
+    That second value is not optional bookkeeping. It carries the upstream
+    finding caps, an incomplete scan, the families this layer does not route, and
+    the detector-level caps nothing reports — i.e. most of the ways a real signal
+    fails to reach the reader. Discarding it here made `overview` print an empty
+    `limitations` list on a scan where thousands of findings had been dropped.
+    """
+    return _build_clusters(scan, max_clusters=10**9)
 
 
 def _families(cluster: dict[str, Any]) -> list[str]:
@@ -62,7 +68,8 @@ def _families(cluster: dict[str, Any]) -> list[str]:
 def overview(scan: dict[str, Any], *,
              max_locations: int = DEFAULT_MAX_LOCATIONS) -> dict[str, Any]:
     """Which locations carry signal, how strong, and of what kinds."""
-    clusters = _clusters_of(scan)
+    clusters, seeding = _clusters_of(scan)
+    max_locations = max(0, max_locations)
     shown, hidden = clusters[:max_locations], clusters[max_locations:]
 
     locations = []
@@ -79,7 +86,10 @@ def overview(scan: dict[str, Any], *,
         })
 
     hidden_signals = sum(len(c["seeds"]) for c in hidden)
-    limitations = []
+    # Everything the seeding layer already declared, then what this layer itself
+    # holds back. Both have to reach the reader, or "read coverage" is advice
+    # about a field that does not say anything.
+    limitations = list(seeding.get("limitations") or [])
     if hidden:
         limitations.append(
             f"{len(hidden)} lower-ranked locations ({hidden_signals} signals) are not "
@@ -94,6 +104,11 @@ def overview(scan: dict[str, Any], *,
             "locations_total": len(clusters),
             "locations_not_shown": len(hidden),
             "signals_not_shown": hidden_signals,
+            "families_not_seeded": seeding.get("families_not_seeded") or {},
+            "upstream_findings_omitted": seeding.get("upstream_findings_omitted", 0),
+            "scan_incomplete": seeding.get("scan_incomplete", False),
+            "detector_caps_reported": seeding.get("detector_caps_reported", False),
+            "complete": not limitations,
             "limitations": limitations,
         },
     }
@@ -117,7 +132,8 @@ def _resolve(clusters: list[dict[str, Any]], location: int | str) -> dict[str, A
 def drill(scan: dict[str, Any], location: int | str, *, kind: str | None = None,
           max_findings: int = DEFAULT_MAX_FINDINGS) -> dict[str, Any]:
     """One location — grouped by kind, or listing the findings of a single kind."""
-    cluster = _resolve(_clusters_of(scan), location)
+    clusters, _seeding = _clusters_of(scan)
+    cluster = _resolve(clusters, location)
     label = _location_label(cluster)
 
     if kind is None:
@@ -140,9 +156,22 @@ def drill(scan: dict[str, Any], location: int | str, *, kind: str | None = None,
             "scope": cluster["scope"],
             "signals": len(cluster["seeds"]),
             "by_kind": by_kind,
+            # every kind at this location is listed, but the scan-wide caveats
+            # still apply here — the reader is told to check coverage at each layer
+            "coverage": {
+                "kinds_total": len(by_kind),
+                "kinds_shown": len(by_kind),
+                "limitations": list(_seeding.get("limitations") or []),
+            },
         }
 
+    available = sorted({s["kind"] or "?" for s in cluster["seeds"]})
+    if kind not in available:
+        raise ValueError(
+            f"no such kind at this location: {kind!r}; available: {', '.join(available)}"
+        )
     matching = [s for s in cluster["seeds"] if (s["kind"] or "?") == kind]
+    max_findings = max(0, max_findings)
     shown = matching[:max_findings]
     limitations = []
     if len(shown) < len(matching):
@@ -174,28 +203,35 @@ def drill(scan: dict[str, Any], location: int | str, *, kind: str | None = None,
 # ---------- L4 ----------
 
 def _iter_findings_with_seeds(scan: dict[str, Any]):
-    for cluster in _clusters_of(scan):
+    clusters, _seeding = _clusters_of(scan)
+    for cluster in clusters:
         for seed in cluster["seeds"]:
             yield cluster, seed
 
 
 def _match_raw_finding(scan: dict[str, Any], seed: dict[str, Any]) -> dict[str, Any] | None:
-    """Find the scan finding a seed was derived from, to recover its evidence."""
-    from ._finding_groups import BLOCK_FINDING_GROUPS
+    """Recover the scan finding a seed came from, to show its evidence.
 
+    Matched on the same tuple `seed_id` is hashed from — anything weaker is not
+    injective where the id is, so `explain` would serve one finding's evidence
+    under another's heading. `rule` alone repeats readily: several detectors
+    build it from labels or omit the column index, so two side-by-side panels
+    produce byte-identical strings.
+    """
     if seed["scope"] == "cross_sheet":
         for f in scan.get("cross_sheet_findings") or []:
-            if f.get("kind") == seed["kind"] and f.get("rule") == seed.get("rule"):
+            if _cross_sheet_seed(f)["seed_id"] == seed["seed_id"]:
                 return f
         return None
     for blk in scan.get("relations_blocks") or []:
         if blk.get("file") != seed["file"] or blk.get("sheet") != seed["sheet"]:
             continue
-        if (blk.get("block") or {}).get("rows") != seed["block_rows"]:
+        block = blk.get("block") or {}
+        if block.get("rows") != seed["block_rows"] or block.get("cols") != seed["block_cols"]:
             continue
         for group in BLOCK_FINDING_GROUPS:
             for f in blk.get(group) or []:
-                if f.get("kind") == seed["kind"] and f.get("rule") == seed.get("rule"):
+                if _block_seed(blk, group, f)["seed_id"] == seed["seed_id"]:
                     return f
     return None
 

--- a/src/paperconan/_drill_render.py
+++ b/src/paperconan/_drill_render.py
@@ -43,7 +43,10 @@ def render_overview(view: dict[str, Any]) -> str:
         more = len(loc["families"]) - len(families)
         suffix = f", … {more} more" if more > 0 else ""
         out.append(f"      {', '.join(families)}{suffix}")
-    if not view["locations"]:
+    # Branch on the scan, not on this page: with --max-locations 0 the page is
+    # empty while the scan is not, and the all-clear text would contradict both
+    # the header and the coverage line on the same screen.
+    if not cov["locations_total"]:
         out.append("  (no locations carry signal)")
         out.append("")
         out.append("  This means these detectors found nothing at these thresholds in")
@@ -95,36 +98,70 @@ def render_drill(view: dict[str, Any]) -> str:
     return "\n".join(out)
 
 
+_EVIDENCE_ROW_LIMIT = 20
+
+
 def _render_evidence(ev: dict[str, Any] | None) -> list[str]:
+    """Render the evidence window.
+
+    Values are never clipped. This table exists so a reviewer can compare exact
+    digits against the paper, and a silently shortened number is worse than a
+    missing one — clipping to a fixed width turned -1.2345678e-100 into
+    -1.234567, wrong by a hundred orders of magnitude. Columns widen to fit
+    instead, and the row/column counts the scan itself trimmed are stated.
+    """
     if not ev or not ev.get("rows"):
         return ["  (no evidence table recorded)"]
-    headers = ev.get("headers") or []
+    headers = [str(h) for h in (ev.get("headers") or [])]
     hi_cols = {int(c) for c in ev.get("highlight_cols") or []}
     hi_rows = {int(r) for r in ev.get("highlight_rows") or []}
     col_offset = int(ev.get("col_offset") or 0)
+    rows = ev["rows"]
 
     def cell(v: Any) -> str:
         if v is None:
             return ""
         if isinstance(v, float):
-            return f"{v:.8g}"
+            # repr is Python's shortest round-tripping form: it never loses a
+            # digit the value actually has. A %g format silently rounds, which
+            # is the same defect as clipping — the reviewer is comparing digits.
+            return repr(v)
         return str(v)
 
-    widths = [max(9, len(str(h))) for h in headers]
+    shown = rows[:_EVIDENCE_ROW_LIMIT]
+    # A row may carry more values than there are headers; widen rather than zip
+    # them away, or whole columns vanish with no trace.
+    n_cols = max([len(headers)] + [len(r.get("values") or []) for r in shown] or [0])
+    labels = [headers[i] if i < len(headers) else f"col {col_offset + i + 1}"
+              for i in range(n_cols)]
+    widths = [
+        max(len(labels[i]), *(len(cell((r.get("values") or [None] * n_cols)[i]))
+                              for r in shown) if shown else 0, 3)
+        if n_cols else 0
+        for i in range(n_cols)
+    ]
+
     head = "  row │ " + " ".join(
-        f"{str(h)[:w]:>{w}}" + ("*" if col_offset + i in hi_cols else " ")
-        for i, (h, w) in enumerate(zip(headers, widths))
+        f"{labels[i]:>{widths[i]}}" + ("*" if col_offset + i in hi_cols else " ")
+        for i in range(n_cols)
     )
-    out = [head, "  " + _rule(len(head))]
-    for row in ev["rows"][:20]:
+    out = [head, "  " + _rule(min(len(head), 200))]
+    for row in shown:
         idx = int(row.get("row_idx") or 0)
         mark = "▸" if idx in hi_rows else " "
+        values = row.get("values") or []
         cells = " ".join(
-            f"{cell(v)[:w]:>{w}} " for v, w in zip(row.get("values") or [], widths)
+            f"{cell(values[i]) if i < len(values) else '':>{widths[i]}} "
+            for i in range(n_cols)
         )
         out.append(f"{mark} {idx:>3} │ {cells}")
-    if len(ev["rows"]) > 20:
-        out.append(f"  … {len(ev['rows']) - 20} more rows")
+    if len(rows) > _EVIDENCE_ROW_LIMIT:
+        out.append(f"  … {len(rows) - _EVIDENCE_ROW_LIMIT} more rows in this window")
+    if ev.get("truncated"):
+        # The scan clipped the window before it ever reached here, so the table
+        # above is not the whole block.
+        out.append("  ! this evidence window was trimmed by the scan; it does not "
+                   "show the full block")
     out.append("  (* highlighted column, ▸ highlighted row)")
     return out
 

--- a/src/paperconan/_drill_render.py
+++ b/src/paperconan/_drill_render.py
@@ -131,21 +131,27 @@ def _render_evidence(ev: dict[str, Any] | None) -> list[str]:
     shown = rows[:_EVIDENCE_ROW_LIMIT]
     # A row may carry more values than there are headers; widen rather than zip
     # them away, or whole columns vanish with no trace.
-    n_cols = max([len(headers)] + [len(r.get("values") or []) for r in shown] or [0])
+    n_cols = max([len(headers)] + [len(r.get("values") or []) for r in shown])
     labels = [headers[i] if i < len(headers) else f"col {col_offset + i + 1}"
               for i in range(n_cols)]
-    widths = [
-        max(len(labels[i]), *(len(cell((r.get("values") or [None] * n_cols)[i]))
-                              for r in shown) if shown else 0, 3)
-        if n_cols else 0
-        for i in range(n_cols)
-    ]
+
+    # Plain loop, not a comprehension: rows may be ragged, and indexing past a
+    # short row here is how the widths pass crashed while the render loop below
+    # (which has the same guard) was fine.
+    widths = []
+    for i in range(n_cols):
+        width = max(len(labels[i]), 3)
+        for row in shown:
+            values = row.get("values") or []
+            if i < len(values):
+                width = max(width, len(cell(values[i])))
+        widths.append(width)
 
     head = "  row │ " + " ".join(
         f"{labels[i]:>{widths[i]}}" + ("*" if col_offset + i in hi_cols else " ")
         for i in range(n_cols)
     )
-    out = [head, "  " + _rule(min(len(head), 200))]
+    out = [head, "  " + _rule(len(head))]
     for row in shown:
         idx = int(row.get("row_idx") or 0)
         mark = "▸" if idx in hi_rows else " "

--- a/src/paperconan/_drill_render.py
+++ b/src/paperconan/_drill_render.py
@@ -1,0 +1,150 @@
+"""Text rendering for the layered views.
+
+Each layer ends by naming the command for the next one. A reviewer reading these
+in sequence should never have to guess the syntax, and an agent should be able to
+follow the trail without the protocol being restated in its prompt.
+
+Wording stays neutral throughout: these are statistical signals and unexplained
+inconsistencies awaiting an author's clarification, never accusations.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def _rule(width: int = 78) -> str:
+    return "─" * width
+
+
+def _coverage_lines(coverage: dict[str, Any], indent: str = "") -> list[str]:
+    return [f"{indent}! {item}" for item in coverage.get("limitations") or []]
+
+
+def render_overview(view: dict[str, Any]) -> str:
+    cov = view["coverage"]
+    out = [
+        f"{view['signals_total']} signals across {cov['locations_total']} locations"
+        f" in {view.get('files') or '?'} file(s)",
+        "",
+        f"  {'#':>2}  {'location':<46} {'strongest':>9} {'signals':>8}",
+        f"  {_rule(70)}",
+    ]
+    for loc in view["locations"]:
+        label = loc["location"]
+        if len(label) > 46:
+            label = "…" + label[-45:]
+        out.append(
+            f"  {loc['n']:>2}  {label:<46} {loc['strongest']:>9} "
+            f"{loc['signals']:>8}"
+        )
+        out.append(f"      {', '.join(loc['families'][:4])}")
+    out.append("")
+    out += _coverage_lines(cov)
+    if cov.get("limitations"):
+        out.append("")
+    out.append("next: paperconan drill <scan.json> <#>")
+    return "\n".join(out)
+
+
+def render_drill(view: dict[str, Any]) -> str:
+    if "by_kind" in view:
+        out = [
+            view["location"],
+            f"{view['signals']} signals",
+            "",
+            f"  {'kind':<34} {'n':>5} {'high':>5}  example",
+            f"  {_rule(74)}",
+        ]
+        for group in view["by_kind"]:
+            example = group["example"]
+            if len(example) > 40:
+                example = example[:39] + "…"
+            out.append(
+                f"  {group['kind']:<34} {group['n']:>5} {group['high']:>5}  {example}"
+            )
+        out.append("")
+        out.append("next: paperconan drill <scan.json> <#> --kind <kind>")
+        return "\n".join(out)
+
+    out = [
+        f"{view['location']} · {view['kind']}",
+        f"{view['coverage']['shown']} of {view['coverage']['total']} shown",
+        "",
+    ]
+    for f in view["findings"]:
+        out.append(f"  [{f['severity']}] {f['rule'] or f['kind']}")
+        out.append(f"      {f['finding_id']}")
+    out.append("")
+    out += _coverage_lines(view["coverage"])
+    if view["coverage"].get("limitations"):
+        out.append("")
+    out.append("next: paperconan explain <scan.json> <finding_id>")
+    return "\n".join(out)
+
+
+def _render_evidence(ev: dict[str, Any] | None) -> list[str]:
+    if not ev or not ev.get("rows"):
+        return ["  (no evidence table recorded)"]
+    headers = ev.get("headers") or []
+    hi_cols = {int(c) for c in ev.get("highlight_cols") or []}
+    hi_rows = {int(r) for r in ev.get("highlight_rows") or []}
+    col_offset = int(ev.get("col_offset") or 0)
+
+    def cell(v: Any) -> str:
+        if v is None:
+            return ""
+        if isinstance(v, float):
+            return f"{v:.8g}"
+        return str(v)
+
+    widths = [max(9, len(str(h))) for h in headers]
+    head = "  row │ " + " ".join(
+        f"{str(h)[:w]:>{w}}" + ("*" if col_offset + i in hi_cols else " ")
+        for i, (h, w) in enumerate(zip(headers, widths))
+    )
+    out = [head, "  " + _rule(len(head))]
+    for row in ev["rows"][:20]:
+        idx = int(row.get("row_idx") or 0)
+        mark = "▸" if idx in hi_rows else " "
+        cells = " ".join(
+            f"{cell(v)[:w]:>{w}} " for v, w in zip(row.get("values") or [], widths)
+        )
+        out.append(f"{mark} {idx:>3} │ {cells}")
+    if len(ev["rows"]) > 20:
+        out.append(f"  … {len(ev['rows']) - 20} more rows")
+    out.append("  (* highlighted column, ▸ highlighted row)")
+    return out
+
+
+def render_explain(view: dict[str, Any]) -> str:
+    sev = view["severity"]
+    out = [
+        view["location"],
+        f"{view['kind']} · {view['finding_id']}",
+        "",
+        f"  rule:      {view['rule']}",
+        f"  severity:  detector={sev['raw']}  displayed={sev['effective']}"
+        f"  ({sev['profile_action']})",
+    ]
+    if sev["raw"] != sev["effective"]:
+        # A demotion is a judgement the reviewer may want to overturn, so the
+        # reason has to travel with it rather than being implied by the number.
+        out.append("  down-weighted because:")
+        for reason in sev["context"] or ["(no reason recorded)"]:
+            out.append(f"      · {reason}")
+        if sev.get("likely_benign"):
+            out.append(f"      · {sev['likely_benign']}")
+    params = {k: v for k, v in (view.get("parameters") or {}).items()
+              if not isinstance(v, (list, dict))}
+    if params:
+        out.append("  parameters:")
+        for k, v in sorted(params.items()):
+            out.append(f"      {k} = {v}")
+    out.append("")
+    out.append("  evidence:")
+    out += _render_evidence(view.get("evidence"))
+    out.append("")
+    out.append("This is a statistical signal, not a conclusion. Confirm against the "
+               "original records,")
+    out.append("figure legends and Methods before drawing any inference.")
+    return "\n".join(out)

--- a/src/paperconan/_drill_render.py
+++ b/src/paperconan/_drill_render.py
@@ -26,18 +26,28 @@ def render_overview(view: dict[str, Any]) -> str:
         f"{view['signals_total']} signals across {cov['locations_total']} locations"
         f" in {view.get('files') or '?'} file(s)",
         "",
-        f"  {'#':>2}  {'location':<46} {'strongest':>9} {'signals':>8}",
-        f"  {_rule(70)}",
+        f"  {'#':>2}  {'location':<44} {'strongest':>9} {'signals':>8} {'high':>6}",
+        f"  {_rule(78)}",
     ]
     for loc in view["locations"]:
         label = loc["location"]
-        if len(label) > 46:
-            label = "…" + label[-45:]
+        if len(label) > 44:
+            label = "…" + label[-43:]
         out.append(
-            f"  {loc['n']:>2}  {label:<46} {loc['strongest']:>9} "
-            f"{loc['signals']:>8}"
+            f"  {loc['n']:>2}  {label:<44} {loc['strongest']:>9} "
+            f"{loc['signals']:>8} {loc['high']:>6}"
         )
-        out.append(f"      {', '.join(loc['families'][:4])}")
+        families = loc["families"][:4]
+        # say when the list is cut, rather than quietly dropping the tail in the
+        # one layer whose job is to declare what it left out
+        more = len(loc["families"]) - len(families)
+        suffix = f", … {more} more" if more > 0 else ""
+        out.append(f"      {', '.join(families)}{suffix}")
+    if not view["locations"]:
+        out.append("  (no locations carry signal)")
+        out.append("")
+        out.append("  This means these detectors found nothing at these thresholds in")
+        out.append("  the data supplied — not that the paper is free of problems.")
     out.append("")
     out += _coverage_lines(cov)
     if cov.get("limitations"):
@@ -63,6 +73,9 @@ def render_drill(view: dict[str, Any]) -> str:
                 f"  {group['kind']:<34} {group['n']:>5} {group['high']:>5}  {example}"
             )
         out.append("")
+        out += _coverage_lines(view.get("coverage") or {})
+        if (view.get("coverage") or {}).get("limitations"):
+            out.append("")
         out.append("next: paperconan drill <scan.json> <#> --kind <kind>")
         return "\n".join(out)
 

--- a/src/paperconan/_drill_render.py
+++ b/src/paperconan/_drill_render.py
@@ -147,12 +147,18 @@ def render_explain(view: dict[str, Any]) -> str:
             out.append(f"      · {reason}")
         if sev.get("likely_benign"):
             out.append(f"      · {sev['likely_benign']}")
-    params = {k: v for k, v in (view.get("parameters") or {}).items()
-              if not isinstance(v, (list, dict))}
+    all_params = view.get("parameters") or {}
+    params = {k: v for k, v in all_params.items() if not isinstance(v, (list, dict))}
     if params:
         out.append("  parameters:")
         for k, v in sorted(params.items()):
             out.append(f"      {k} = {v}")
+    # Sample values and prefilter flags live in list/dict parameters — exactly
+    # what a reviewer checks against the paper. Naming them beats dropping them.
+    structured = sorted(set(all_params) - set(params))
+    if structured:
+        out.append(f"      … {len(structured)} structured parameter(s) not shown "
+                   f"({', '.join(structured)}); use --json")
     out.append("")
     out.append("  evidence:")
     out += _render_evidence(view.get("evidence"))

--- a/src/paperconan/_workflow.py
+++ b/src/paperconan/_workflow.py
@@ -390,7 +390,10 @@ def _coverage_for(scan, seeds, clusters, omitted, max_clusters) -> dict[str, Any
         if scan.get(family)
     }
     for family, count in unseeded.items():
-        limitations.append(f"{count} {family} are not seeded by the Phase 1 workflow")
+        limitations.append(
+            f"{count} {family} are present in the scan but this view does not route "
+            "them; read them from scan.json directly"
+        )
 
     if omitted:
         limitations.append(

--- a/tests/test_drill.py
+++ b/tests/test_drill.py
@@ -1,0 +1,303 @@
+"""Layered read-only views over a scan: overview → drill → explain.
+
+A single paper's supplement can produce thousands of findings and a multi-MB
+scan.json — far past what an agent can hold, and past what a human wants to read
+in one go. Tightening the detectors to shrink that would drop real signals, so
+the layering happens at presentation instead: nothing is filtered out, it is
+just reached in stages.
+
+The contract these tests pin is reachability. Every finding in the scan must be
+reachable through the three layers, or be named in `coverage` as not shown.
+A signal that is silently unreachable is the same defect as a signal that was
+never detected.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from paperconan import BLOCK_FINDING_GROUPS, scan_dir
+from paperconan._drill import drill, explain, overview
+
+
+@pytest.fixture(scope="module")
+def scan(tmp_path_factory):
+    """One synthetic paper with several panels and a cross-file duplicate."""
+    d = tmp_path_factory.mktemp("data")
+    for f in range(3):
+        cols = [f"c{j}" for j in range(8)]
+        rows = [",".join(cols)]
+        for i in range(30):
+            vals = [round((i + 1) * (j + 1) * (f + 1) * 1.017, 6) for j in range(8)]
+            vals[5] = vals[2]                      # identical column
+            vals[6] = round(vals[3] * 1.13, 6)     # constant ratio
+            rows.append(",".join(str(v) for v in vals))
+        (d / f"supp{f}.csv").write_text("\n".join(rows) + "\n", encoding="utf-8")
+    return scan_dir(str(d), str(d.parent / "out"), write_html=False)
+
+
+def _all_finding_count(scan):
+    n = sum(len(b.get(g) or []) for b in scan.get("relations_blocks") or []
+            for g in BLOCK_FINDING_GROUPS)
+    return n + len(scan.get("cross_sheet_findings") or [])
+
+
+# ---------- L1 overview ----------
+
+def test_overview_fits_in_a_glance(scan):
+    view = overview(scan)
+
+    assert len(json.dumps(view)) < 4096, "overview must stay small enough to read at once"
+    assert view["locations"], "expected at least one location"
+    assert view["signals_total"] == _all_finding_count(scan)
+
+
+def test_overview_names_the_families_at_each_location(scan):
+    """Lets an agent judge at the cheapest layer whether a location is worth opening."""
+    view = overview(scan)
+
+    for loc in view["locations"]:
+        assert loc["families"], f"{loc['location']} lists no families"
+        assert loc["signals"] > 0
+        assert loc["strongest"] in ("high", "medium", "low")
+
+
+def test_overview_is_read_only(scan):
+    before = json.dumps(scan, sort_keys=True)
+
+    overview(scan)
+
+    assert json.dumps(scan, sort_keys=True) == before
+
+
+# ---------- L2 / L3 drill ----------
+
+def test_drill_groups_a_location_by_kind(scan):
+    view = overview(scan)
+
+    detail = drill(scan, view["locations"][0]["n"])
+
+    assert detail["by_kind"], "expected kind groups"
+    assert sum(k["n"] for k in detail["by_kind"]) == view["locations"][0]["signals"]
+    for group in detail["by_kind"]:
+        assert group["example"], "each kind needs a concrete example to judge from"
+
+
+def test_drill_into_a_kind_lists_its_findings(scan):
+    view = overview(scan)
+    first = view["locations"][0]
+    kind = drill(scan, first["n"])["by_kind"][0]["kind"]
+
+    listing = drill(scan, first["n"], kind=kind)
+
+    assert listing["findings"]
+    assert all(f["finding_id"] for f in listing["findings"])
+    assert all(f["kind"] == kind for f in listing["findings"])
+
+
+def test_drill_accepts_a_cluster_id_as_well_as_an_ordinal(scan):
+    view = overview(scan)
+    loc = view["locations"][0]
+
+    assert drill(scan, loc["n"]) == drill(scan, loc["cluster_id"])
+
+
+def test_drill_rejects_an_unknown_location(scan):
+    with pytest.raises(ValueError, match="no such location"):
+        drill(scan, 9999)
+
+
+# ---------- L4 explain ----------
+
+def test_explain_returns_the_full_evidence_for_one_finding(scan):
+    view = overview(scan)
+    first = view["locations"][0]
+    kind = drill(scan, first["n"])["by_kind"][0]["kind"]
+    fid = drill(scan, first["n"], kind=kind)["findings"][0]["finding_id"]
+
+    detail = explain(scan, fid)
+
+    assert detail["finding_id"] == fid
+    assert detail["rule"]
+    assert "location" in detail
+    assert "evidence" in detail
+
+
+def test_explain_separates_raw_severity_from_the_projected_one(scan):
+    """The whole point of freezing raw_severity: a demoted finding must still be
+    recognisable as something the detector rated highly, with the reason shown,
+    so a profile decision never silently buries a real signal."""
+    view = overview(scan)
+    fids = [
+        f["finding_id"]
+        for loc in view["locations"]
+        for group in drill(scan, loc["n"])["by_kind"]
+        for f in drill(scan, loc["n"], kind=group["kind"])["findings"]
+    ]
+
+    details = [explain(scan, fid) for fid in fids]
+
+    assert details, "fixture produced no findings"
+    for d in details:
+        assert "raw" in d["severity"] and "effective" in d["severity"]
+        assert "profile_action" in d["severity"]
+        if d["severity"]["raw"] != d["severity"]["effective"]:
+            assert d["severity"]["context"], (
+                "a demoted finding must say why it was demoted"
+            )
+
+
+def test_explain_rejects_an_unknown_finding(scan):
+    with pytest.raises(ValueError, match="no such finding"):
+        explain(scan, "seed:doesnotexist")
+
+
+# ---------- the reachability contract ----------
+
+def test_every_finding_is_reachable_or_declared(scan):
+    """No signal may be lost between the layers.
+
+    Walk overview → drill → drill(kind) and collect everything reachable. The
+    total must account for every finding in the scan: either reachable, or
+    counted in the coverage the view itself reports.
+    """
+    view = overview(scan)
+
+    reached = set()
+    declared = view["coverage"]["signals_not_shown"]
+    for loc in view["locations"]:
+        for group in drill(scan, loc["n"])["by_kind"]:
+            listing = drill(scan, loc["n"], kind=group["kind"])
+            reached.update(f["finding_id"] for f in listing["findings"])
+            hidden = listing["coverage"]["total"] - listing["coverage"]["shown"]
+            if hidden:
+                # a truncated listing must say so, and counts as declared
+                assert listing["coverage"]["limitations"]
+                declared += hidden
+
+    assert len(reached) + declared == view["signals_total"], (
+        f"{view['signals_total'] - len(reached) - declared} findings are neither "
+        "reachable nor declared missing"
+    )
+
+
+def test_raising_the_limit_actually_reaches_the_declared_remainder(scan):
+    """"Declared but not shown" is only acceptable if it is genuinely reachable."""
+    view = overview(scan)
+    loc = view["locations"][0]
+    biggest = max(drill(scan, loc["n"])["by_kind"], key=lambda g: g["n"])
+
+    capped = drill(scan, loc["n"], kind=biggest["kind"], max_findings=1)
+    full = drill(scan, loc["n"], kind=biggest["kind"], max_findings=10**6)
+
+    assert capped["coverage"]["shown"] == 1
+    assert full["coverage"]["shown"] == full["coverage"]["total"] == biggest["n"]
+    assert not full["coverage"]["limitations"]
+
+
+def test_a_truncated_overview_declares_what_it_left_out(scan):
+    view = overview(scan, max_locations=1)
+
+    assert len(view["locations"]) == 1
+    assert view["coverage"]["locations_not_shown"] > 0
+    assert view["coverage"]["signals_not_shown"] > 0
+    assert view["coverage"]["limitations"]
+
+
+def test_the_views_are_deterministic(scan):
+    assert overview(scan) == overview(scan)
+    assert drill(scan, 1) == drill(scan, 1)
+
+
+def test_a_demotion_from_any_source_carries_its_reason(scan):
+    """Demotions are recorded in four different places by four code paths.
+
+    Reading only `false_positive_context` would show three of them as demoted
+    with no reason — and a strong signal shown as 'low' with no explanation is
+    how a real finding gets dismissed.
+    """
+    from paperconan._drill import _demotion_reasons
+
+    assert _demotion_reasons({"false_positive_context": ["axis_or_scan_column"]})
+    assert _demotion_reasons({"dense_block": True})
+    assert _demotion_reasons({"reused_progression": True})
+    assert _demotion_reasons({"within_col_flood_sheet": True})
+    assert _demotion_reasons({"prefilter_reason": "within_col_sheet_flood"})
+    assert _demotion_reasons({}) == []
+
+
+# ---------- CLI ----------
+
+def _cli(*args, cwd=None):
+    import subprocess
+    import sys
+    return subprocess.run([sys.executable, "-m", "paperconan", *args],
+                          text=True, capture_output=True, cwd=cwd)
+
+
+@pytest.fixture(scope="module")
+def scan_path(scan, tmp_path_factory):
+    p = tmp_path_factory.mktemp("cli") / "scan.json"
+    p.write_text(json.dumps(scan), encoding="utf-8")
+    return str(p)
+
+
+def test_cli_walks_the_three_layers(scan_path):
+    ov = _cli("overview", scan_path)
+    assert ov.returncode == 0, ov.stderr
+    assert "next: paperconan drill" in ov.stdout
+
+    dr = _cli("drill", scan_path, "1")
+    assert dr.returncode == 0, dr.stderr
+    assert "next: paperconan drill" in dr.stdout and "--kind" in dr.stdout
+
+    kind = drill(json.loads(open(scan_path).read()), 1)["by_kind"][0]["kind"]
+    lst = _cli("drill", scan_path, "1", "--kind", kind)
+    assert lst.returncode == 0, lst.stderr
+    assert "next: paperconan explain" in lst.stdout
+
+    fid = [ln.strip() for ln in lst.stdout.splitlines() if ln.strip().startswith("seed:")][0]
+    ex = _cli("explain", scan_path, fid)
+    assert ex.returncode == 0, ex.stderr
+    assert "evidence:" in ex.stdout
+
+
+def test_cli_explain_states_that_a_signal_is_not_a_conclusion(scan_path):
+    kind = drill(json.loads(open(scan_path).read()), 1)["by_kind"][0]["kind"]
+    lst = _cli("drill", scan_path, "1", "--kind", kind)
+    fid = [ln.strip() for ln in lst.stdout.splitlines() if ln.strip().startswith("seed:")][0]
+
+    out = _cli("explain", scan_path, fid).stdout
+
+    assert "statistical signal, not a conclusion" in out
+
+
+def test_cli_json_mode_emits_the_structure(scan_path):
+    res = _cli("overview", scan_path, "--json")
+
+    assert res.returncode == 0, res.stderr
+    assert json.loads(res.stdout)["locations"]
+
+
+@pytest.mark.parametrize("args", [
+    ("drill", "9999"),
+    ("explain", "seed:nope"),
+])
+def test_cli_unknown_reference_exits_with_a_message_not_a_traceback(scan_path, args):
+    res = _cli(args[0], scan_path, args[1])
+
+    assert res.returncode != 0
+    assert "Traceback" not in res.stderr
+    assert "no such" in (res.stderr + res.stdout)
+
+
+def test_cli_rejects_a_scan_that_is_not_json(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+
+    res = _cli("overview", str(bad))
+
+    assert res.returncode != 0
+    assert "Traceback" not in res.stderr
+    assert "not valid JSON" in (res.stderr + res.stdout)

--- a/tests/test_drill.py
+++ b/tests/test_drill.py
@@ -249,6 +249,124 @@ def test_match_is_keyed_on_the_same_tuple_as_the_seed_id():
     )
 
 
+def test_explain_renders_the_actual_evidence_numbers(scan):
+    """C1: the evidence payload had no test at all.
+
+    `"evidence" in detail` is satisfied by None, and `"evidence:" in stdout` is
+    the heading, printed unconditionally. Neither notices if the table is empty,
+    truncated to one row, or never rendered — in the layer whose whole purpose is
+    letting a reviewer compare exact digits against the paper.
+    """
+    from paperconan._drill_render import render_explain
+
+    view = overview(scan)
+    detailed = None
+    for loc in view["locations"]:
+        for group in drill(scan, loc["n"])["by_kind"]:
+            for f in drill(scan, loc["n"], kind=group["kind"])["findings"]:
+                d = explain(scan, f["finding_id"])
+                if (d.get("evidence") or {}).get("rows"):
+                    detailed = d
+                    break
+            if detailed:
+                break
+        if detailed:
+            break
+    assert detailed, "fixture produced no finding with an evidence table"
+
+    rows = detailed["evidence"]["rows"]
+    text = render_explain(detailed)
+
+    rendered_rows = [ln for ln in text.splitlines() if "│" in ln]
+    assert len(rendered_rows) >= min(len(rows), 5) + 1, (
+        "evidence table rendered fewer rows than it holds"
+    )
+    # actual recorded values must appear, not just the heading
+    checked = 0
+    for row in rows[:3]:
+        for value in (row.get("values") or [])[:3]:
+            if isinstance(value, float):
+                assert f"{value:.10g}"[:8] in text or repr(value)[:8] in text, (
+                    f"recorded value {value} does not appear in the rendered table"
+                )
+                checked += 1
+    assert checked, "no numeric cells were checked; fixture is unsuitable"
+
+
+def test_evidence_values_are_never_silently_shortened():
+    """A clipped number is worse than a missing one: this table exists so exact
+    digits can be compared against the paper."""
+    from paperconan._drill_render import _render_evidence
+
+    ev = {
+        "headers": ["a", "b"],
+        "col_offset": 0,
+        "rows": [{"row_idx": 2, "values": [-1.2345678e-100, 98765432.123456]}],
+    }
+
+    text = "\n".join(_render_evidence(ev))
+
+    assert "-1.2345678e-100" in text, "a tiny magnitude was clipped"
+    assert "98765432.123456" in text, "a long value was clipped"
+
+
+def test_evidence_says_when_the_scan_itself_trimmed_the_window():
+    from paperconan._drill_render import _render_evidence
+
+    ev = {"headers": ["a"], "rows": [{"row_idx": 2, "values": [1.0]}], "truncated": True}
+
+    assert "trimmed by the scan" in "\n".join(_render_evidence(ev))
+
+
+def test_evidence_shows_columns_that_have_no_header():
+    """zip(values, headers) silently dropped the tail; whole columns vanished."""
+    from paperconan._drill_render import _render_evidence
+
+    ev = {"headers": ["a"], "rows": [{"row_idx": 2, "values": [1.0, 42.5, 7.25]}]}
+
+    text = "\n".join(_render_evidence(ev))
+
+    assert "42.5" in text and "7.25" in text
+
+
+def test_a_cross_sheet_finding_resolves_to_its_parameters(scan):
+    """The cross-sheet lookup could be disabled entirely without a test noticing."""
+    view = overview(scan)
+    cross = [loc for loc in view["locations"] if loc["scope"] == "cross_sheet"]
+    assert cross, "fixture has no cross-sheet location"
+
+    loc = cross[0]
+    kind = drill(scan, loc["n"])["by_kind"][0]["kind"]
+    fid = drill(scan, loc["n"], kind=kind)["findings"][0]["finding_id"]
+
+    detail = explain(scan, fid)
+
+    assert detail["parameters"], (
+        "cross-sheet finding resolved to nothing; explain would show an empty shell"
+    )
+
+
+def test_the_projected_severity_comes_from_the_scan_not_the_seed(scan):
+    """I4: forcing effective = raw left the suite green, though most of the
+    fixture's findings are genuinely demoted."""
+    view = overview(scan)
+    details = [
+        explain(scan, f["finding_id"])
+        for loc in view["locations"]
+        for group in drill(scan, loc["n"])["by_kind"]
+        for f in drill(scan, loc["n"], kind=group["kind"])["findings"]
+    ]
+
+    demoted = [d for d in details if d["severity"]["raw"] != d["severity"]["effective"]]
+
+    assert demoted, (
+        "no finding shows a raw/effective split; either the fixture stopped "
+        "producing demotions or the two values are being read from one source"
+    )
+    for d in demoted:
+        assert d["severity"]["context"]
+
+
 def test_explain_rejects_an_unknown_finding(scan):
     with pytest.raises(ValueError, match="no such finding"):
         explain(scan, "seed:doesnotexist")
@@ -294,7 +412,12 @@ def test_raising_the_limit_actually_reaches_the_declared_remainder(scan):
 
     assert capped["coverage"]["shown"] == 1
     assert full["coverage"]["shown"] == full["coverage"]["total"] == biggest["n"]
-    # the listing's own truncation notice is gone once nothing is held back...
+    # Positive first: a negative assertion is trivially satisfied if the notice
+    # is deleted outright, which is how this survived a passing mutation.
+    assert any("raise max_findings" in x for x in capped["coverage"]["limitations"]), (
+        "a truncated listing did not say it was truncated"
+    )
+    # gone once nothing is held back...
     assert not any("raise max_findings" in x for x in full["coverage"]["limitations"])
     # ...but scan-wide caveats are not this layer's to drop
     assert any("detector-level caps" in x for x in full["coverage"]["limitations"])
@@ -354,7 +477,23 @@ def test_a_truncated_overview_declares_what_it_left_out(scan):
     assert len(view["locations"]) == 1
     assert view["coverage"]["locations_not_shown"] > 0
     assert view["coverage"]["signals_not_shown"] > 0
-    assert view["coverage"]["limitations"]
+    # positive, not `assert limitations` — the always-present detector-caps line
+    # satisfies that on its own, so it says nothing about truncation
+    assert any("max_locations" in x for x in view["coverage"]["limitations"]), (
+        "a truncated overview did not say which locations it dropped"
+    )
+
+
+def test_an_all_locations_hidden_overview_does_not_read_as_a_clean_paper(scan):
+    """--max-locations 0 empties the page but not the scan; the all-clear text
+    would then contradict the header and the coverage line on one screen."""
+    from paperconan._drill_render import render_overview
+
+    text = render_overview(overview(scan, max_locations=0))
+
+    assert "no locations carry signal" not in text
+    assert "free of problems" not in text
+    assert "max_locations" in text
 
 
 def test_the_views_are_deterministic(scan):

--- a/tests/test_drill.py
+++ b/tests/test_drill.py
@@ -310,6 +310,94 @@ def test_evidence_values_are_never_silently_shortened():
     assert "98765432.123456" in text, "a long value was clipped"
 
 
+def test_each_value_lands_under_its_own_header_in_its_own_row():
+    """The evidence table's job is to let a reviewer point at a cell.
+
+    Asserting that a number appears "somewhere on the page" leaves column order,
+    dropped trailing columns, row numbering and the highlight markers all
+    unguarded — a reviewer could read the right digits against the wrong header.
+    """
+    from paperconan._drill_render import _render_evidence
+
+    # five columns, not three: a three-column fixture cannot tell "render all"
+    # from "render the first three", which is the realistic refactor slip
+    labels = ["alpha", "beta", "gamma", "delta", "epsilon"]
+    ev = {
+        "headers": labels,
+        "col_offset": 0,
+        "highlight_cols": [1],
+        "highlight_rows": [7],
+        "rows": [{"row_idx": 7, "values": [1.5, 2.5, 3.5, 4.5, 5.5]},
+                 {"row_idx": 8, "values": [6.5, 7.5, 8.5, 9.5, 10.5]}],
+    }
+
+    lines = _render_evidence(ev)
+    head = lines[0]
+    body = [ln for ln in lines if "│" in ln][1:]
+
+    assert len(body) == 2, "one line per row"
+    # Each value sits under its own header, so column order cannot silently
+    # flip. Columns are right-aligned, so it is the right edges that line up.
+    for label, value in zip(labels, ["1.5", "2.5", "3.5", "4.5", "5.5"]):
+        label_end = head.index(label) + len(label)
+        value_end = body[0].index(value) + len(value)
+        assert abs(label_end - value_end) <= 1, f"{value} is not under {label}"
+    # trailing columns are rendered, not dropped
+    assert "9.5" in body[1] and "10.5" in body[1]
+    # spreadsheet row numbers survive, so the reviewer can find the row again
+    assert "7" in body[0] and "8" in body[1]
+    # the markers that say which cell matters
+    assert body[0].lstrip().startswith("▸"), "highlighted row is not marked"
+    assert body[1].lstrip()[0] != "▸", "a non-highlighted row was marked"
+    assert "beta*" in head.replace(" ", "") or head.count("*") == 1
+
+
+def test_evidence_says_how_many_rows_it_did_not_print():
+    """The scan keeps up to 50 rows; the renderer shows 20 — live, not theoretical."""
+    from paperconan._drill_render import _render_evidence
+
+    ev = {"headers": ["a"], "col_offset": 0,
+          "rows": [{"row_idx": i, "values": [float(i)]} for i in range(2, 33)]}
+
+    text = "\n".join(_render_evidence(ev))
+
+    assert "11 more rows in this window" in text
+
+
+def test_evidence_handles_ragged_rows_without_crashing():
+    """The widths pass indexed past a short row; the old zip() truncated instead.
+
+    Not reachable from a scan paperconan writes — its windows are rectangular —
+    but a foreign or older scan.json would surface as a raw traceback.
+    """
+    from paperconan._drill_render import _render_evidence
+
+    short_then_long = {"headers": ["a", "b"], "rows": [
+        {"row_idx": 2, "values": [1.0]},
+        {"row_idx": 3, "values": [2.0, 3.0, 4.0]},
+    ]}
+    long_then_short = {"headers": ["a", "b"], "rows": [
+        {"row_idx": 2, "values": [2.0, 3.0, 4.0]},
+        {"row_idx": 3, "values": [1.0]},
+    ]}
+
+    for ev in (short_then_long, long_then_short):
+        text = "\n".join(_render_evidence(ev))
+        assert "4.0" in text, "the widest row lost a column"
+
+
+@pytest.mark.parametrize("ev", [
+    {"headers": [], "rows": [{"row_idx": 2, "values": [1.0]}]},
+    {"headers": ["a"], "rows": [{"row_idx": 2, "values": [None, None]}]},
+    {"headers": ["a"], "rows": [{"row_idx": 2, "values": ["text", 1]}]},
+    {"headers": ["a"], "rows": [{"row_idx": 2, "values": []}]},
+])
+def test_evidence_renders_edge_shapes_without_raising(ev):
+    from paperconan._drill_render import _render_evidence
+
+    assert _render_evidence(ev)
+
+
 def test_evidence_says_when_the_scan_itself_trimmed_the_window():
     from paperconan._drill_render import _render_evidence
 

--- a/tests/test_drill.py
+++ b/tests/test_drill.py
@@ -37,10 +37,32 @@ def scan(tmp_path_factory):
     return scan_dir(str(d), str(d.parent / "out"), write_html=False)
 
 
-def _all_finding_count(scan):
+# Every finding-bearing list a scan can carry. Deliberately enumerated from the
+# scan's own shape rather than from the seeding layer's BLOCK_FINDING_GROUPS: an
+# earlier version counted only what the implementation seeds, so families it
+# skips were absent from both the reachable set and the expected total, and the
+# reachability test was green while six findings were unaccounted for.
+_SCAN_FINDING_KEYS = (
+    "cross_sheet_findings", "image_findings",
+    "digit_distribution", "decimal_endings", "decimal_tail_clusters",
+)
+
+
+def _seeded_finding_count(scan):
+    """What the layers are expected to route."""
     n = sum(len(b.get(g) or []) for b in scan.get("relations_blocks") or []
             for g in BLOCK_FINDING_GROUPS)
     return n + len(scan.get("cross_sheet_findings") or [])
+
+
+def _families_present(scan):
+    """Every finding-bearing family actually in this scan, with its count."""
+    present = {k: len(scan.get(k) or []) for k in _SCAN_FINDING_KEYS if scan.get(k)}
+    blocks = sum(len(b.get(g) or []) for b in scan.get("relations_blocks") or []
+                 for g in BLOCK_FINDING_GROUPS)
+    if blocks:
+        present["relations_blocks"] = blocks
+    return present
 
 
 # ---------- L1 overview ----------
@@ -50,7 +72,7 @@ def test_overview_fits_in_a_glance(scan):
 
     assert len(json.dumps(view)) < 4096, "overview must stay small enough to read at once"
     assert view["locations"], "expected at least one location"
-    assert view["signals_total"] == _all_finding_count(scan)
+    assert view["signals_total"] == _seeded_finding_count(scan)
 
 
 def test_overview_names_the_families_at_each_location(scan):
@@ -148,6 +170,67 @@ def test_explain_separates_raw_severity_from_the_projected_one(scan):
             )
 
 
+def test_explain_never_serves_another_findings_evidence(scan):
+    """`explain` is where a reviewer decides whether to act, so the evidence has
+    to belong to the id asked for.
+
+    The lookup must key on the same tuple `seed_id` is hashed from. Anything
+    weaker is not injective where the id is: several detectors build `rule` from
+    row labels or omit the column index, so two side-by-side panels can produce
+    byte-identical rule strings.
+    """
+    view = overview(scan)
+    pairs = []
+    for loc in view["locations"]:
+        for group in drill(scan, loc["n"])["by_kind"]:
+            for f in drill(scan, loc["n"], kind=group["kind"])["findings"]:
+                detail = explain(scan, f["finding_id"])
+                pairs.append((f["finding_id"], detail))
+
+    assert pairs, "fixture produced no findings"
+    for fid, detail in pairs:
+        assert detail["finding_id"] == fid
+        # the evidence must come from the block the heading names
+        if detail.get("evidence") and detail["location"]:
+            assert detail["kind"], "a finding with evidence must name its kind"
+
+    # distinct ids must not collapse onto one evidence table
+    by_evidence = {}
+    for fid, detail in pairs:
+        ev = json.dumps(detail.get("evidence"), sort_keys=True)
+        by_evidence.setdefault((detail["location"], detail["kind"], ev), []).append(fid)
+    for key, ids in by_evidence.items():
+        if len(ids) > 1:
+            rules = {explain(scan, i)["rule"] for i in ids}
+            assert len(rules) == len(ids) or len(rules) == 1, (
+                f"{len(ids)} ids share one evidence table at {key[0]}"
+            )
+
+
+def test_match_is_keyed_on_the_same_tuple_as_the_seed_id():
+    """Unit-level: two blocks differing only in columns must not cross-match."""
+    from paperconan._drill import _match_raw_finding
+    from paperconan._workflow import _block_seed
+
+    finding = {"kind": "block_value_duplication", "rule": "same rule text",
+               "severity": "high", "raw_severity": "high", "evidence": {"rows": [1]}}
+    other = dict(finding, evidence={"rows": [2]})
+    scan = {"relations_blocks": [
+        {"file": "f.csv", "sheet": "s", "block": {"rows": "2-41", "cols": "1-3"},
+         "block_dups": [finding]},
+        {"file": "f.csv", "sheet": "s", "block": {"rows": "2-41", "cols": "5-7"},
+         "block_dups": [other]},
+    ]}
+
+    seed_b = _block_seed(scan["relations_blocks"][1], "block_dups", other)
+    matched = _match_raw_finding(scan, seed_b)
+
+    assert matched is not None
+    assert matched["evidence"] == {"rows": [2]}, (
+        "panel 2's id resolved to panel 1's evidence"
+    )
+
+
 def test_explain_rejects_an_unknown_finding(scan):
     with pytest.raises(ValueError, match="no such finding"):
         explain(scan, "seed:doesnotexist")
@@ -194,6 +277,54 @@ def test_raising_the_limit_actually_reaches_the_declared_remainder(scan):
     assert capped["coverage"]["shown"] == 1
     assert full["coverage"]["shown"] == full["coverage"]["total"] == biggest["n"]
     assert not full["coverage"]["limitations"]
+
+
+def test_a_family_present_but_unreachable_is_named_in_coverage(scan):
+    """The reachability claim covers the whole scan, not just what gets seeded.
+
+    Some families (digit_distribution, decimal_endings, …) are not routed by the
+    layers at all. Counting them out of the expected total hides that; they have
+    to be named instead, or a reviewer has no way to learn they exist.
+    """
+    view = overview(scan)
+    present = _families_present(scan)
+
+    reachable_families = {"relations_blocks", "cross_sheet_findings"}
+    unreachable = {k: n for k, n in present.items() if k not in reachable_families}
+    assert unreachable, "fixture no longer exercises an unrouted family"
+
+    declared = json.dumps(view["coverage"], ensure_ascii=False)
+    for family, count in unreachable.items():
+        assert family in declared, (
+            f"{count} {family} are in the scan but no coverage field mentions them"
+        )
+
+
+def test_overview_carries_the_limitations_the_seeding_layer_recorded(scan,
+                                                                    monkeypatch):
+    """overview must not drop what _build_clusters already knew it missed."""
+    import paperconan._audit as audit
+    monkeypatch.setattr(audit, "_MAX_FINDINGS_PER_BLOCK", 1)
+
+    from paperconan import scan_dir
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        d = __import__("pathlib").Path(td) / "d"
+        d.mkdir()
+        rows = ["a,b,c,d"] + [
+            ",".join(str(round((i + 1) * (j + 1) * 1.017, 6)) for j in range(4))
+            for i in range(20)
+        ]
+        (d / "p.csv").write_text("\n".join(rows) + "\n", encoding="utf-8")
+        capped = scan_dir(str(d), str(d.parent / "out"), write_html=False)
+
+    view = overview(capped)
+
+    assert capped.get("findings_omitted"), "fixture did not trip the finding cap"
+    assert any("finding caps" in x for x in view["coverage"]["limitations"]), (
+        "overview dropped the upstream cap the seeding layer reported"
+    )
+    assert view["coverage"]["complete"] is False
 
 
 def test_a_truncated_overview_declares_what_it_left_out(scan):
@@ -290,6 +421,63 @@ def test_cli_unknown_reference_exits_with_a_message_not_a_traceback(scan_path, a
     assert res.returncode != 0
     assert "Traceback" not in res.stderr
     assert "no such" in (res.stderr + res.stdout)
+
+
+def test_an_unknown_kind_is_an_error_not_an_empty_list(scan):
+    """Silence would read as "this location has none of those", which is a
+    different claim from "you typed a kind that does not exist here"."""
+    with pytest.raises(ValueError, match="no such kind"):
+        drill(scan, 1, kind="totally_made_up_kind")
+
+
+def test_cli_unknown_kind_lists_what_is_available(scan_path):
+    res = _cli("drill", scan_path, "1", "--kind", "totally_made_up_kind")
+
+    assert res.returncode != 0
+    assert "Traceback" not in res.stderr
+    assert "no such kind" in (res.stderr + res.stdout)
+
+
+@pytest.mark.parametrize("content", ["[]", "null", '{"a": 1}', '"text"'])
+def test_cli_rejects_json_that_is_not_a_scan(tmp_path, content):
+    """Valid JSON that is not a scan must not render as "0 signals" — that reads
+    as a clean paper when it actually means the wrong file was opened."""
+    bad = tmp_path / f"bad{abs(hash(content))}.json"
+    bad.write_text(content, encoding="utf-8")
+
+    res = _cli("overview", str(bad))
+
+    assert res.returncode != 0
+    assert "Traceback" not in res.stderr
+    assert "does not look like" in (res.stderr + res.stdout)
+
+
+def test_cli_empty_overview_says_that_quiet_is_not_clean(tmp_path):
+    empty = tmp_path / "empty.json"
+    empty.write_text(json.dumps({
+        "tool": "paperconan", "schema_version": 1, "n_files": 1,
+        "relations_blocks": [], "cross_sheet_findings": [],
+    }), encoding="utf-8")
+
+    res = _cli("overview", str(empty))
+
+    assert res.returncode == 0, res.stderr
+    assert "not that the paper is free of problems" in res.stdout
+
+
+def test_cli_overview_shows_the_high_count_per_location(scan_path):
+    """strongest alone cannot distinguish 1 high among 200 from 60 among 60."""
+    res = _cli("overview", scan_path)
+
+    assert "high" in res.stdout.splitlines()[2], "no high column in the header"
+
+
+def test_cli_drill_prints_coverage_at_the_kind_grouping_layer(scan_path):
+    """SKILL.md tells the agent to read coverage at every layer."""
+    res = _cli("drill", scan_path, "1")
+
+    assert res.returncode == 0, res.stderr
+    assert "!" in res.stdout, "no coverage line at the grouping layer"
 
 
 def test_cli_rejects_a_scan_that_is_not_json(tmp_path):

--- a/tests/test_drill.py
+++ b/tests/test_drill.py
@@ -14,6 +14,7 @@ never detected.
 from __future__ import annotations
 
 import json
+import re
 
 import pytest
 
@@ -37,15 +38,12 @@ def scan(tmp_path_factory):
     return scan_dir(str(d), str(d.parent / "out"), write_html=False)
 
 
-# Every finding-bearing list a scan can carry. Deliberately enumerated from the
-# scan's own shape rather than from the seeding layer's BLOCK_FINDING_GROUPS: an
-# earlier version counted only what the implementation seeds, so families it
-# skips were absent from both the reachable set and the expected total, and the
-# reachability test was green while six findings were unaccounted for.
-_SCAN_FINDING_KEYS = (
-    "cross_sheet_findings", "image_findings",
-    "digit_distribution", "decimal_endings", "decimal_tail_clusters",
-)
+# Structural keys — scan bookkeeping, not findings.
+_NON_FINDING_KEYS = {
+    "relations_blocks", "image_assets", "scan_errors", "scan_stats", "paper",
+    "coverage", "tool", "tool_version", "schema_version", "profile", "input_dir",
+    "scanned_at", "scan_status",
+}
 
 
 def _seeded_finding_count(scan):
@@ -56,8 +54,20 @@ def _seeded_finding_count(scan):
 
 
 def _families_present(scan):
-    """Every finding-bearing family actually in this scan, with its count."""
-    present = {k: len(scan.get(k) or []) for k in _SCAN_FINDING_KEYS if scan.get(k)}
+    """Every finding-bearing family in this scan, discovered from its own shape.
+
+    Deliberately not a constant. A previous version listed the families by hand
+    and the list turned out to equal `_workflow._UNSEEDED_FAMILIES`, so the test
+    could only ever find families the implementation already declared — the same
+    scoping error it was written to replace, one constant over. Detecting the key
+    structurally means a newly added family fails this test on the day it lands.
+    """
+    present = {}
+    for key, value in scan.items():
+        if key in _NON_FINDING_KEYS or not isinstance(value, list) or not value:
+            continue
+        if all(isinstance(item, dict) for item in value):
+            present[key] = len(value)
     blocks = sum(len(b.get(g) or []) for b in scan.get("relations_blocks") or []
                  for g in BLOCK_FINDING_GROUPS)
     if blocks:
@@ -194,17 +204,25 @@ def test_explain_never_serves_another_findings_evidence(scan):
         if detail.get("evidence") and detail["location"]:
             assert detail["kind"], "a finding with evidence must name its kind"
 
-    # distinct ids must not collapse onto one evidence table
-    by_evidence = {}
-    for fid, detail in pairs:
-        ev = json.dumps(detail.get("evidence"), sort_keys=True)
-        by_evidence.setdefault((detail["location"], detail["kind"], ev), []).append(fid)
-    for key, ids in by_evidence.items():
-        if len(ids) > 1:
-            rules = {explain(scan, i)["rule"] for i in ids}
-            assert len(rules) == len(ids) or len(rules) == 1, (
-                f"{len(ids)} ids share one evidence table at {key[0]}"
+    # Distinct ids must resolve to distinct raw findings. Checked against the
+    # rule text rather than the evidence blob, since two genuinely different
+    # findings can legitimately share an evidence window over the same block.
+    from paperconan._drill import _match_raw_finding
+    from paperconan._workflow import _build_clusters
+
+    clusters, _ = _build_clusters(scan, max_clusters=10**9)
+    resolved = {}
+    for cluster in clusters:
+        for seed in cluster["seeds"]:
+            raw = _match_raw_finding(scan, seed)
+            if raw is None:
+                continue
+            key = id(raw)
+            assert key not in resolved, (
+                f"{seed['seed_id']} and {resolved[key]} both resolved to the same "
+                "raw finding; explain would serve one of them the other's evidence"
             )
+            resolved[key] = seed["seed_id"]
 
 
 def test_match_is_keyed_on_the_same_tuple_as_the_seed_id():
@@ -276,7 +294,10 @@ def test_raising_the_limit_actually_reaches_the_declared_remainder(scan):
 
     assert capped["coverage"]["shown"] == 1
     assert full["coverage"]["shown"] == full["coverage"]["total"] == biggest["n"]
-    assert not full["coverage"]["limitations"]
+    # the listing's own truncation notice is gone once nothing is held back...
+    assert not any("raise max_findings" in x for x in full["coverage"]["limitations"])
+    # ...but scan-wide caveats are not this layer's to drop
+    assert any("detector-level caps" in x for x in full["coverage"]["limitations"])
 
 
 def test_a_family_present_but_unreachable_is_named_in_coverage(scan):
@@ -452,6 +473,56 @@ def test_cli_rejects_json_that_is_not_a_scan(tmp_path, content):
     assert "does not look like" in (res.stderr + res.stdout)
 
 
+def test_cli_rejects_the_workflow_artifacts_that_sit_beside_a_scan(tmp_path):
+    """The realistic wrong-file case, not a synthetic one.
+
+    Every workflow artifact carries `schema_version`, so a one-of gate let
+    `overview states/s000.json` render "0 signals" — and the empty-overview text
+    then asserts the detectors found nothing about a file never scanned.
+    """
+    from paperconan._workflow import start_workflow
+
+    data = tmp_path / "data"
+    data.mkdir()
+    rows = ["a,b"] + [f"{i + 1},{(i + 1) * 2}" for i in range(12)]
+    (data / "p.csv").write_text("\n".join(rows) + "\n", encoding="utf-8")
+    out = tmp_path / "wf"
+    start_workflow(str(data), str(out))
+
+    for rel in ("workflow_state.json", "states/s000.json",
+                "steps/t000/candidate_packet.json"):
+        res = _cli("overview", str(out / rel))
+        assert res.returncode != 0, f"{rel} was accepted as a scan"
+        assert "does not look like" in (res.stderr + res.stdout), rel
+
+
+def test_cli_explain_names_parameters_it_cannot_render(scan_path):
+    """Sample values live in list parameters — the numbers a reviewer checks
+    against the paper. Dropping them silently from the text is the same defect
+    the family list had at L1."""
+    with open(scan_path, encoding="utf-8") as fh:
+        s = json.load(fh)
+    fid = None
+    for loc in overview(s)["locations"]:
+        for group in drill(s, loc["n"])["by_kind"]:
+            for f in drill(s, loc["n"], kind=group["kind"])["findings"]:
+                params = explain(s, f["finding_id"])["parameters"]
+                if any(isinstance(v, (list, dict)) for v in params.values()):
+                    fid = f["finding_id"]
+                    break
+            if fid:
+                break
+        if fid:
+            break
+    assert fid, "fixture has no finding with structured parameters"
+
+    out = _cli("explain", scan_path, fid).stdout
+
+    assert "structured parameter" in out, (
+        "list/dict parameters were dropped from the text with no notice"
+    )
+
+
 def test_cli_empty_overview_says_that_quiet_is_not_clean(tmp_path):
     empty = tmp_path / "empty.json"
     empty.write_text(json.dumps({
@@ -465,11 +536,44 @@ def test_cli_empty_overview_says_that_quiet_is_not_clean(tmp_path):
     assert "not that the paper is free of problems" in res.stdout
 
 
-def test_cli_overview_shows_the_high_count_per_location(scan_path):
-    """strongest alone cannot distinguish 1 high among 200 from 60 among 60."""
+def test_cli_overview_renders_the_high_count_value(scan_path):
+    """strongest alone cannot distinguish 1 high among 200 from 60 among 60.
+
+    Asserts the rendered number, not the column label — an earlier version
+    checked only the header and stayed green with the value removed.
+    """
+    with open(scan_path, encoding="utf-8") as fh:
+        expected = overview(json.load(fh))["locations"][0]
+
     res = _cli("overview", scan_path)
 
-    assert "high" in res.stdout.splitlines()[2], "no high column in the header"
+    assert res.returncode == 0, res.stderr
+    row = next(ln for ln in res.stdout.splitlines() if ln.strip().startswith("1 "))
+    trailing = [int(x) for x in re.findall(r"\d+", row)][-2:]
+    assert trailing == [expected["signals"], expected["high"]], (
+        f"row ends with {trailing}, expected signals={expected['signals']} "
+        f"then high={expected['high']}"
+    )
+
+
+def test_cli_overview_marks_a_truncated_family_list(tmp_path):
+    """L1 must not silently drop the tail of a long family list."""
+    from paperconan._drill_render import render_overview
+
+    view = {
+        "files": 1, "signals_total": 9,
+        "locations": [{
+            "n": 1, "cluster_id": "cluster:x", "scope": "block",
+            "location": "f.csv :: s", "strongest": "high", "signals": 9, "high": 9,
+            "families": ["a", "b", "c", "d", "e", "f"],
+        }],
+        "coverage": {"locations_total": 1, "locations_not_shown": 0,
+                     "signals_not_shown": 0, "limitations": []},
+    }
+
+    text = render_overview(view)
+
+    assert "2 more" in text, "families were truncated without saying so"
 
 
 def test_cli_drill_prints_coverage_at_the_kind_grouping_layer(scan_path):


### PR DESCRIPTION
Adds layered read-only views so one paper's scan can be read a screenful at a time instead of all at once. Reviewed four times; final verdict **Ready to merge**, with the two named follow-ups fixed here rather than deferred.

## Why

A single supplement routinely yields hundreds to thousands of findings and a multi-MB `scan.json`. Handing that to a reviewer buries the few signals worth acting on. Tightening the detectors to shrink it would trade a presentation problem for a detection problem — the real signals go too.

So nothing is filtered. The same findings are reached in stages:

```bash
paperconan overview audit/scan.json                  # which locations carry signal
paperconan drill    audit/scan.json 2                # that location, grouped by kind
paperconan drill    audit/scan.json 2 --kind <kind>  # the individual findings
paperconan explain  audit/scan.json <finding_id>     # one finding + evidence table
```

On a 6.3 MB scan the first layer is 0.4 KB. `--json` on any of them.

## The contract

**Every finding is reachable through the layers, or named in that layer's `coverage`** — and raising the limit genuinely reaches what was declared. A silently unreachable signal is no better than one never detected. The reviewer re-derived this independently on several corpora and could not falsify it.

Coverage carries what the layers hold back *and* what the scan already knew it missed: upstream finding caps, an incomplete scan, families not routed, and the detector-level caps nothing reports.

## What `explain` shows

Separates the detector's severity from the projected one, with the demotion reason gathered from all four places a demotion is recorded (three never write `false_positive_context`). This is not theoretical — on synthetic data a 60-row exactly duplicated column shows as `detector=high displayed=low`, down-weighted only for sharing a block with many other relations.

Evidence values use `repr` — the shortest round-tripping form. An earlier `%g`-plus-clip rendering turned `-1.2345678e-100` into `-1.234567`, wrong by a hundred orders of magnitude, in the table that exists so digits can be compared against the paper.

## Review history

Four rounds. Round 1: 3 Critical. Round 2: the remediation fixed C1 at two of three layers and two new tests passed with their feature removed. Round 3: the central claim held, but L4's evidence payload and the truncation notices had never been guarded at all. Round 4: pass.

Every fix was verified by reverting it and confirming a test goes red; the surviving-mutation counts are what drove rounds 2-4.

## Validation

- Full suite: `1456 passed, 1 skipped`
- `tests/golden/` unchanged
- Mutation-tested: all 8 mutations from the final round caught
- `skills/paperconan/SKILL.md` documents the protocol and warns that a demoted finding is not a benign one

🤖 Generated with [Claude Code](https://claude.com/claude-code)