### PR TITLE
fix: report detector result caps, and keep the caveat for the rest

### DIFF
--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -74,15 +74,19 @@ Three things to hold onto while reading:
   own caps dropped before the layers saw them, and detector-level caps that still
   reach no channel. Raise `--max-locations` / `--max-findings` to reach the
   remainder; the rest are limits of the scan, not of the view.
-- **`scan:` lines name a detector that stopped early.** A line such as
-  `scan: detector finding limit in detect_short_row_reuse (limit=60)` or
-  `... candidate pool limit ... (candidates=1500, limit=400)` means that detector
-  hit its own ceiling and stopped enumerating — the block was **not** searched to
-  the end, and `scan_status` is `partial`. Treat the sheet it names as
-  under-examined rather than clean; re-run with the matching `PAPERCONAN_*`
-  environment variable raised if the location matters. A caveat that no cap is
-  reported still stands for whole-detector skips (a block too wide or too tall),
-  which reach no channel at all.
+- **`scan:` lines carry every scan-layer limitation, not just detector ones.**
+  They come in two shapes. A **file or sheet** line names what was not read at
+  all — `scan: file too large limit in big.xlsx (size_mb=250.0)`. A **detector**
+  line names a detector that stopped early —
+  `scan: detector finding limit in detect_short_row_reuse (limit=60)`, or
+  `scan: detector candidate pool limit in detect_scaled_row_reuse (candidates=1500, limit=1500)`,
+  where `candidates` is the pool before truncation and `limit` the cap. Either
+  way `scan_status` is `partial` and the search was cut short, so do not read a
+  quiet result on that input as clean. Detector lines name **no file or sheet** —
+  the whole scan is affected, not one location — so re-run with the matching
+  `PAPERCONAN_*` variable raised rather than looking for a sheet to re-check.
+  A separate caveat covers whole-detector skips (a block too wide or too tall),
+  which reach no channel at all and so are never named here.
 - **A quiet overview is not a clean paper.** It means these detectors found
   nothing at these thresholds in the data that was supplied.
 

--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -79,7 +79,15 @@ Three things to hold onto while reading:
   emits others in the same form (a sheet-scoped line appends the sheet name after
   the file). Whole-detector skips are the exception — they reach no channel and
   are never named here at all.
-  - `scan: file too large in big.xlsx` — a file or sheet that was not read at all.
+  - `scan: file too large in big.xlsx` — a file that was not read at all.
+    `scan: unreadable in notes.xlsx` is the same class: nothing in that file was
+    examined.
+  - `scan: formula cache missing in m.xlsx Fig 3b (cells=812)` — that many
+    formula cells stored no cached value, so paperconan never saw the numbers
+    they compute. Those cells were **not** audited; the sheet is partly unread.
+  - `scan: report block limit in m.xlsx Fig 3b (count=200)` — block collection
+    for that sheet stopped at an output budget, so later blocks were never
+    analysed. Raise `PAPERCONAN_MAX_REPORT_BLOCKS`.
   - `scan: detector candidate pool limit in detect_short_row_reuse (limit=400)` —
     a detector stopped building candidates at its cap, so rows past it were never
     compared.

--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -74,8 +74,11 @@ Three things to hold onto while reading:
   own caps dropped before the layers saw them, and detector-level caps that still
   reach no channel. Raise `--max-locations` / `--max-findings` to reach the
   remainder; the rest are limits of the scan, not of the view.
-- **`scan:` lines carry every scan-layer limitation, not just detector ones.**
-  Verbatim shapes the code emits:
+- **`scan:` lines carry scan-layer limitations, not just detector ones.** The
+  shapes below are the ones you will meet most often, quoted verbatim; the code
+  emits others in the same form (a sheet-scoped line appends the sheet name after
+  the file). Whole-detector skips are the exception — they reach no channel and
+  are never named here at all.
   - `scan: file too large in big.xlsx` — a file or sheet that was not read at all.
   - `scan: detector candidate pool limit in detect_short_row_reuse (limit=400)` —
     a detector stopped building candidates at its cap, so rows past it were never
@@ -85,14 +88,16 @@ Three things to hold onto while reading:
   - `scan: detector compute budget limit in detect_row_relations` — a detector ran
     out of its work budget.
 
-  Any of these means `scan_status` is `partial` and the search was cut short, so a
+  Any of these means `scan_status` is not `complete` (`partial`, or `failed` when
+  nothing could be read at all) and the search was cut short, so a
   quiet result on that input is not evidence of a clean one. Detector lines name
   **no file or sheet**: the record does not carry one, so the line cannot tell you
-  *where* the truncation bit — it may have been one block or many. Re-run the scan
-  before concluding anything about the sheets that detector covers. Some caps have
-  a `PAPERCONAN_*` override (the compute budgets, the per-sheet row caps); others
-  are bare defaults with no knob, and for those the only remedy is narrowing the
-  input. A separate caveat covers whole-detector skips (a block too wide or too
+  *where* the truncation bit — it may have been one block or many. Re-running
+  unchanged proves nothing: the scan is deterministic, so it reproduces the same
+  truncation byte for byte. Re-run with the matching `PAPERCONAN_*` cap raised
+  (`PAPERCONAN_SHORT_ROW_MAX_ROWS`, `PAPERCONAN_ROW_PAIR_MAX_ROWS`, the
+  `*_BUDGET` vars), or on a narrowed input. Some caps are bare defaults with no
+  knob; for those, narrowing the input is the only remedy. A separate caveat covers whole-detector skips (a block too wide or too
   tall), which reach no channel at all and so are never named here.
 - **A quiet overview is not a clean paper.** It means these detectors found
   nothing at these thresholds in the data that was supplied.

--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -75,18 +75,25 @@ Three things to hold onto while reading:
   reach no channel. Raise `--max-locations` / `--max-findings` to reach the
   remainder; the rest are limits of the scan, not of the view.
 - **`scan:` lines carry every scan-layer limitation, not just detector ones.**
-  They come in two shapes. A **file or sheet** line names what was not read at
-  all — `scan: file too large limit in big.xlsx (size_mb=250.0)`. A **detector**
-  line names a detector that stopped early —
-  `scan: detector finding limit in detect_short_row_reuse (limit=60)`, or
-  `scan: detector candidate pool limit in detect_scaled_row_reuse (candidates=1500, limit=1500)`,
-  where `candidates` is the pool before truncation and `limit` the cap. Either
-  way `scan_status` is `partial` and the search was cut short, so do not read a
-  quiet result on that input as clean. Detector lines name **no file or sheet** —
-  the whole scan is affected, not one location — so re-run with the matching
-  `PAPERCONAN_*` variable raised rather than looking for a sheet to re-check.
-  A separate caveat covers whole-detector skips (a block too wide or too tall),
-  which reach no channel at all and so are never named here.
+  Verbatim shapes the code emits:
+  - `scan: file too large in big.xlsx` — a file or sheet that was not read at all.
+  - `scan: detector candidate pool limit in detect_short_row_reuse (limit=400)` —
+    a detector stopped building candidates at its cap, so rows past it were never
+    compared.
+  - `scan: detector finding limit in detect_row_pair_digit_coupling (limit=25)` —
+    a detector stopped emitting at its cap.
+  - `scan: detector compute budget limit in detect_row_relations` — a detector ran
+    out of its work budget.
+
+  Any of these means `scan_status` is `partial` and the search was cut short, so a
+  quiet result on that input is not evidence of a clean one. Detector lines name
+  **no file or sheet**: the record does not carry one, so the line cannot tell you
+  *where* the truncation bit — it may have been one block or many. Re-run the scan
+  before concluding anything about the sheets that detector covers. Some caps have
+  a `PAPERCONAN_*` override (the compute budgets, the per-sheet row caps); others
+  are bare defaults with no knob, and for those the only remedy is narrowing the
+  input. A separate caveat covers whole-detector skips (a block too wide or too
+  tall), which reach no channel at all and so are never named here.
 - **A quiet overview is not a clean paper.** It means these detectors found
   nothing at these thresholds in the data that was supplied.
 

--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -82,12 +82,20 @@ Three things to hold onto while reading:
   - `scan: file too large in big.xlsx` — a file that was not read at all.
     `scan: unreadable in notes.xlsx` is the same class: nothing in that file was
     examined.
-  - `scan: formula cache missing in m.xlsx Fig 3b (cells=812)` — that many
-    formula cells stored no cached value, so paperconan never saw the numbers
-    they compute. Those cells were **not** audited; the sheet is partly unread.
-  - `scan: report block limit in m.xlsx Fig 3b (count=200)` — block collection
-    for that sheet stopped at an output budget, so later blocks were never
-    analysed. Raise `PAPERCONAN_MAX_REPORT_BLOCKS`.
+  - `scan: formula cache missing in m.xlsx Fig 3b (cells=['C4', 'C5', 'C6'], count=812)`
+    — `count` is how many formula cells stored no cached value; `cells` is a
+    short list of examples, not the whole set. paperconan never saw the numbers
+    those cells compute, so they were **not** audited and the sheet is partly
+    unread.
+  - `scan: formula cache unreadable in m.xlsx` — the formula-cache inspection
+    itself did not complete, so paperconan cannot say whether that file has
+    unread formula cells. Absence of a `formula cache missing` line for it
+    proves nothing. `formula metadata byte limit` and `formula metadata sheet
+    limit` are the same class, naming which bound stopped the inspection.
+  - `scan: report block limit in m.xlsx Fig 3b (count=3)` — block collection for
+    that sheet stopped at an output budget, so later blocks were never analysed.
+    Two budgets emit this same line: raise `PAPERCONAN_MAX_REPORT_BLOCKS`, and if
+    that changes nothing raise `PAPERCONAN_MAX_TOTAL_FINDINGS`.
   - `scan: detector candidate pool limit in detect_short_row_reuse (limit=400)` —
     a detector stopped building candidates at its cap, so rows past it were never
     compared.

--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -71,8 +71,8 @@ Three things to hold onto while reading:
   They state what was not shown and why: locations beyond
   the listed count, findings beyond a listing limit, families this layer does not
   route (digit distributions, decimal endings, image findings), findings the scan's
-  own caps dropped before the layers saw them, and detector-level caps that are
-  reported nowhere at all. Raise `--max-locations` / `--max-findings` to reach the
+  own caps dropped before the layers saw them, and detector-level caps that still
+  reach no channel. Raise `--max-locations` / `--max-findings` to reach the
   remainder; the rest are limits of the scan, not of the view.
 - **A quiet overview is not a clean paper.** It means these detectors found
   nothing at these thresholds in the data that was supplied.

--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -74,6 +74,15 @@ Three things to hold onto while reading:
   own caps dropped before the layers saw them, and detector-level caps that still
   reach no channel. Raise `--max-locations` / `--max-findings` to reach the
   remainder; the rest are limits of the scan, not of the view.
+- **`scan:` lines name a detector that stopped early.** A line such as
+  `scan: detector finding limit in detect_short_row_reuse (limit=60)` or
+  `... candidate pool limit ... (candidates=1500, limit=400)` means that detector
+  hit its own ceiling and stopped enumerating — the block was **not** searched to
+  the end, and `scan_status` is `partial`. Treat the sheet it names as
+  under-examined rather than clean; re-run with the matching `PAPERCONAN_*`
+  environment variable raised if the location matters. A caveat that no cap is
+  reported still stands for whole-detector skips (a block too wide or too tall),
+  which reach no channel at all.
 - **A quiet overview is not a clean paper.** It means these detectors found
   nothing at these thresholds in the data that was supplied.
 

--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -1298,9 +1298,19 @@ def detect_row_relations(sheet, r0, r1, c0, c1, header, coverage=None):
     # scans and train readers to skip the coverage line. The workflow's
     # deliberately over-broad caveat ("too wide or too tall") is what covers it,
     # and test_a_block_past_the_row_cap_loses_relations_and_says_nothing pins
-    # the loss so it cannot widen unnoticed. The cap is also ~15x tighter than
-    # _ROW_REL_BUDGET, which bounds the same loop and *does* report — raising it
-    # is a detection change and belongs in its own PR.
+    # the loss so it cannot widen unnoticed. Note that caveat lives in the
+    # workflow packet only — a plain `paperconan <dir>` run gets scan.json and
+    # report.html, neither of which carries it.
+    #
+    # _ROW_REL_MAX_ROWS is also the gate in _scaled_row_candidates, so the same
+    # constant drops a second detector; that site has its own note.
+    #
+    # At the 12-14 column shapes above, this ceiling is ~15x tighter than
+    # _ROW_REL_BUDGET, which bounds the same loop and *does* report. The two
+    # cross near 3,400 columns and past that the budget is the tighter one — so
+    # "redundant" holds for ordinary panels, not for the genome-scale wide
+    # blocks this detector also covers. Raising it is a detection change (recall
+    # against cost and false positives) and belongs in its own PR.
     if n_rows < 2 or n_cols < _ROW_REL_MIN_COLS or n_rows > _ROW_REL_MAX_ROWS:
         return findings
 
@@ -3298,7 +3308,14 @@ def _scaled_row_candidates(grid_sheets):
     for (fname, sname), sheet in grid_sheets.items():
         for bi, (r0, r1) in enumerate(_row_bands(sheet)):
             if (r1 - r0) < 2 or (r1 - r0) > _ROW_REL_MAX_ROWS:
-                continue                                  # tall matrices are not this orientation
+                # Second site sharing _ROW_REL_MAX_ROWS, and it is a cost cap here
+                # too, not orientation: a band's height says nothing about whether
+                # a row in it is a scalar multiple of a row in *another* band or
+                # sheet, which is what this detector compares. A 61-row band drops
+                # out entirely, taking identical_row_reuse with it. Unreported, for
+                # the same reason as detect_row_relations' ceiling — see the note
+                # there, and test_a_tall_band_loses_scaled_row_reuse_and_says_nothing.
+                continue
             for r in range(r0, r1):
                 a = sheet.numeric[r, :]
                 finite = a[~np.isnan(a)]
@@ -3392,13 +3409,18 @@ def detect_scaled_row_reuse(grid_sheets, profile="review", max_candidates=1500,
                 _capped = True
                 break
         if budget <= 0 or len(findings) >= max_findings:
-            # only the result-cap arm is a finding limit; a spent compute
-            # budget is reported separately and may have found nothing
+            # This `if` fires on either arm; only the result-cap arm is a
+            # finding limit, since a spent compute budget is reported separately
+            # and may have found nothing. Belt-and-braces: the inner break
+            # already sets _capped on the result-cap path, so this re-assert is
+            # a no-op today. It is kept so a future append path that forgets the
+            # inner flag still attributes correctly rather than silently.
             _capped = _capped or len(findings) >= max_findings
             break
     if truncated or budget <= 0:
-        # Never silently cap coverage — say what was bounded (stderr only; scan.json stays
-        # deterministic). Real condition-layout papers stay far under these limits.
+        # Never silently cap coverage — say what was bounded, on stderr for a human
+        # watching the run and in scan.json for every downstream consumer. Real
+        # condition-layout papers stay far under these limits.
         print(f"[paperconan] detect_scaled_row_reuse: coverage bounded "
               f"(candidates={len(cands)}{'+truncated' if truncated else ''}, "
               f"budget_exhausted={budget <= 0})", file=sys.stderr)
@@ -3708,8 +3730,12 @@ def detect_short_row_reuse(grid_sheets, profile="review", max_findings=60,
                     _capped = True
                     break
             if budget <= 0 or len(findings) >= max_findings:
-                # only the result-cap arm is a finding limit; a spent compute
-                # budget is reported separately and may have found nothing
+                # This `if` fires on either arm; only the result-cap arm is a
+                # finding limit, since a spent compute budget is reported separately
+                # and may have found nothing. Belt-and-braces: the inner break
+                # already sets _capped on the result-cap path, so this re-assert is
+                # a no-op today. It is kept so a future append path that forgets the
+                # inner flag still attributes correctly rather than silently.
                 _capped = _capped or len(findings) >= max_findings
                 break
 
@@ -3797,8 +3823,12 @@ def detect_short_row_reuse(grid_sheets, profile="review", max_findings=60,
                     break
 
         if budget <= 0 or len(findings) >= max_findings:
-            # only the result-cap arm is a finding limit; a spent compute
-            # budget is reported separately and may have found nothing
+            # This `if` fires on either arm; only the result-cap arm is a
+            # finding limit, since a spent compute budget is reported separately
+            # and may have found nothing. Belt-and-braces: the inner break
+            # already sets _capped on the result-cap path, so this re-assert is
+            # a no-op today. It is kept so a future append path that forgets the
+            # inner flag still attributes correctly rather than silently.
             _capped = _capped or len(findings) >= max_findings
             break
     if budget <= 0:
@@ -3939,8 +3969,12 @@ def detect_within_row_shared_fraction(grid_sheets, profile="review", max_finding
                 _capped = True
                 break
         if budget <= 0 or len(findings) >= max_findings:
-            # only the result-cap arm is a finding limit; a spent compute
-            # budget is reported separately and may have found nothing
+            # This `if` fires on either arm; only the result-cap arm is a
+            # finding limit, since a spent compute budget is reported separately
+            # and may have found nothing. Belt-and-braces: the inner break
+            # already sets _capped on the result-cap path, so this re-assert is
+            # a no-op today. It is kept so a future append path that forgets the
+            # inner flag still attributes correctly rather than silently.
             _capped = _capped or len(findings) >= max_findings
             break
     if budget <= 0:
@@ -4057,13 +4091,21 @@ def detect_row_pair_shared_fraction(grid_sheets, profile="review", max_findings=
                     _capped = True
                     break
             if budget <= 0 or len(findings) >= max_findings:
-                # only the result-cap arm is a finding limit; a spent compute
-                # budget is reported separately and may have found nothing
+                # This `if` fires on either arm; only the result-cap arm is a
+                # finding limit, since a spent compute budget is reported separately
+                # and may have found nothing. Belt-and-braces: the inner break
+                # already sets _capped on the result-cap path, so this re-assert is
+                # a no-op today. It is kept so a future append path that forgets the
+                # inner flag still attributes correctly rather than silently.
                 _capped = _capped or len(findings) >= max_findings
                 break
         if budget <= 0 or len(findings) >= max_findings:
-            # only the result-cap arm is a finding limit; a spent compute
-            # budget is reported separately and may have found nothing
+            # This `if` fires on either arm; only the result-cap arm is a
+            # finding limit, since a spent compute budget is reported separately
+            # and may have found nothing. Belt-and-braces: the inner break
+            # already sets _capped on the result-cap path, so this re-assert is
+            # a no-op today. It is kept so a future append path that forgets the
+            # inner flag still attributes correctly rather than silently.
             _capped = _capped or len(findings) >= max_findings
             break
     if budget <= 0:
@@ -4110,7 +4152,7 @@ _MAX_CELLS = int(os.environ.get("PAPERCONAN_MAX_CELLS", "10000000"))
 _OOXML_FORMULA_INSPECT = os.environ.get(
     "PAPERCONAN_OOXML_FORMULA_INSPECT", "1") not in ("0", "false", "False", "")
 # Wide blocks (dense correlation matrices) blow up the O(col²) relation/equal-pair detectors in
-# both compute time and output size (scan.json / report.html). Skip just those two detectors when
+# both compute time and output size (scan.json / report.html). Skip those three detectors when
 # a block is wider than this; the cheap column-wise detectors still run. 0 disables the skip.
 _MAX_BLOCK_COLS = int(os.environ.get("PAPERCONAN_MAX_BLOCK_COLS", "120"))
 # Output cap: each finding embeds a table-snippet as evidence, so a paper with thousands of
@@ -4357,8 +4399,11 @@ def scan_dir(in_dir, out_dir, *, write_md=False, write_html=True, paper=None,
                 blocks_analyzed_here += 1
                 header = header_for(sheet, r0, c0, c1)
                 # On very wide blocks (dense correlation matrices) the O(col²) relation and
-                # equal-pair detectors explode in compute + output, so skip just those two; the
-                # column-wise detectors below still run. (_MAX_BLOCK_COLS=0 disables the skip.)
+                # equal-pair detectors explode in compute + output, so skip those three
+                # (relations, equal_pairs, row_pair_digit_coupling); the column-wise
+                # detectors below still run. (_MAX_BLOCK_COLS=0 disables the skip.)
+                # Unreported: this is one of the whole-detector skips the workflow's
+                # over-broad "too wide or too tall" caveat stands in for.
                 wide = _MAX_BLOCK_COLS and (c1 - c0) > _MAX_BLOCK_COLS
                 rel = [] if wide else detect_relations(sheet, r0, r1, c0, c1, header)
                 ap = detect_arithmetic_progression(sheet, r0, r1, c0, c1, header)

--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -978,8 +978,11 @@ def _note_detector_cap(coverage, detector: str, reason: str, **details) -> None:
     These caps bound worst-case work on genome-scale supplements, which is
     correct — but a search that was cut short must not be reportable as a
     complete one. Routing them into ScanCoverage flips scan_status to "partial"
-    and carries the reason to every consumer, instead of the stderr line (or, on
-    several paths, the silence) they used to get.
+    and carries the reason to every consumer that renders coverage — the raw
+    HTML report, the layered views, the workflow packet — instead of the stderr
+    line (or, on several paths, the silence) they used to get. The adjudicated
+    report renders no scan coverage at all, so a cap does not reach a reader
+    there; `scan_status` is the signal to check before adjudicating.
     """
     if coverage is None:
         return
@@ -1283,12 +1286,21 @@ def detect_row_relations(sheet, r0, r1, c0, c1, header, coverage=None):
     findings = []
     n_rows = r1 - r0
     n_cols = c1 - c0
-    # Not a truncation: this detector looks for relations *between rows across
-    # many columns*, so a tall narrow matrix is out of scope rather than cut
-    # short. _scaled_row_candidates gates on the same constant and calls it
-    # scope. Reporting it as a limitation fired on 61x14 — the commonest
-    # supplementary shape there is — and would have trained readers to ignore
-    # the coverage line entirely.
+    # Two different bounds share this line. The column floor is scope: with
+    # fewer than _ROW_REL_MIN_COLS columns a "relation between rows" is not
+    # evidence of anything. The row ceiling is not — it is a cost cap on the
+    # O(rows^2 * cols) pair loop, and it truncates: a 61x14 block is squarely in
+    # this detector's orientation, and an exact ratio between two of its rows is
+    # found at 60 rows and lost at 61 while scan_status stays "complete".
+    #
+    # Left unreported on purpose, for now: 61x14 is among the commonest
+    # supplementary shapes, so emitting a limitation here would fire on ordinary
+    # scans and train readers to skip the coverage line. The workflow's
+    # deliberately over-broad caveat ("too wide or too tall") is what covers it,
+    # and test_a_block_past_the_row_cap_loses_relations_and_says_nothing pins
+    # the loss so it cannot widen unnoticed. The cap is also ~15x tighter than
+    # _ROW_REL_BUDGET, which bounds the same loop and *does* report — raising it
+    # is a detection change and belongs in its own PR.
     if n_rows < 2 or n_cols < _ROW_REL_MIN_COLS or n_rows > _ROW_REL_MAX_ROWS:
         return findings
 
@@ -1304,9 +1316,14 @@ def detect_row_relations(sheet, r0, r1, c0, c1, header, coverage=None):
             if budget <= 0:
                 print(f"[paperconan] detect_row_relations: column-op budget exhausted on a "
                       f"{n_rows}x{n_cols} block — coverage bounded", file=sys.stderr)
+                # No rows/cols here on purpose: the dedup key is
+                # (scope, reason, file, sheet, detector) and this record carries
+                # no file or sheet, so every block that exhausts the budget
+                # collapses into one entry. Naming the first block's shape would
+                # let one record speak for blocks the reader never hears about.
+                # The stderr line above stays per-occurrence.
                 _note_detector_cap(
                     coverage, "detect_row_relations", "detector_compute_budget_limit",
-                    rows=n_rows, cols=n_cols,
                 )
                 return findings
             label_b = labels[rb]

--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -953,6 +953,16 @@ _ROW_REL_RTOL = float(os.environ.get("PAPERCONAN_ROW_REL_RTOL", "1e-3"))
 # under _MAX_CELLS) would otherwise cost ~minutes. Bound total pair*cols work; a
 # starved run stops early (stderr note) rather than hanging.
 _ROW_REL_BUDGET = int(os.environ.get("PAPERCONAN_ROW_REL_BUDGET", "6000000"))
+# The remaining detector compute budgets. Module constants rather than in-function
+# literals so a truncation they cause can be reproduced in a test and tuned by an
+# operator, per the PAPERCONAN_* convention — as in-function literals they were
+# untestable, which is why their wiring went unverified.
+_RECURRING_VEC_BUDGET = int(os.environ.get("PAPERCONAN_RECURRING_VEC_BUDGET", "3000000"))
+_WITHIN_ROW_VEC_BUDGET = int(os.environ.get("PAPERCONAN_WITHIN_ROW_VEC_BUDGET", "2000000"))
+_SCALED_ROW_BUDGET = int(os.environ.get("PAPERCONAN_SCALED_ROW_BUDGET", "4000000"))
+_SHORT_ROW_BUDGET = int(os.environ.get("PAPERCONAN_SHORT_ROW_BUDGET", "4000000"))
+_WITHIN_ROW_FRAC_BUDGET = int(os.environ.get("PAPERCONAN_WITHIN_ROW_FRAC_BUDGET", "8000000"))
+_ROW_PAIR_FRAC_BUDGET = int(os.environ.get("PAPERCONAN_ROW_PAIR_FRAC_BUDGET", "40000000"))
 
 
 def _note_detector_cap(coverage, detector: str, reason: str, **details) -> None:
@@ -2935,7 +2945,7 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
     cross_figure_possible = (
         len({figure_key(s) for (_f, s) in grid_sheets if figure_key(s) is not None}) >= 2)
     occ = {}   # rounded tuple -> list of (file, sheet, figure_key, row, start_col)
-    budget = 3_000_000   # bound worst-case work on genome-scale papers (linear, but many blocks)
+    budget = _RECURRING_VEC_BUDGET   # worst-case work on genome-scale papers
     # The window index feeds ONLY the cross-figure path; skip building it entirely otherwise
     # (the within-row pass below scans rows directly).
     for (fname, sname), sheet in (grid_sheets.items() if cross_figure_possible else ()):
@@ -2960,6 +2970,12 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
                 break
         if budget <= 0:
             break
+    if cross_figure_possible and budget <= 0:
+        # The second budget in this function. The within-row pass below has its
+        # own; wiring only that one left the cross-figure index — the higher-value
+        # signal, a tuple recurring across figures — truncating in silence.
+        _note_detector_cap(coverage, "detect_recurring_row_vectors",
+                           "detector_compute_budget_limit", pass_="cross_figure")
 
     cands = []
     for vec, places in (occ.items() if cross_figure_possible else ()):
@@ -3028,7 +3044,7 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
     # sparse sub-panel (S2H sits in columns the grid segmentation never blocks) would otherwise
     # be invisible. Same gates as the cross-figure path; the repeat corroborates itself, so one
     # figure namespace is enough.
-    wr_budget = 2_000_000
+    wr_budget = _WITHIN_ROW_VEC_BUDGET
     wr_cands = []
     for (fname, sname), sheet in grid_sheets.items():
         fk = figure_key(sname)
@@ -3303,7 +3319,7 @@ def detect_scaled_row_reuse(grid_sheets, profile="review", max_candidates=1500,
         cands = cands[:max_candidates]
     findings = []
     _capped = False   # set only where a loop is actually abandoned
-    budget = 4_000_000
+    budget = _SCALED_ROW_BUDGET
     for i in range(len(cands)):
         A = cands[i]
         for j in range(i + 1, len(cands)):
@@ -3359,7 +3375,9 @@ def detect_scaled_row_reuse(grid_sheets, profile="review", max_candidates=1500,
                 _capped = True
                 break
         if budget <= 0 or len(findings) >= max_findings:
-            _capped = True
+            # only the result-cap arm is a finding limit; a spent compute
+            # budget is reported separately and may have found nothing
+            _capped = _capped or len(findings) >= max_findings
             break
     if truncated or budget <= 0:
         # Never silently cap coverage — say what was bounded (stderr only; scan.json stays
@@ -3562,7 +3580,7 @@ def detect_short_row_reuse(grid_sheets, profile="review", max_findings=60,
         by_sheet.setdefault((c["file"], c["sheet"]), []).append(c)
     findings = []
     _capped = False   # set only where a loop is actually abandoned
-    budget = 4_000_000
+    budget = _SHORT_ROW_BUDGET
     for (fname, sname), rows in by_sheet.items():
         fig = figure_key(sname)
         # Sheet-wide frequency of each high-precision value, BUCKETED to 5 significant
@@ -3666,7 +3684,9 @@ def detect_short_row_reuse(grid_sheets, profile="review", max_findings=60,
                     _capped = True
                     break
             if budget <= 0 or len(findings) >= max_findings:
-                _capped = True
+                # only the result-cap arm is a finding limit; a spent compute
+                # budget is reported separately and may have found nothing
+                _capped = _capped or len(findings) >= max_findings
                 break
 
         # Second pass — isolated low-precision divisor case: B = k * A over a PARTIAL run where
@@ -3753,7 +3773,9 @@ def detect_short_row_reuse(grid_sheets, profile="review", max_findings=60,
                     break
 
         if budget <= 0 or len(findings) >= max_findings:
-            _capped = True
+            # only the result-cap arm is a finding limit; a spent compute
+            # budget is reported separately and may have found nothing
+            _capped = _capped or len(findings) >= max_findings
             break
     if budget <= 0:
         print("[paperconan] detect_short_row_reuse: coverage bounded (budget exhausted)",
@@ -3836,7 +3858,7 @@ def detect_within_row_shared_fraction(grid_sheets, profile="review", max_finding
     Signal, not verdict — confirm against the legend/Methods before drawing a conclusion."""
     findings = []
     _capped = False   # set only where a loop is actually abandoned
-    budget = 8_000_000
+    budget = _WITHIN_ROW_FRAC_BUDGET
     for (fname, sname), sheet in grid_sheets.items():
         fig = figure_key(sname)
         for r in range(sheet.nrows):
@@ -3893,7 +3915,9 @@ def detect_within_row_shared_fraction(grid_sheets, profile="review", max_finding
                 _capped = True
                 break
         if budget <= 0 or len(findings) >= max_findings:
-            _capped = True
+            # only the result-cap arm is a finding limit; a spent compute
+            # budget is reported separately and may have found nothing
+            _capped = _capped or len(findings) >= max_findings
             break
     if budget <= 0:
         print("[paperconan] detect_within_row_shared_fraction: coverage bounded "
@@ -3945,7 +3969,7 @@ def detect_row_pair_shared_fraction(grid_sheets, profile="review", max_findings=
             by_sheet[(fname, sname)] = rows
     findings = []
     _capped = False   # set only where a loop is actually abandoned
-    budget = 40_000_000                       # global compute bound across all sheets
+    budget = _ROW_PAIR_FRAC_BUDGET
     for (fname, sname), rows in by_sheet.items():
         fig = figure_key(sname)
         for i in range(len(rows)):
@@ -4009,10 +4033,14 @@ def detect_row_pair_shared_fraction(grid_sheets, profile="review", max_findings=
                     _capped = True
                     break
             if budget <= 0 or len(findings) >= max_findings:
-                _capped = True
+                # only the result-cap arm is a finding limit; a spent compute
+                # budget is reported separately and may have found nothing
+                _capped = _capped or len(findings) >= max_findings
                 break
         if budget <= 0 or len(findings) >= max_findings:
-            _capped = True
+            # only the result-cap arm is a finding limit; a spent compute
+            # budget is reported separately and may have found nothing
+            _capped = _capped or len(findings) >= max_findings
             break
     if budget <= 0:
         print("[paperconan] detect_row_pair_shared_fraction: coverage bounded "

--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -1179,10 +1179,18 @@ def detect_row_pair_digit_coupling(sheet, r0, r1, c0, c1, header, min_n=10,
     if len(findings) > _ROW_PAIR_MAX_FINDINGS_PER_BLOCK:
         # A result cap like any other, and it truncates before _cap_block_findings
         # runs, so without this the drop reaches neither findings_omitted nor
-        # scan_status. Reported per block: unlike the detector-level records this
-        # one has a file and sheet, so the dedup key keeps each block distinct.
+        # scan_status.
+        #
+        # No per-block count: this goes through _note_detector_cap, so the record
+        # carries no file or sheet and the dedup key collapses every overflowing
+        # block in the scan into one entry. A `found` here would be the first
+        # such block's count while reading as the total — the same trap that cost
+        # detect_row_relations its rows/cols. The limit alone is honest; the
+        # stderr line below stays per-block.
+        print(f"[paperconan] detect_row_pair_digit_coupling: {len(findings)} findings "
+              f"capped at {_ROW_PAIR_MAX_FINDINGS_PER_BLOCK} in one block", file=sys.stderr)
         _note_detector_cap(coverage, "detect_row_pair_digit_coupling",
-                           "detector_finding_limit", found=len(findings),
+                           "detector_finding_limit",
                            limit=_ROW_PAIR_MAX_FINDINGS_PER_BLOCK)
     return findings[:_ROW_PAIR_MAX_FINDINGS_PER_BLOCK]
 

--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -1041,7 +1041,8 @@ def _row_pair_low_cardinality_integer_like(x, y):
     return bool(near_integer >= 0.9 and max_abs <= 20 and distinct <= max(5, len(finite) // 4))
 
 
-def detect_row_pair_digit_coupling(sheet, r0, r1, c0, c1, header, min_n=10):
+def detect_row_pair_digit_coupling(sheet, r0, r1, c0, c1, header, min_n=10,
+                                   coverage=None):
     """Detect suspicious paired rows that preserve low-order digits across many cells.
 
     This targets source-data layouts where replicate/condition rows are aligned by
@@ -1175,6 +1176,14 @@ def detect_row_pair_digit_coupling(sheet, r0, r1, c0, c1, header, min_n=10):
         -f["coarse_10_diff_frac"],
         -f["n"],
     ))
+    if len(findings) > _ROW_PAIR_MAX_FINDINGS_PER_BLOCK:
+        # A result cap like any other, and it truncates before _cap_block_findings
+        # runs, so without this the drop reaches neither findings_omitted nor
+        # scan_status. Reported per block: unlike the detector-level records this
+        # one has a file and sheet, so the dedup key keeps each block distinct.
+        _note_detector_cap(coverage, "detect_row_pair_digit_coupling",
+                           "detector_finding_limit", found=len(findings),
+                           limit=_ROW_PAIR_MAX_FINDINGS_PER_BLOCK)
     return findings[:_ROW_PAIR_MAX_FINDINGS_PER_BLOCK]
 
 
@@ -1299,9 +1308,10 @@ def detect_row_relations(sheet, r0, r1, c0, c1, header, coverage=None):
     # deliberately over-broad caveat ("too wide or too tall") is what covers it,
     # and test_a_block_past_the_row_cap_loses_relations_and_says_nothing pins
     # the loss so it cannot widen unnoticed. That caveat reaches the workflow
-    # packet and the layered views (`paperconan overview` / `drill` / `explain`,
-    # which read it through _build_clusters); a plain `paperconan <dir>` run gets
-    # scan.json and report.html, neither of which carries it.
+    # packet and the layered views that render a coverage block — `paperconan
+    # overview` and both `drill` forms, via _build_clusters. `explain` renders no
+    # coverage block, and a plain `paperconan <dir>` run gets scan.json and
+    # report.html, neither of which carries it either.
     #
     # _ROW_REL_MAX_ROWS is also the gate in _scaled_row_candidates, so the same
     # constant drops a second detector; that site has its own note.
@@ -3427,7 +3437,7 @@ def detect_scaled_row_reuse(grid_sheets, profile="review", max_candidates=1500,
         # watching the run and in scan.json for every downstream consumer. Real
         # condition-layout papers stay far under these limits.
         print(f"[paperconan] detect_scaled_row_reuse: coverage bounded "
-              f"(candidates={len(cands)}{'+truncated' if truncated else ''}, "
+              f"(candidates={pool_size}{'+truncated' if truncated else ''}, "
               f"budget_exhausted={budget <= 0})", file=sys.stderr)
         # Two distinct causes, reported separately: a truncated candidate pool is
         # not a spent compute budget, and naming the wrong one sends a reader to
@@ -4169,9 +4179,10 @@ _MAX_CELLS = int(os.environ.get("PAPERCONAN_MAX_CELLS", "10000000"))
 # to skip the extra per-workbook XML pass on throughput-sensitive corpora.
 _OOXML_FORMULA_INSPECT = os.environ.get(
     "PAPERCONAN_OOXML_FORMULA_INSPECT", "1") not in ("0", "false", "False", "")
-# Wide blocks (dense correlation matrices) blow up the O(col²) relation, equal-pair and
-# row-pair-digit-coupling detectors in both compute time and output size (scan.json /
-# report.html). Skip those three when
+# Wide blocks (dense correlation matrices) blow up the O(col²) relation and equal-pair
+# detectors in both compute time and output size (scan.json / report.html);
+# row-pair-digit-coupling is only linear in columns but is skipped with them because its
+# per-row digit work is still wasted on a correlation matrix. Skip those three when
 # a block is wider than this; the cheap column-wise detectors still run. 0 disables the skip.
 _MAX_BLOCK_COLS = int(os.environ.get("PAPERCONAN_MAX_BLOCK_COLS", "120"))
 # Output cap: each finding embeds a table-snippet as evidence, so a paper with thousands of
@@ -4427,7 +4438,8 @@ def scan_dir(in_dir, out_dir, *, write_md=False, write_html=True, paper=None,
                 rel = [] if wide else detect_relations(sheet, r0, r1, c0, c1, header)
                 ap = detect_arithmetic_progression(sheet, r0, r1, c0, c1, header)
                 eq = [] if wide else detect_equal_pairs(sheet, r0, r1, c0, c1, header)
-                rp = [] if wide else detect_row_pair_digit_coupling(sheet, r0, r1, c0, c1, header)
+                rp = [] if wide else detect_row_pair_digit_coupling(sheet, r0, r1, c0, c1, header,
+                                                                   coverage=coverage)
                 # Runs UNCONDITIONALLY (not gated by `wide`): row-oriented condition/measurement
                 # layouts are exactly the wide blocks the column detectors skip, and this is
                 # where a "row B = row A * k" relationship lives. Self-gates on rows/cols.

--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -955,6 +955,20 @@ _ROW_REL_RTOL = float(os.environ.get("PAPERCONAN_ROW_REL_RTOL", "1e-3"))
 _ROW_REL_BUDGET = int(os.environ.get("PAPERCONAN_ROW_REL_BUDGET", "6000000"))
 
 
+def _note_detector_cap(coverage, detector: str, reason: str, **details) -> None:
+    """Record that a detector stopped before exhausting its search space.
+
+    These caps bound worst-case work on genome-scale supplements, which is
+    correct — but a search that was cut short must not be reportable as a
+    complete one. Routing them into ScanCoverage flips scan_status to "partial"
+    and carries the reason to every consumer, instead of the stderr line (or, on
+    several paths, the silence) they used to get.
+    """
+    if coverage is None:
+        return
+    coverage.add_limitation("detector", reason, detector=detector, **details)
+
+
 def _row_label(sheet, r, c0):
     labels = []
     for c in range(max(0, c0 - 4), c0):
@@ -1233,7 +1247,7 @@ def _demote_reused_progressions(report_blocks):
     return report_blocks
 
 
-def detect_row_relations(sheet, r0, r1, c0, c1, header):
+def detect_row_relations(sheet, r0, r1, c0, c1, header, coverage=None):
     """Row-oriented mirror of `detect_relations`: flag two ROWS that hold an exact
     relationship across many columns.
 
@@ -1253,6 +1267,12 @@ def detect_row_relations(sheet, r0, r1, c0, c1, header):
     n_rows = r1 - r0
     n_cols = c1 - c0
     if n_rows < 2 or n_cols < _ROW_REL_MIN_COLS or n_rows > _ROW_REL_MAX_ROWS:
+        if n_rows > _ROW_REL_MAX_ROWS and n_cols >= _ROW_REL_MIN_COLS:
+            # Reported on no channel at all before: the block was simply skipped.
+            _note_detector_cap(
+                coverage, "detect_row_relations", "detector_block_rows_limit",
+                rows=n_rows, limit=_ROW_REL_MAX_ROWS,
+            )
         return findings
 
     budget = _ROW_REL_BUDGET
@@ -1267,6 +1287,10 @@ def detect_row_relations(sheet, r0, r1, c0, c1, header):
             if budget <= 0:
                 print(f"[paperconan] detect_row_relations: column-op budget exhausted on a "
                       f"{n_rows}x{n_cols} block — coverage bounded", file=sys.stderr)
+                _note_detector_cap(
+                    coverage, "detect_row_relations", "detector_compute_budget_limit",
+                    rows=n_rows, cols=n_cols,
+                )
                 return findings
             label_b = labels[rb]
             if _AXIS_CONTEXT_LABEL_RE.search(label_b):
@@ -2889,7 +2913,8 @@ _WR_MAX_ROW_CELLS = int(os.environ.get("PAPERCONAN_WR_MAX_ROW_CELLS", "20000"))
 
 
 def detect_recurring_row_vectors(grid_sheets, profile="review",
-                                 min_k=4, max_k=8, max_rows=300, max_findings=20):
+                                 min_k=4, max_k=8, max_rows=300, max_findings=20,
+                                 coverage=None):
     """B2 — a fixed ordered numeric tuple recurring as a contiguous row-slice across >=3 places
     spanning >=2 figure namespaces. Six independent mice cannot yield the identical six-value
     vector in several arms; a specific high-information tuple reappearing across unrelated figures
@@ -3053,6 +3078,8 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
     if wr_budget <= 0:
         print("[paperconan] detect_recurring_row_vectors: within-row coverage bounded",
               file=sys.stderr)
+        _note_detector_cap(coverage, "detect_recurring_row_vectors",
+                           "detector_compute_budget_limit")
     # One physical repeat yields many overlapping windows (k=4..8) — keep the strongest (most
     # copies, then longest) per row, dropping >=50%-cell-overlap duplicates.
     wr_cands.sort(key=lambda x: (-len(x[5]), -len(x[0])))
@@ -3100,6 +3127,9 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
         if len(findings) >= max_findings:
             break
 
+    if len(findings) >= max_findings:
+        _note_detector_cap(coverage, "detect_recurring_row_vectors", "detector_finding_limit",
+                           limit=max_findings)
     apply_profile_to_findings(findings, profile)
     return findings
 
@@ -3242,7 +3272,7 @@ def _scaled_row_candidates(grid_sheets):
 
 
 def detect_scaled_row_reuse(grid_sheets, profile="review", max_candidates=1500,
-                            max_findings=40):
+                            max_findings=40, coverage=None):
     """Two DATA ROWS in DIFFERENT blocks (cross-block within a sheet) or different
     sheets that hold `row_B == row_A * k` over a long contiguous run of positionally-
     aligned columns — the scalar-multiple case (k != 1, `scaled_row_reuse`) and its
@@ -3324,6 +3354,11 @@ def detect_scaled_row_reuse(grid_sheets, profile="review", max_candidates=1500,
         print(f"[paperconan] detect_scaled_row_reuse: coverage bounded "
               f"(candidates={len(cands)}{'+truncated' if truncated else ''}, "
               f"budget_exhausted={budget <= 0})", file=sys.stderr)
+        _note_detector_cap(coverage, "detect_scaled_row_reuse",
+                           "detector_compute_budget_limit", candidates=len(cands))
+    if len(findings) >= max_findings:
+        _note_detector_cap(coverage, "detect_scaled_row_reuse", "detector_finding_limit",
+                           limit=max_findings)
     apply_profile_to_findings(findings, profile)
     return findings
 
@@ -3499,7 +3534,8 @@ def _short_row_candidates(grid_sheets):
     return cands
 
 
-def detect_short_row_reuse(grid_sheets, profile="review", max_findings=60):
+def detect_short_row_reuse(grid_sheets, profile="review", max_findings=60,
+                           coverage=None):
     """SHORT high-precision identical or constant-ratio runs (3..11 columns) between two
     data rows of one sheet — the JCI "Supporting Data Values" fingerprint that the >=12
     column `detect_scaled_row_reuse` and `detect_row_relations` cannot see: a control
@@ -3703,6 +3739,11 @@ def detect_short_row_reuse(grid_sheets, profile="review", max_findings=60):
     if budget <= 0:
         print("[paperconan] detect_short_row_reuse: coverage bounded (budget exhausted)",
               file=sys.stderr)
+        _note_detector_cap(coverage, "detect_short_row_reuse",
+                           "detector_compute_budget_limit")
+    if len(findings) >= max_findings:
+        _note_detector_cap(coverage, "detect_short_row_reuse", "detector_finding_limit",
+                           limit=max_findings)
     apply_profile_to_findings(findings, profile)
     return findings
 
@@ -3764,7 +3805,8 @@ def _shared_frac_is_small_denominator(frac, max_q=128):
     return False
 
 
-def detect_within_row_shared_fraction(grid_sheets, profile="review", max_findings=60):
+def detect_within_row_shared_fraction(grid_sheets, profile="review", max_findings=60,
+                                      coverage=None):
     """Two cells of ONE row that share a long high-precision fractional tail while their
     integer parts differ (e.g. 20.316768 and 102.316768) — a copy-then-shift: a value or a
     whole row-slice reused with the integer part rewritten but the decimals left intact.
@@ -3834,11 +3876,17 @@ def detect_within_row_shared_fraction(grid_sheets, profile="review", max_finding
     if budget <= 0:
         print("[paperconan] detect_within_row_shared_fraction: coverage bounded "
               "(budget exhausted)", file=sys.stderr)
+        _note_detector_cap(coverage, "detect_within_row_shared_fraction",
+                           "detector_compute_budget_limit")
+    if len(findings) >= max_findings:
+        _note_detector_cap(coverage, "detect_within_row_shared_fraction", "detector_finding_limit",
+                           limit=max_findings)
     apply_profile_to_findings(findings, profile)
     return findings
 
 
-def detect_row_pair_shared_fraction(grid_sheets, profile="review", max_findings=60):
+def detect_row_pair_shared_fraction(grid_sheets, profile="review", max_findings=60,
+                                    coverage=None):
     """Two ROWS that share the same high-precision decimal fraction at a contiguous run of
     aligned columns while their integer parts differ — the row-oriented twin of
     `integer_diff_shared_fraction` (which only compares two COLUMNS). A concentration row
@@ -3943,6 +3991,11 @@ def detect_row_pair_shared_fraction(grid_sheets, profile="review", max_findings=
     if budget <= 0:
         print("[paperconan] detect_row_pair_shared_fraction: coverage bounded "
               "(global budget exhausted)", file=sys.stderr)
+        _note_detector_cap(coverage, "detect_row_pair_shared_fraction",
+                           "detector_compute_budget_limit")
+    if len(findings) >= max_findings:
+        _note_detector_cap(coverage, "detect_row_pair_shared_fraction", "detector_finding_limit",
+                           limit=max_findings)
     apply_profile_to_findings(findings, profile)
     return findings
 
@@ -4236,7 +4289,7 @@ def scan_dir(in_dir, out_dir, *, write_md=False, write_html=True, paper=None,
                 # Runs UNCONDITIONALLY (not gated by `wide`): row-oriented condition/measurement
                 # layouts are exactly the wide blocks the column detectors skip, and this is
                 # where a "row B = row A * k" relationship lives. Self-gates on rows/cols.
-                rr = detect_row_relations(sheet, r0, r1, c0, c1, header)
+                rr = detect_row_relations(sheet, r0, r1, c0, c1, header, coverage=coverage)
                 wc = detect_within_column_patterns(sheet, r0, r1, c0, c1, header)
                 wc = wc + detect_dispersed_repeats(sheet, r0, r1, c0, c1, header)
                 # Block-scoped (not column-scoped): its own group so the packet
@@ -4314,22 +4367,22 @@ def scan_dir(in_dir, out_dir, *, write_md=False, write_html=True, paper=None,
     # B3: matrix-to-matrix decimal-fraction reuse between two blocks of the same sheet.
     cross_sheet_findings += detect_within_sheet_fraction_reuse(grid_sheets, profile=profile)
     # B2: a fixed high-information row-vector recurring across >=2 figures.
-    cross_sheet_findings += detect_recurring_row_vectors(grid_sheets, profile=profile)
+    cross_sheet_findings += detect_recurring_row_vectors(grid_sheets, profile=profile, coverage=coverage)
     # B6: a condition ROW that is an exact scalar multiple of a row in another block /
     # sheet (cross-block sibling of detect_row_relations; the Extended Data Fig. 5B case).
-    cross_sheet_findings += detect_scaled_row_reuse(grid_sheets, profile=profile)
+    cross_sheet_findings += detect_scaled_row_reuse(grid_sheets, profile=profile, coverage=coverage)
     # B6b: the SHORT high-precision variant — a 3-11 column identical/scaled run between two
     # rows (incl. isolated single-row panels) that the >=12 column detectors above miss. No
     # dedup against the long-run detector is needed: it only emits runs >=12 columns and this
     # one only runs <12, so the two never report the same relation on the same pair.
-    cross_sheet_findings += detect_short_row_reuse(grid_sheets, profile=profile)
+    cross_sheet_findings += detect_short_row_reuse(grid_sheets, profile=profile, coverage=coverage)
     # B6c: copy-then-integer-shift WITHIN a row — two cells sharing a long fractional tail
     # with different integer parts (the column- and block-pair shared-fraction detectors
     # never look across the columns of a single row).
-    cross_sheet_findings += detect_within_row_shared_fraction(grid_sheets, profile=profile)
+    cross_sheet_findings += detect_within_row_shared_fraction(grid_sheets, profile=profile, coverage=coverage)
     # B6d: the row-PAIR twin of integer_diff_shared_fraction — two rows sharing a decimal
     # fraction at aligned columns with different integer parts (copy-then-shift across rows).
-    cross_sheet_findings += detect_row_pair_shared_fraction(grid_sheets, profile=profile)
+    cross_sheet_findings += detect_row_pair_shared_fraction(grid_sheets, profile=profile, coverage=coverage)
     _attach_benign(cross_sheet_findings)
 
     digit_reports, decimal_reports, tail_cluster_reports = [], [], []

--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -2975,7 +2975,7 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
         # own; wiring only that one left the cross-figure index — the higher-value
         # signal, a tuple recurring across figures — truncating in silence.
         _note_detector_cap(coverage, "detect_recurring_row_vectors",
-                           "detector_compute_budget_limit", pass_="cross_figure")
+                           "detector_cross_figure_budget_limit")
 
     cands = []
     for vec, places in (occ.items() if cross_figure_possible else ()):
@@ -3104,7 +3104,7 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
         print("[paperconan] detect_recurring_row_vectors: within-row coverage bounded",
               file=sys.stderr)
         _note_detector_cap(coverage, "detect_recurring_row_vectors",
-                           "detector_compute_budget_limit")
+                           "detector_within_row_budget_limit")
     # One physical repeat yields many overlapping windows (k=4..8) — keep the strongest (most
     # copies, then longest) per row, dropping >=50%-cell-overlap duplicates.
     wr_cands.sort(key=lambda x: (-len(x[5]), -len(x[0])))
@@ -3385,8 +3385,15 @@ def detect_scaled_row_reuse(grid_sheets, profile="review", max_candidates=1500,
         print(f"[paperconan] detect_scaled_row_reuse: coverage bounded "
               f"(candidates={len(cands)}{'+truncated' if truncated else ''}, "
               f"budget_exhausted={budget <= 0})", file=sys.stderr)
-        _note_detector_cap(coverage, "detect_scaled_row_reuse",
-                           "detector_compute_budget_limit", candidates=len(cands))
+        # Two distinct causes, reported separately: a truncated candidate pool is
+        # not a spent compute budget, and naming the wrong one sends a reader to
+        # the wrong knob. The stderr line above already prints both flags.
+        if truncated:
+            _note_detector_cap(coverage, "detect_scaled_row_reuse",
+                               "detector_candidate_pool_limit", candidates=len(cands))
+        if budget <= 0:
+            _note_detector_cap(coverage, "detect_scaled_row_reuse",
+                               "detector_compute_budget_limit")
     if _capped:
         _note_detector_cap(coverage, "detect_scaled_row_reuse", "detector_finding_limit",
                            limit=max_findings)

--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -956,7 +956,14 @@ _ROW_REL_BUDGET = int(os.environ.get("PAPERCONAN_ROW_REL_BUDGET", "6000000"))
 
 
 def _note_detector_cap(coverage, detector: str, reason: str, **details) -> None:
-    """Record that a detector stopped before exhausting its search space.
+    """Record that a detector stopped at one of its own limits.
+
+    Known boundary: `detector_finding_limit` fires whenever a result cap was
+    reached, including the case where the detector had nothing further to find
+    anyway (natural output == the cap). That errs toward saying "there may be
+    more" rather than toward a false all-clear, which is the safe direction for
+    this tool; distinguishing the two needs per-break-site knowledge of what
+    remained unexamined.
 
     These caps bound worst-case work on genome-scale supplements, which is
     correct — but a search that was cut short must not be reportable as a
@@ -1266,13 +1273,13 @@ def detect_row_relations(sheet, r0, r1, c0, c1, header, coverage=None):
     findings = []
     n_rows = r1 - r0
     n_cols = c1 - c0
+    # Not a truncation: this detector looks for relations *between rows across
+    # many columns*, so a tall narrow matrix is out of scope rather than cut
+    # short. _scaled_row_candidates gates on the same constant and calls it
+    # scope. Reporting it as a limitation fired on 61x14 — the commonest
+    # supplementary shape there is — and would have trained readers to ignore
+    # the coverage line entirely.
     if n_rows < 2 or n_cols < _ROW_REL_MIN_COLS or n_rows > _ROW_REL_MAX_ROWS:
-        if n_rows > _ROW_REL_MAX_ROWS and n_cols >= _ROW_REL_MIN_COLS:
-            # Reported on no channel at all before: the block was simply skipped.
-            _note_detector_cap(
-                coverage, "detect_row_relations", "detector_block_rows_limit",
-                rows=n_rows, limit=_ROW_REL_MAX_ROWS,
-            )
         return findings
 
     budget = _ROW_REL_BUDGET
@@ -2987,6 +2994,7 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
         kept.append(c)
 
     findings = []
+    _capped = False   # set only where a loop is actually abandoned
     for vec, places, namespaces, sites, _cells in kept:
         sheets_hit = sorted({p[1] for p in places})
         loc = "; ".join(sheets_hit[:6])
@@ -3011,6 +3019,7 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
             rule=(f"the {len(vec)}-value vector {list(vec)} recurs at {len(sites)} places across "
                   f"{len(namespaces)} figures ({loc})")))
         if len(findings) >= max_findings:
+            _capped = True
             break
 
     # Within-ROW member of the same family: the identical high-precision segment appearing at
@@ -3125,9 +3134,10 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
                   f"{len(chosen)} non-overlapping positions within row {r + 1} of {sn} "
                   f"({coordinate_text})")))
         if len(findings) >= max_findings:
+            _capped = True
             break
 
-    if len(findings) >= max_findings:
+    if _capped:
         _note_detector_cap(coverage, "detect_recurring_row_vectors", "detector_finding_limit",
                            limit=max_findings)
     apply_profile_to_findings(findings, profile)
@@ -3292,6 +3302,7 @@ def detect_scaled_row_reuse(grid_sheets, profile="review", max_candidates=1500,
     if truncated:
         cands = cands[:max_candidates]
     findings = []
+    _capped = False   # set only where a loop is actually abandoned
     budget = 4_000_000
     for i in range(len(cands)):
         A = cands[i]
@@ -3345,8 +3356,10 @@ def detect_scaled_row_reuse(grid_sheets, profile="review", max_candidates=1500,
                 rule=(f"row '{A['label']}' ({sa_name}) {rel} over a run of {run_len} "
                       f"positionally-aligned columns across 2 {scope}")))
             if len(findings) >= max_findings:
+                _capped = True
                 break
         if budget <= 0 or len(findings) >= max_findings:
+            _capped = True
             break
     if truncated or budget <= 0:
         # Never silently cap coverage — say what was bounded (stderr only; scan.json stays
@@ -3356,7 +3369,7 @@ def detect_scaled_row_reuse(grid_sheets, profile="review", max_candidates=1500,
               f"budget_exhausted={budget <= 0})", file=sys.stderr)
         _note_detector_cap(coverage, "detect_scaled_row_reuse",
                            "detector_compute_budget_limit", candidates=len(cands))
-    if len(findings) >= max_findings:
+    if _capped:
         _note_detector_cap(coverage, "detect_scaled_row_reuse", "detector_finding_limit",
                            limit=max_findings)
     apply_profile_to_findings(findings, profile)
@@ -3548,6 +3561,7 @@ def detect_short_row_reuse(grid_sheets, profile="review", max_findings=60,
     for c in _short_row_candidates(grid_sheets):
         by_sheet.setdefault((c["file"], c["sheet"]), []).append(c)
     findings = []
+    _capped = False   # set only where a loop is actually abandoned
     budget = 4_000_000
     for (fname, sname), rows in by_sheet.items():
         fig = figure_key(sname)
@@ -3649,8 +3663,10 @@ def detect_short_row_reuse(grid_sheets, profile="review", max_findings=60,
                 _add_finding(A["label"], B["label"], A["row"], B["row"],
                              kind, k, run_len, x_run)
                 if len(findings) >= max_findings:
+                    _capped = True
                     break
             if budget <= 0 or len(findings) >= max_findings:
+                _capped = True
                 break
 
         # Second pass — isolated low-precision divisor case: B = k * A over a PARTIAL run where
@@ -3730,18 +3746,21 @@ def detect_short_row_reuse(grid_sheets, profile="review", max_findings=60,
                     _add_finding(nlbl, B["label"], nbr, B["row"],
                                  "scaled_row_reuse", k, run_len, dv_run)
                     if len(findings) >= max_findings:
+                        _capped = True
                         break
                 if len(findings) >= max_findings:
+                    _capped = True
                     break
 
         if budget <= 0 or len(findings) >= max_findings:
+            _capped = True
             break
     if budget <= 0:
         print("[paperconan] detect_short_row_reuse: coverage bounded (budget exhausted)",
               file=sys.stderr)
         _note_detector_cap(coverage, "detect_short_row_reuse",
                            "detector_compute_budget_limit")
-    if len(findings) >= max_findings:
+    if _capped:
         _note_detector_cap(coverage, "detect_short_row_reuse", "detector_finding_limit",
                            limit=max_findings)
     apply_profile_to_findings(findings, profile)
@@ -3816,6 +3835,7 @@ def detect_within_row_shared_fraction(grid_sheets, profile="review", max_finding
     different integers is ~1e-6 by chance, so requiring that tail length is the FP control.
     Signal, not verdict — confirm against the legend/Methods before drawing a conclusion."""
     findings = []
+    _capped = False   # set only where a loop is actually abandoned
     budget = 8_000_000
     for (fname, sname), sheet in grid_sheets.items():
         fig = figure_key(sname)
@@ -3870,15 +3890,17 @@ def detect_within_row_shared_fraction(grid_sheets, profile="review", max_finding
                       f"the integer part (e.g. {sample}) — a copy-then-integer-shift pattern "
                       f"in {sname}")))
             if len(findings) >= max_findings:
+                _capped = True
                 break
         if budget <= 0 or len(findings) >= max_findings:
+            _capped = True
             break
     if budget <= 0:
         print("[paperconan] detect_within_row_shared_fraction: coverage bounded "
               "(budget exhausted)", file=sys.stderr)
         _note_detector_cap(coverage, "detect_within_row_shared_fraction",
                            "detector_compute_budget_limit")
-    if len(findings) >= max_findings:
+    if _capped:
         _note_detector_cap(coverage, "detect_within_row_shared_fraction", "detector_finding_limit",
                            limit=max_findings)
     apply_profile_to_findings(findings, profile)
@@ -3922,6 +3944,7 @@ def detect_row_pair_shared_fraction(grid_sheets, profile="review", max_findings=
         if len(rows) >= 2:
             by_sheet[(fname, sname)] = rows
     findings = []
+    _capped = False   # set only where a loop is actually abandoned
     budget = 40_000_000                       # global compute bound across all sheets
     for (fname, sname), rows in by_sheet.items():
         fig = figure_key(sname)
@@ -3983,17 +4006,20 @@ def detect_row_pair_shared_fraction(grid_sheets, profile="review", max_findings=
                           f"(e.g. {sample}) — a copy-then-integer-shift across two rows "
                           f"in {sname}")))
                 if len(findings) >= max_findings:
+                    _capped = True
                     break
             if budget <= 0 or len(findings) >= max_findings:
+                _capped = True
                 break
         if budget <= 0 or len(findings) >= max_findings:
+            _capped = True
             break
     if budget <= 0:
         print("[paperconan] detect_row_pair_shared_fraction: coverage bounded "
               "(global budget exhausted)", file=sys.stderr)
         _note_detector_cap(coverage, "detect_row_pair_shared_fraction",
                            "detector_compute_budget_limit")
-    if len(findings) >= max_findings:
+    if _capped:
         _note_detector_cap(coverage, "detect_row_pair_shared_fraction", "detector_finding_limit",
                            limit=max_findings)
     apply_profile_to_findings(findings, profile)

--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -955,8 +955,8 @@ _ROW_REL_RTOL = float(os.environ.get("PAPERCONAN_ROW_REL_RTOL", "1e-3"))
 _ROW_REL_BUDGET = int(os.environ.get("PAPERCONAN_ROW_REL_BUDGET", "6000000"))
 # The remaining detector compute budgets. Module constants rather than in-function
 # literals so a truncation they cause can be reproduced in a test and tuned by an
-# operator, per the PAPERCONAN_* convention — as in-function literals they were
-# untestable, which is why their wiring went unverified.
+# operator, per the PAPERCONAN_* convention — as in-function literals they could
+# only be driven by editing the source, which is why their wiring went unverified.
 _RECURRING_VEC_BUDGET = int(os.environ.get("PAPERCONAN_RECURRING_VEC_BUDGET", "3000000"))
 _WITHIN_ROW_VEC_BUDGET = int(os.environ.get("PAPERCONAN_WITHIN_ROW_VEC_BUDGET", "2000000"))
 _SCALED_ROW_BUDGET = int(os.environ.get("PAPERCONAN_SCALED_ROW_BUDGET", "4000000"))
@@ -1298,9 +1298,10 @@ def detect_row_relations(sheet, r0, r1, c0, c1, header, coverage=None):
     # scans and train readers to skip the coverage line. The workflow's
     # deliberately over-broad caveat ("too wide or too tall") is what covers it,
     # and test_a_block_past_the_row_cap_loses_relations_and_says_nothing pins
-    # the loss so it cannot widen unnoticed. Note that caveat lives in the
-    # workflow packet only — a plain `paperconan <dir>` run gets scan.json and
-    # report.html, neither of which carries it.
+    # the loss so it cannot widen unnoticed. That caveat reaches the workflow
+    # packet and the layered views (`paperconan overview` / `drill` / `explain`,
+    # which read it through _build_clusters); a plain `paperconan <dir>` run gets
+    # scan.json and report.html, neither of which carries it.
     #
     # _ROW_REL_MAX_ROWS is also the gate in _scaled_row_candidates, so the same
     # constant drops a second detector; that site has its own note.
@@ -3349,6 +3350,10 @@ def detect_scaled_row_reuse(grid_sheets, profile="review", max_candidates=1500,
     """
     cands = _scaled_row_candidates(grid_sheets)
     truncated = len(cands) > max_candidates
+    # Captured before the slice: len(cands) afterwards is always max_candidates,
+    # so reporting it would print the cap back at the reader and lose the one
+    # quantity that says how much was dropped.
+    pool_size = len(cands)
     if truncated:
         cands = cands[:max_candidates]
     findings = []
@@ -3429,7 +3434,8 @@ def detect_scaled_row_reuse(grid_sheets, profile="review", max_candidates=1500,
         # the wrong knob. The stderr line above already prints both flags.
         if truncated:
             _note_detector_cap(coverage, "detect_scaled_row_reuse",
-                               "detector_candidate_pool_limit", candidates=len(cands))
+                               "detector_candidate_pool_limit",
+                               candidates=pool_size, limit=max_candidates)
         if budget <= 0:
             _note_detector_cap(coverage, "detect_scaled_row_reuse",
                                "detector_compute_budget_limit")
@@ -3587,7 +3593,7 @@ def _longest_hp_offset_run(a, b):
     return c, best_len, x_run
 
 
-def _short_row_candidates(grid_sheets):
+def _short_row_candidates(grid_sheets, coverage=None):
     """Every data row carrying >=_SHORT_ROW_MIN_COLS high-precision values with >=3
     DISTINCT such values — including ISOLATED single rows that `_scaled_row_candidates`
     drops (its bands need >=2 rows of >=12 finite cells). Grouped by sheet downstream."""
@@ -3606,6 +3612,15 @@ def _short_row_candidates(grid_sheets):
                 continue
             rows.append(dict(file=fname, sheet=sname, row=r, label=label, a=a))
             if len(rows) >= _SHORT_ROW_MAX_ROWS_PER_SHEET:
+                # Same construct as detect_scaled_row_reuse's max_candidates,
+                # which is wired: a candidate pool cut short, so later rows are
+                # never compared. Was silent on every channel, including stderr.
+                print(f"[paperconan] detect_short_row_reuse: {sname} candidate rows "
+                      f"capped at {_SHORT_ROW_MAX_ROWS_PER_SHEET} — later rows not "
+                      "compared", file=sys.stderr)
+                _note_detector_cap(coverage, "detect_short_row_reuse",
+                                   "detector_candidate_pool_limit",
+                                   limit=_SHORT_ROW_MAX_ROWS_PER_SHEET)
                 break
         cands.extend(rows)
     return cands
@@ -3622,7 +3637,7 @@ def detect_short_row_reuse(grid_sheets, profile="review", max_findings=60,
     A whole power-of-ten ratio is a unit restatement (benign) and is skipped. Signal, not
     verdict — confirm against the legend/Methods before drawing any conclusion."""
     by_sheet = {}
-    for c in _short_row_candidates(grid_sheets):
+    for c in _short_row_candidates(grid_sheets, coverage=coverage):
         by_sheet.setdefault((c["file"], c["sheet"]), []).append(c)
     findings = []
     _capped = False   # set only where a loop is actually abandoned
@@ -4022,6 +4037,9 @@ def detect_row_pair_shared_fraction(grid_sheets, profile="review", max_findings=
                     print(f"[paperconan] detect_row_pair_shared_fraction: {sname} candidate "
                           f"rows capped at {_ROW_PAIR_MAX_ROWS_PER_SHEET} — later rows not "
                           "compared", file=sys.stderr)
+                    _note_detector_cap(coverage, "detect_row_pair_shared_fraction",
+                                       "detector_candidate_pool_limit",
+                                       limit=_ROW_PAIR_MAX_ROWS_PER_SHEET)
                     break
         if len(rows) >= 2:
             by_sheet[(fname, sname)] = rows
@@ -4151,8 +4169,9 @@ _MAX_CELLS = int(os.environ.get("PAPERCONAN_MAX_CELLS", "10000000"))
 # to skip the extra per-workbook XML pass on throughput-sensitive corpora.
 _OOXML_FORMULA_INSPECT = os.environ.get(
     "PAPERCONAN_OOXML_FORMULA_INSPECT", "1") not in ("0", "false", "False", "")
-# Wide blocks (dense correlation matrices) blow up the O(col²) relation/equal-pair detectors in
-# both compute time and output size (scan.json / report.html). Skip those three detectors when
+# Wide blocks (dense correlation matrices) blow up the O(col²) relation, equal-pair and
+# row-pair-digit-coupling detectors in both compute time and output size (scan.json /
+# report.html). Skip those three when
 # a block is wider than this; the cheap column-wise detectors still run. 0 disables the skip.
 _MAX_BLOCK_COLS = int(os.environ.get("PAPERCONAN_MAX_BLOCK_COLS", "120"))
 # Output cap: each finding embeds a table-snippet as evidence, so a paper with thousands of

--- a/src/paperconan/_coverage.py
+++ b/src/paperconan/_coverage.py
@@ -60,7 +60,8 @@ class ScanCoverage:
         # key every capped detector after the first matches the first and is
         # silently discarded, so a scan that capped three detectors would name
         # only one. Detector records still collapse across blocks and sheets --
-        # one entry per detector per scan -- which is why they carry no counts.
+        # one entry per (detector, reason) per scan, since `reason` is in the key
+        # too -- which is why they carry no counts.
         key = (scope, reason, item.get("file"), item.get("sheet"),
                item.get("detector"))
         if key in self._limitation_keys:

--- a/src/paperconan/_coverage.py
+++ b/src/paperconan/_coverage.py
@@ -55,11 +55,12 @@ class ScanCoverage:
         # Deduplicate identical events so a repeated cause records once, and cap
         # the retained list so a pathological input cannot balloon the report
         # (GH#15-class size guard). The identity is
-        # (scope, reason, file, sheet, detector) — `detector` is in it because
-        # detector records carry no file or
-        # sheet, so without it every capped detector after the first collapses into
-        # it and is silently discarded, so a scan that capped three detectors
-        # would name only one of them.
+        # (scope, reason, file, sheet, detector). `detector` has to be part of
+        # it because detector records carry no file and no sheet: on a 4-tuple
+        # key every capped detector after the first matches the first and is
+        # silently discarded, so a scan that capped three detectors would name
+        # only one. Detector records still collapse across blocks and sheets --
+        # one entry per detector per scan -- which is why they carry no counts.
         key = (scope, reason, item.get("file"), item.get("sheet"),
                item.get("detector"))
         if key in self._limitation_keys:

--- a/src/paperconan/_coverage.py
+++ b/src/paperconan/_coverage.py
@@ -52,10 +52,11 @@ class ScanCoverage:
     def add_limitation(self, scope: str, reason: str, **details: Any) -> None:
         item = {"scope": scope, "reason": reason}
         item.update({k: v for k, v in details.items() if v is not None})
-        # Deduplicate identical (scope, reason, file, sheet) events so a repeated
-        # cause records once, and cap the retained list so a pathological input
-        # cannot balloon the report (GH#15-class size guard).
-        # `detector` is part of the identity: detector records carry no file or
+        # Deduplicate identical events so a repeated cause records once, and cap
+        # the retained list so a pathological input cannot balloon the report
+        # (GH#15-class size guard). The identity is
+        # (scope, reason, file, sheet, detector) — `detector` is in it because
+        # detector records carry no file or
         # sheet, so without it every capped detector collapses into the first one
         # and the rest are dropped while the report claims they were counted.
         key = (scope, reason, item.get("file"), item.get("sheet"),

--- a/src/paperconan/_coverage.py
+++ b/src/paperconan/_coverage.py
@@ -57,8 +57,9 @@ class ScanCoverage:
         # (GH#15-class size guard). The identity is
         # (scope, reason, file, sheet, detector) — `detector` is in it because
         # detector records carry no file or
-        # sheet, so without it every capped detector collapses into the first one
-        # and the rest are dropped while the report claims they were counted.
+        # sheet, so without it every capped detector after the first collapses into
+        # it and is silently discarded — while the caveat told the reader result
+        # caps were reported.
         key = (scope, reason, item.get("file"), item.get("sheet"),
                item.get("detector"))
         if key in self._limitation_keys:

--- a/src/paperconan/_coverage.py
+++ b/src/paperconan/_coverage.py
@@ -58,8 +58,8 @@ class ScanCoverage:
         # (scope, reason, file, sheet, detector) — `detector` is in it because
         # detector records carry no file or
         # sheet, so without it every capped detector after the first collapses into
-        # it and is silently discarded — while the caveat told the reader result
-        # caps were reported.
+        # it and is silently discarded, so a scan that capped three detectors
+        # would name only one of them.
         key = (scope, reason, item.get("file"), item.get("sheet"),
                item.get("detector"))
         if key in self._limitation_keys:

--- a/src/paperconan/_coverage.py
+++ b/src/paperconan/_coverage.py
@@ -55,7 +55,11 @@ class ScanCoverage:
         # Deduplicate identical (scope, reason, file, sheet) events so a repeated
         # cause records once, and cap the retained list so a pathological input
         # cannot balloon the report (GH#15-class size guard).
-        key = (scope, reason, item.get("file"), item.get("sheet"))
+        # `detector` is part of the identity: detector records carry no file or
+        # sheet, so without it every capped detector collapses into the first one
+        # and the rest are dropped while the report claims they were counted.
+        key = (scope, reason, item.get("file"), item.get("sheet"),
+               item.get("detector"))
         if key in self._limitation_keys:
             return
         if len(self.limitations) >= _limitations_cap():

--- a/src/paperconan/_drill.py
+++ b/src/paperconan/_drill.py
@@ -48,7 +48,7 @@ def _clusters_of(scan: dict[str, Any]) -> tuple[list[dict[str, Any]], dict[str, 
 
     That second value is not optional bookkeeping. It carries the upstream
     finding caps, an incomplete scan, the families this layer does not route, and
-    the detector-level caps nothing reports — i.e. most of the ways a real signal
+    the detector-level caps still reaching no channel — i.e. most of the ways a real signal
     fails to reach the reader. Discarding it here made `overview` print an empty
     `limitations` list on a scan where thousands of findings had been dropped.
     """

--- a/src/paperconan/_html.py
+++ b/src/paperconan/_html.py
@@ -733,7 +733,6 @@ _JS = """
 
 
 _STATUS_LABELS = {
-    "complete": ("ok", "全部输入均已检测 · full coverage"),
     "partial": ("warn", "部分输入未检测(见下)· partial coverage"),
     "failed": ("warn", "没有可检测的输入 · no input analyzed"),
 }

--- a/src/paperconan/_html.py
+++ b/src/paperconan/_html.py
@@ -750,8 +750,7 @@ def _render_scan_status(scan: dict) -> str:
     status = scan.get("scan_status")
     if not isinstance(coverage, dict) or status not in _STATUS_LABELS:
         return ""
-    if status == "complete":
-        return ""
+
     tone, label = _STATUS_LABELS[status]
     counts = (
         f'{coverage.get("files_succeeded", 0)}/{coverage.get("files_discovered", 0)} files, '
@@ -764,6 +763,10 @@ def _render_scan_status(scan: dict) -> str:
         f'<li>{_esc(item.get("scope"))} · {_esc(item.get("reason"))}'
         + (f' · <code>{_esc(item.get("file"))}</code>' if item.get("file") else "")
         + (f' · {_esc(item.get("sheet"))}' if item.get("sheet") else "")
+        # Detector records carry no file/sheet — without the detector name every
+        # capped detector renders as an identical row the reader cannot tell apart.
+        + (f' · <code>{_esc(item.get("detector"))}</code>' if item.get("detector") else "")
+        + (f' · limit={_esc(item.get("limit"))}' if item.get("limit") else "")
         + (f' · ×{_esc(item.get("count"))}' if item.get("count") else "")
         + "</li>"
         for item in limitations[:_MAX_RENDERED_LIMITATIONS]

--- a/src/paperconan/_html.py
+++ b/src/paperconan/_html.py
@@ -766,6 +766,8 @@ def _render_scan_status(scan: dict) -> str:
         # Detector records carry no file/sheet — without the detector name every
         # capped detector renders as an identical row the reader cannot tell apart.
         + (f' · <code>{_esc(item.get("detector"))}</code>' if item.get("detector") else "")
+        + (f' · {_esc(item.get("candidates"))} candidates'
+           if item.get("candidates") else "")
         + (f' · limit={_esc(item.get("limit"))}' if item.get("limit") else "")
         + (f' · ×{_esc(item.get("count"))}' if item.get("count") else "")
         + "</li>"

--- a/src/paperconan/_workflow.py
+++ b/src/paperconan/_workflow.py
@@ -40,8 +40,10 @@ NUMERIC_CANONICALIZATION_VERSION = 1
 # record into ScanCoverage. Many resource caps still do not. Two that anyone can
 # check from the source: scan_dir's `wide` gate drops detect_relations,
 # detect_equal_pairs and detect_row_pair_digit_coupling outright past
-# _MAX_BLOCK_COLS, and detect_row_relations' row ceiling loses an exact relation
-# at 61 rows -- both while the scan reports itself complete. So this stays
+# _MAX_BLOCK_COLS, and _ROW_REL_MAX_ROWS silently disables two detectors at 61
+# rows -- detect_row_relations loses an exact relation, and _scaled_row_candidates
+# drops the band entirely, taking identical_row_reuse with it. All while the scan
+# reports itself complete. So this stays
 # False: the caveat below is over-broad, but it is true, and a wrong all-clear
 # is worse than a broad warning. No count is given here on purpose; an earlier
 # version cited one that no reader could verify and that would drift silently
@@ -418,9 +420,10 @@ def _coverage_for(scan, seeds, clusters, omitted, max_clusters) -> dict[str, Any
         dropped = int(scan_coverage.get("limitations_omitted") or 0)
         if dropped:
             limitations.append(
-                f"scan: {dropped} further limitations were recorded but dropped by the "
-                f"record cap (PAPERCONAN_MAX_LIMITATIONS); the scan lines above are a "
-                f"sample, not the whole set"
+                f"scan: {dropped} further limitation records were dropped by the record "
+                f"cap (PAPERCONAN_MAX_LIMITATIONS); the scan lines above are a sample, "
+                f"not the whole set. Records, not distinct causes: repeats of one cause "
+                f"past the cap are each counted, so this bounds what was lost from above"
             )
 
     unseeded = {
@@ -472,11 +475,11 @@ def _coverage_for(scan, seeds, clusters, omitted, max_clusters) -> dict[str, Any
         "families_not_seeded": unseeded,
         "coverage_complete": not limitations,
         "limitations": limitations,
-        # Known blind spot, stated rather than implied: several detectors stop at
-        # their own `max_findings` or compute budget and report that only on
-        # stderr, so it reaches neither scan_status nor findings_omitted. Until
-        # those are wired into ScanCoverage, `coverage_complete` means "complete
-        # as far as the scan reported", not "every finding was seeded".
+        # Known blind spot, stated rather than implied. Six detectors now record
+        # their result caps and compute budgets through ScanCoverage; the rest of
+        # the resource caps still reach no channel, so `coverage_complete` means
+        # "complete as far as the scan reported", not "every finding was seeded".
+        # See the caveat assembled above for what that leaves out.
         "detector_caps_reported": DETECTOR_CAPS_REPORTED,
     }
 

--- a/src/paperconan/_workflow.py
+++ b/src/paperconan/_workflow.py
@@ -36,9 +36,11 @@ SCHEMA_VERSION = 2
 # from an older policy are never silently compared against a newer one.
 WORKFLOW_POLICY_VERSION = 1
 NUMERIC_CANONICALIZATION_VERSION = 1
-# Detector *result* caps (max_findings) and the row-relation compute budget now
-# record into ScanCoverage. Many resource caps still do not. Two that anyone can
-# check from the source, both whole-detector skips rather than result caps:
+# Detector result caps, compute budgets and candidate-pool caps now record into
+# ScanCoverage. Many resource caps still do not, and no exhaustive list is
+# attempted here — it would go stale as caps get wired, which is how an earlier
+# version of this note came to name coverage the code did not have. Two anyone
+# can check from the source, both whole-detector skips:
 # scan_dir's `wide` gate drops detect_relations, detect_equal_pairs and
 # detect_row_pair_digit_coupling outright past
 # _MAX_BLOCK_COLS, and _ROW_REL_MAX_ROWS silently disables two detectors at 61
@@ -50,6 +52,19 @@ NUMERIC_CANONICALIZATION_VERSION = 1
 # version cited one that no reader could verify and that would drift silently
 # as caps get wired.
 DETECTOR_CAPS_REPORTED = False
+
+# Measured consequence of wiring these, recorded so it is a decision and not a
+# surprise: on ten real supplementary-data sets, `scan_status` went from
+# "partial" on 3 to "partial" on essentially all of them, because the
+# candidate-pool and per-block result caps genuinely truncate on ordinary
+# inputs (a 14x14 block hits detect_row_pair_digit_coupling's cap of 25 with 91
+# pairs found). Reporting it is right — those searches really were cut short —
+# but it means `partial` is now the normal state and carries little information
+# on its own. What carries information is the `limitations` list, which names
+# the detector and its limit. Two consequences worth keeping in view: anything
+# downstream that gates on `scan_status == "complete"` will now see almost
+# nothing, and the caps being this tight on ordinary data is an argument for
+# raising them — a detection change, separate PR.
 
 MAX_EXPANSION_ROUNDS = 2
 # Route steps are bounded so a context-only loop cannot spin forever; the cap is
@@ -445,10 +460,10 @@ def _coverage_for(scan, seeds, clusters, omitted, max_clusters) -> dict[str, Any
         )
 
     # Result caps, compute budgets and candidate-pool caps now record through
-    # ScanCoverage. What still reaches no channel is the whole-detector skips:
-    # a block dropped for being too wide (the `wide` gate) or too tall
-    # (_ROW_REL_MAX_ROWS, a cost bound that drops real relations at 61 rows).
-    # Until those are wired
+    # ScanCoverage. Others still reach no channel — whole-detector skips for a
+    # block too wide (the `wide` gate) or too tall (_ROW_REL_MAX_ROWS, a cost
+    # bound that drops real relations at 61 rows), and per-row truncations
+    # inside detectors that are otherwise wired. Until those are wired
     # the workflow cannot know whether a block was fully enumerated, so it must
     # not claim it was. Stating it here rather than only in a side field means
     # `coverage_complete` is false by construction and the caveat reaches the
@@ -476,10 +491,12 @@ def _coverage_for(scan, seeds, clusters, omitted, max_clusters) -> dict[str, Any
         "families_not_seeded": unseeded,
         "coverage_complete": not limitations,
         "limitations": limitations,
-        # Known blind spot, stated rather than implied. Every detector result cap
-        # and compute budget now records through ScanCoverage, as do the candidate
-        # pool caps; whole-detector skips (the `wide` gate, _ROW_REL_MAX_ROWS) do
-        # not, so `coverage_complete` means
+        # Known blind spot, stated rather than implied. Result caps, compute
+        # budgets and candidate-pool caps now record through ScanCoverage. Not
+        # all of them: whole-detector skips (the `wide` gate, _ROW_REL_MAX_ROWS,
+        # BLOCK_DUP_MAX_CELLS) reach no channel, and neither do per-row
+        # truncations like _WR_MAX_ROW_CELLS. No exhaustive list is attempted
+        # here — that is the point of the caveat. So `coverage_complete` means
         # "complete as far as the scan reported", not "every finding was seeded".
         # See the caveat assembled above for what that leaves out.
         "detector_caps_reported": DETECTOR_CAPS_REPORTED,

--- a/src/paperconan/_workflow.py
+++ b/src/paperconan/_workflow.py
@@ -36,10 +36,13 @@ SCHEMA_VERSION = 2
 # from an older policy are never silently compared against a newer one.
 WORKFLOW_POLICY_VERSION = 1
 NUMERIC_CANONICALIZATION_VERSION = 1
-# Detector max_findings / compute budgets now record into ScanCoverage, so a
-# search that was cut short reaches scan_status and this layer's limitations
-# rather than passing as complete. coverage_complete can mean what it says again.
-DETECTOR_CAPS_REPORTED = True
+# Detector *result* caps (max_findings) and the row-relation compute budget now
+# record into ScanCoverage. Many resource caps still do not — an audit of the
+# detector layer found 17, including whole-detector skips like _MAX_BLOCK_COLS,
+# where a 130-column block loses detect_relations entirely and the scan reports
+# itself complete. So this stays False: the caveat below is over-broad, but it
+# is true, and a wrong all-clear is worse than a broad warning.
+DETECTOR_CAPS_REPORTED = False
 
 MAX_EXPANSION_ROUNDS = 2
 # Route steps are bounded so a context-only loop cannot spin forever; the cap is
@@ -433,9 +436,10 @@ def _coverage_for(scan, seeds, clusters, omitted, max_clusters) -> dict[str, Any
     # construction and the caveat reaches the CLI, which prints `limitations`.
     if not DETECTOR_CAPS_REPORTED:
         limitations.append(
-            "detector-level caps are not reported to the scan layer, so a detector "
-            "that stopped at its own max_findings or compute budget is not counted "
-            "here (see coverage.detector_caps_reported)"
+            "some detector resource caps are still not reported: a detector that "
+            "skipped a block for being too wide or too tall, or stopped at an "
+            "internal compute budget, may not appear above. Result caps "
+            "(max_findings) and the row-relation budget are reported."
         )
 
     return {

--- a/src/paperconan/_workflow.py
+++ b/src/paperconan/_workflow.py
@@ -57,7 +57,7 @@ DETECTOR_CAPS_REPORTED = False
 # surprise: on ten real supplementary-data sets, `scan_status` went from
 # "partial" on 3 to "partial" on essentially all of them, because the
 # candidate-pool caps genuinely truncate on ordinary inputs: any sheet with
-# more than 400 candidate rows trips _SHORT_ROW_MAX_ROWS_PER_SHEET or
+# 400 or more candidate rows trips _SHORT_ROW_MAX_ROWS_PER_SHEET or
 # _ROW_PAIR_MAX_ROWS_PER_SHEET, and supplements that size are routine.
 # Reporting it is right — those searches really were cut short —
 # but it means `partial` is now the normal state and carries little information

--- a/src/paperconan/_workflow.py
+++ b/src/paperconan/_workflow.py
@@ -37,11 +37,15 @@ SCHEMA_VERSION = 2
 WORKFLOW_POLICY_VERSION = 1
 NUMERIC_CANONICALIZATION_VERSION = 1
 # Detector *result* caps (max_findings) and the row-relation compute budget now
-# record into ScanCoverage. Many resource caps still do not — an audit of the
-# detector layer found 17, including whole-detector skips like _MAX_BLOCK_COLS,
-# where a 130-column block loses detect_relations entirely and the scan reports
-# itself complete. So this stays False: the caveat below is over-broad, but it
-# is true, and a wrong all-clear is worse than a broad warning.
+# record into ScanCoverage. Many resource caps still do not. Two that anyone can
+# check from the source: scan_dir's `wide` gate drops detect_relations,
+# detect_equal_pairs and detect_row_pair_digit_coupling outright past
+# _MAX_BLOCK_COLS, and detect_row_relations' row ceiling loses an exact relation
+# at 61 rows -- both while the scan reports itself complete. So this stays
+# False: the caveat below is over-broad, but it is true, and a wrong all-clear
+# is worse than a broad warning. No count is given here on purpose; an earlier
+# version cited one that no reader could verify and that would drift silently
+# as caps get wired.
 DETECTOR_CAPS_REPORTED = False
 
 MAX_EXPANSION_ROUNDS = 2
@@ -409,6 +413,15 @@ def _coverage_for(scan, seeds, clusters, omitted, max_clusters) -> dict[str, Any
         )
         for entry in scan_coverage.get("limitations") or []:
             limitations.append("scan: " + _describe_scan_limitation(entry))
+        # The record list is itself capped. Reporting the retained records
+        # without the dropped count shows a short list that reads as a full one.
+        dropped = int(scan_coverage.get("limitations_omitted") or 0)
+        if dropped:
+            limitations.append(
+                f"scan: {dropped} further limitations were recorded but dropped by the "
+                f"record cap (PAPERCONAN_MAX_LIMITATIONS); the scan lines above are a "
+                f"sample, not the whole set"
+            )
 
     unseeded = {
         family: len(scan.get(family) or [])
@@ -427,20 +440,25 @@ def _coverage_for(scan, seeds, clusters, omitted, max_clusters) -> dict[str, Any
             f"{len(omitted)} lower-ranked clusters were not routed"
         )
 
-    # Several detectors stop at their own limits. Some now record through
-    # ScanCoverage; an audit found others that still reach no channel at all —
-    # whole-detector skips on wide blocks, and result caps outside the wired
-    # set. Until every one is wired
-    # (a scan-layer change, separate PR) the workflow cannot know whether a block
-    # was fully enumerated, so it must not claim it was. Stating it here rather
-    # than only in a side field means `coverage_complete` is false by
-    # construction and the caveat reaches the CLI, which prints `limitations`.
+    # Six detectors now record their result caps and compute budgets through
+    # ScanCoverage. An audit found others that still reach no channel at all:
+    # whole-detector skips on blocks that are too wide or too tall (see
+    # detect_row_relations' row cap, a cost bound that drops real relations at
+    # 61 rows) and result caps outside the wired set. Until every one is wired
+    # the workflow cannot know whether a block was fully enumerated, so it must
+    # not claim it was. Stating it here rather than only in a side field means
+    # `coverage_complete` is false by construction and the caveat reaches the
+    # CLI, which prints `limitations`.
+    #
+    # Deliberately not an enumeration: a list here goes stale the moment a cap
+    # is wired, which is how an earlier version of this text came to name
+    # coverage the code did not have.
     if not DETECTOR_CAPS_REPORTED:
         limitations.append(
             "some detector caps are still not reported: a detector that skipped a "
             "block for being too wide or too tall, or stopped at an internal "
-            "limit, may not appear above. What is reported appears in this list; "
-            "this line does not enumerate what is not."
+            "limit, may not appear above. This line does not enumerate what is "
+            "not reported."
         )
 
     return {

--- a/src/paperconan/_workflow.py
+++ b/src/paperconan/_workflow.py
@@ -38,8 +38,9 @@ WORKFLOW_POLICY_VERSION = 1
 NUMERIC_CANONICALIZATION_VERSION = 1
 # Detector *result* caps (max_findings) and the row-relation compute budget now
 # record into ScanCoverage. Many resource caps still do not. Two that anyone can
-# check from the source: scan_dir's `wide` gate drops detect_relations,
-# detect_equal_pairs and detect_row_pair_digit_coupling outright past
+# check from the source, both whole-detector skips rather than result caps:
+# scan_dir's `wide` gate drops detect_relations, detect_equal_pairs and
+# detect_row_pair_digit_coupling outright past
 # _MAX_BLOCK_COLS, and _ROW_REL_MAX_ROWS silently disables two detectors at 61
 # rows -- detect_row_relations loses an exact relation, and _scaled_row_candidates
 # drops the band entirely, taking identical_row_reuse with it. All while the scan
@@ -443,11 +444,11 @@ def _coverage_for(scan, seeds, clusters, omitted, max_clusters) -> dict[str, Any
             f"{len(omitted)} lower-ranked clusters were not routed"
         )
 
-    # Six detectors now record their result caps and compute budgets through
-    # ScanCoverage. An audit found others that still reach no channel at all:
-    # whole-detector skips on blocks that are too wide or too tall (see
-    # detect_row_relations' row cap, a cost bound that drops real relations at
-    # 61 rows) and result caps outside the wired set. Until every one is wired
+    # Result caps, compute budgets and candidate-pool caps now record through
+    # ScanCoverage. What still reaches no channel is the whole-detector skips:
+    # a block dropped for being too wide (the `wide` gate) or too tall
+    # (_ROW_REL_MAX_ROWS, a cost bound that drops real relations at 61 rows).
+    # Until those are wired
     # the workflow cannot know whether a block was fully enumerated, so it must
     # not claim it was. Stating it here rather than only in a side field means
     # `coverage_complete` is false by construction and the caveat reaches the
@@ -475,9 +476,10 @@ def _coverage_for(scan, seeds, clusters, omitted, max_clusters) -> dict[str, Any
         "families_not_seeded": unseeded,
         "coverage_complete": not limitations,
         "limitations": limitations,
-        # Known blind spot, stated rather than implied. Six detectors now record
-        # their result caps and compute budgets through ScanCoverage; the rest of
-        # the resource caps still reach no channel, so `coverage_complete` means
+        # Known blind spot, stated rather than implied. Every detector result cap
+        # and compute budget now records through ScanCoverage, as do the candidate
+        # pool caps; whole-detector skips (the `wide` gate, _ROW_REL_MAX_ROWS) do
+        # not, so `coverage_complete` means
         # "complete as far as the scan reported", not "every finding was seeded".
         # See the caveat assembled above for what that leaves out.
         "detector_caps_reported": DETECTOR_CAPS_REPORTED,

--- a/src/paperconan/_workflow.py
+++ b/src/paperconan/_workflow.py
@@ -427,19 +427,20 @@ def _coverage_for(scan, seeds, clusters, omitted, max_clusters) -> dict[str, Any
             f"{len(omitted)} lower-ranked clusters were not routed"
         )
 
-    # Several detectors stop at their own max_findings or compute budget and
-    # report it to no channel at all — not scan_status, not findings_omitted,
-    # and for some paths not even stderr. Until they are wired into ScanCoverage
+    # Several detectors stop at their own limits. Some now record through
+    # ScanCoverage; an audit found others that still reach no channel at all —
+    # whole-detector skips on wide blocks, and result caps outside the wired
+    # set. Until every one is wired
     # (a scan-layer change, separate PR) the workflow cannot know whether a block
     # was fully enumerated, so it must not claim it was. Stating it here rather
     # than only in a side field means `coverage_complete` is false by
     # construction and the caveat reaches the CLI, which prints `limitations`.
     if not DETECTOR_CAPS_REPORTED:
         limitations.append(
-            "some detector resource caps are still not reported: a detector that "
-            "skipped a block for being too wide or too tall, or stopped at an "
-            "internal compute budget, may not appear above. Result caps "
-            "(max_findings) and the row-relation budget are reported."
+            "some detector caps are still not reported: a detector that skipped a "
+            "block for being too wide or too tall, or stopped at an internal "
+            "limit, may not appear above. What is reported appears in this list; "
+            "this line does not enumerate what is not."
         )
 
     return {

--- a/src/paperconan/_workflow.py
+++ b/src/paperconan/_workflow.py
@@ -56,9 +56,10 @@ DETECTOR_CAPS_REPORTED = False
 # Measured consequence of wiring these, recorded so it is a decision and not a
 # surprise: on ten real supplementary-data sets, `scan_status` went from
 # "partial" on 3 to "partial" on essentially all of them, because the
-# candidate-pool and per-block result caps genuinely truncate on ordinary
-# inputs (a 14x14 block hits detect_row_pair_digit_coupling's cap of 25 with 91
-# pairs found). Reporting it is right — those searches really were cut short —
+# candidate-pool caps genuinely truncate on ordinary inputs: any sheet with
+# more than 400 candidate rows trips _SHORT_ROW_MAX_ROWS_PER_SHEET or
+# _ROW_PAIR_MAX_ROWS_PER_SHEET, and supplements that size are routine.
+# Reporting it is right — those searches really were cut short —
 # but it means `partial` is now the normal state and carries little information
 # on its own. What carries information is the `limitations` list, which names
 # the detector and its limit. Two consequences worth keeping in view: anything

--- a/src/paperconan/_workflow.py
+++ b/src/paperconan/_workflow.py
@@ -36,9 +36,10 @@ SCHEMA_VERSION = 2
 # from an older policy are never silently compared against a newer one.
 WORKFLOW_POLICY_VERSION = 1
 NUMERIC_CANONICALIZATION_VERSION = 1
-# Flip to True in the PR that wires detector max_findings / compute budgets into
-# ScanCoverage. Until then coverage_complete is false by construction.
-DETECTOR_CAPS_REPORTED = False
+# Detector max_findings / compute budgets now record into ScanCoverage, so a
+# search that was cut short reaches scan_status and this layer's limitations
+# rather than passing as complete. coverage_complete can mean what it says again.
+DETECTOR_CAPS_REPORTED = True
 
 MAX_EXPANSION_ROUNDS = 2
 # Route steps are bounded so a context-only loop cannot spin forever; the cap is
@@ -356,6 +357,28 @@ _UNSEEDED_FAMILIES = (
 )
 
 
+def _describe_scan_limitation(entry: Any) -> str:
+    """A sentence, not a Python repr — these reach a reader's terminal."""
+    if isinstance(entry, str):
+        return entry
+    if not isinstance(entry, dict):
+        return str(entry)
+    reason = str(entry.get("reason") or "unspecified").replace("_", " ")
+    where = " ".join(
+        str(entry[k]) for k in ("detector", "file", "sheet") if entry.get(k)
+    )
+    extra = ", ".join(
+        f"{k}={entry[k]}" for k in sorted(entry)
+        if k not in ("scope", "reason", "detector", "file", "sheet")
+    )
+    text = reason
+    if where:
+        text += f" in {where}"
+    if extra:
+        text += f" ({extra})"
+    return text
+
+
 def _coverage_for(scan, seeds, clusters, omitted, max_clusters) -> dict[str, Any]:
     limitations: list[str] = []
 
@@ -382,7 +405,7 @@ def _coverage_for(scan, seeds, clusters, omitted, max_clusters) -> dict[str, Any
             "seeds cover only what it analysed"
         )
         for entry in scan_coverage.get("limitations") or []:
-            limitations.append(f"scan: {entry}" if isinstance(entry, str) else f"scan: {entry!r}")
+            limitations.append("scan: " + _describe_scan_limitation(entry))
 
     unseeded = {
         family: len(scan.get(family) or [])

--- a/tests/test_detector_cap_coverage.py
+++ b/tests/test_detector_cap_coverage.py
@@ -114,8 +114,9 @@ def _write_csv(path, rows):
 def _grid_for_pool_cap(detector):
     """A grid with more candidate rows than the pool cap under test.
 
-    Each of these detectors builds its candidate list through its own gates, so
-    a grid that overflows one does not overflow the other.
+    Each detector builds its candidate list through its own gates, so a grid has
+    to be chosen per detector: _shared_tail_across_rows only overflows the
+    row-pair cap, while _repeated_short_rows happens to overflow both.
     """
     if detector == "detect_row_pair_shared_fraction":
         return _shared_tail_across_rows()
@@ -708,7 +709,7 @@ def test_the_html_coverage_row_distinguishes_one_capped_detector_from_another(tm
     assert "limit=60" in html, "the cap value did not reach the report"
 
 
-def test_a_truncated_candidate_pool_reports_the_pool_not_the_cap(tmp_path):
+def test_a_truncated_candidate_pool_reports_the_pool_not_the_cap(tmp_path, capsys):
     """The one number on the record has to say how much was dropped.
 
     len(cands) is read after the slice, so reporting it prints max_candidates
@@ -724,13 +725,21 @@ def test_a_truncated_candidate_pool_reports_the_pool_not_the_cap(tmp_path):
     audit.detect_scaled_row_reuse(grids, profile="review", max_candidates=3,
                                   max_findings=10**6, coverage=coverage)
 
+    assert pool > 3, "fixture no longer overflows the candidate cap"
     record = next(i for i in coverage.to_dict()["limitations"]
                   if i["reason"] == "detector_candidate_pool_limit")
-    assert pool > 3, "fixture no longer overflows the candidate cap"
     assert record["candidates"] == pool, (
         f"reported {record['candidates']} candidates for a pool of {pool}"
     )
     assert record["limit"] == 3
+
+    # The stderr line is a peer reporting channel, not a lesser one -- it had the
+    # same post-slice bug and no test, so fixing only the structured record left
+    # the human watching the run reading the cap back at themselves.
+    err = capsys.readouterr().err
+    assert f"candidates={pool}" in err, (
+        f"stderr reported the cap instead of the pool: {err.strip()!r}"
+    )
 
 
 @pytest.mark.parametrize("detector,knob,reason", [
@@ -759,4 +768,36 @@ def test_sibling_candidate_pool_caps_reach_coverage(tmp_path, monkeypatch,
         f"{detector}'s candidate pool was cut at {knob} without recording it: "
         f"{_reasons(scan)}"
     )
+    assert scan["scan_status"] != "complete"
+
+
+def test_the_row_pair_digit_coupling_block_cap_reaches_coverage(tmp_path):
+    """A result cap that truncated before _cap_block_findings ever saw it.
+
+    detect_row_pair_digit_coupling ended in `findings[:25]`. That is a result cap
+    like any other, but it ran ahead of the block-level cap, so the drop reached
+    neither findings_omitted nor scan_status -- the one category the workflow's
+    blind-spot note had been rewritten to claim was empty.
+
+    No monkeypatching: 14 rows of 14 columns whose pairwise differences are
+    multiples of 10 produce all C(14,2)=91 pairs and hit the default cap of 25,
+    so this fires on an ordinary block and loses 66 findings.
+    """
+    cols = 14
+    base = [round(12.34 + j * 7.91, 2) for j in range(cols)]
+    rows = [[f"c{j}" for j in range(cols)]]
+    for i in range(14):
+        rows.append([round(v + 10 * (i + 1), 2) for v in base])
+    _write_csv(tmp_path / "d" / "p.csv", rows)
+
+    scan = scan_dir(str(tmp_path / "d"), str(tmp_path / "out"), write_html=False)
+
+    records = [i for i in (scan.get("coverage") or {}).get("limitations") or []
+               if i.get("detector") == "detect_row_pair_digit_coupling"
+               and i.get("reason") == "detector_finding_limit"]
+    assert records, (
+        f"the per-block result cap recorded nothing under its own reason: "
+        f"{[(i.get('detector'), i.get('reason')) for i in (scan.get('coverage') or {}).get('limitations') or []]}"
+    )
+    assert records[0]["found"] > records[0]["limit"], records[0]
     assert scan["scan_status"] != "complete"

--- a/tests/test_detector_cap_coverage.py
+++ b/tests/test_detector_cap_coverage.py
@@ -52,18 +52,6 @@ def test_an_exhausted_row_relation_budget_reaches_coverage(tmp_path, monkeypatch
     assert scan["coverage"]["truncated"] is True
 
 
-def test_a_block_too_tall_for_row_relations_is_recorded(tmp_path, monkeypatch):
-    """This path returned [] with no notice on any channel at all."""
-    import paperconan._audit as audit
-    monkeypatch.setattr(audit, "_ROW_REL_MAX_ROWS", 3)
-
-    _panel(tmp_path / "d" / "p.csv")
-    scan = scan_dir(str(tmp_path / "d"), str(tmp_path / "out"), write_html=False)
-
-    assert "detector_block_rows_limit" in _reasons(scan), _reasons(scan)
-    assert scan["scan_status"] != "complete"
-
-
 # ---------- the per-detector result caps ----------
 
 _CAPPED_DETECTORS = (
@@ -99,21 +87,27 @@ def _two_sheets():
 def test_each_capped_detector_reports_reaching_its_finding_limit(name):
     """Every capped detector is wired to the coverage object.
 
-    Uses max_findings=0 so the limit is reached regardless of what the fixture
-    happens to trigger. That verifies the wiring, not that a real corpus trips
-    it — the end-to-end case is covered separately below, for the one detector a
-    synthetic fixture can currently drive to its cap.
+    Uses max_findings=1 against a fixture rich enough that several of these
+    detectors produce more than one finding. Detectors the fixture cannot drive
+    past one are skipped rather than asserted vacuously — a detector that never
+    reaches its cap correctly records nothing.
     """
     import paperconan._audit as audit
 
     coverage = ScanCoverage(files_discovered=1)
 
-    getattr(audit, name)(_two_sheets(), profile="review", max_findings=0,
+    natural = len(getattr(audit, name)(_two_sheets(), profile="review",
+                                       max_findings=10**6))
+    if natural < 2:
+        pytest.skip(f"{name} yields {natural} finding(s) on this fixture; "
+                    "cannot drive it past its cap")
+
+    getattr(audit, name)(_two_sheets(), profile="review", max_findings=1,
                          coverage=coverage)
 
     reasons = [item["reason"] for item in coverage.to_dict()["limitations"]]
     assert "detector_finding_limit" in reasons, (
-        f"{name} reached its cap without recording it: {reasons}"
+        f"{name} was cut short without recording it: {reasons}"
     )
 
 
@@ -160,12 +154,60 @@ def test_an_uncapped_scan_records_no_detector_limitation(tmp_path):
 
 # ---------- the workflow caveat can now be retired ----------
 
-def test_the_workflow_no_longer_declares_caps_unreported():
-    """With the caps wired through, the blanket caveat becomes false and the
-    packet can report real completeness again."""
+def test_the_unreported_cap_caveat_stays_until_every_cap_is_wired():
+    """Result caps are wired; many resource caps are not.
+
+    An audit of the detector layer found 17 that still report nowhere —
+    _MAX_BLOCK_COLS drops detect_relations entirely on a wide block while the
+    scan calls itself complete. Flipping this flag on partial wiring replaced an
+    over-broad but true caveat with a false all-clear, which is strictly worse
+    for a tool whose job is to not miss things.
+    """
     from paperconan._workflow import DETECTOR_CAPS_REPORTED
 
-    assert DETECTOR_CAPS_REPORTED is True
+    assert DETECTOR_CAPS_REPORTED is False
+
+
+def test_a_block_wider_than_the_column_cap_is_still_an_unreported_gap():
+    """Pins the gap the caveat exists for, so it cannot be quietly forgotten.
+
+    A planted identical column is found at 110 columns and lost at 130, and the
+    scan reports complete either way. When this starts failing, the cap has been
+    wired and DETECTOR_CAPS_REPORTED can be revisited.
+    """
+    import tempfile
+    from pathlib import Path
+
+    from paperconan import BLOCK_FINDING_GROUPS
+
+    def kinds_at(width):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td) / "d"
+            d.mkdir()
+            header = ",".join(f"c{j}" for j in range(width))
+            lines = [header]
+            for i in range(15):
+                vals = [round((i + 1) * (j + 1) * 1.017, 6) for j in range(width)]
+                vals[3] = vals[1]          # an exactly duplicated column
+                lines.append(",".join(str(v) for v in vals))
+            (d / "p.csv").write_text("\n".join(lines) + "\n", encoding="utf-8")
+            scan = scan_dir(str(d), str(Path(td) / "out"), write_html=False)
+        found = {f.get("kind") for b in scan["relations_blocks"]
+                 for g in BLOCK_FINDING_GROUPS for f in (b.get(g) or [])}
+        return found, scan["scan_status"]
+
+    narrow_kinds, narrow_status = kinds_at(110)
+    wide_kinds, wide_status = kinds_at(130)
+
+    assert "identical_column" in narrow_kinds, "fixture no longer plants a signal"
+    assert "identical_column" not in wide_kinds, (
+        "the wide-block cap appears to have been wired — revisit "
+        "DETECTOR_CAPS_REPORTED and this test"
+    )
+    assert narrow_status == "complete"
+    assert wide_status == "complete", (
+        "the wide-block skip now reaches coverage; update DETECTOR_CAPS_REPORTED"
+    )
 
 
 def test_a_scan_limitation_reads_as_a_sentence_not_a_python_repr():
@@ -183,14 +225,57 @@ def test_a_scan_limitation_reads_as_a_sentence_not_a_python_repr():
     assert "rows=60" in text
 
 
-def test_a_clean_scan_now_reaches_complete_coverage(tmp_path):
-    """The end of the chain: nothing dropped anywhere, so the view may say so."""
-    from paperconan._drill import overview
+def test_an_ordinary_table_is_not_reported_as_truncated(tmp_path):
+    """The commonest supplementary shape must not read as a partial scan.
 
-    _panel(tmp_path / "d" / "p.csv", rows=12, cols=4)
+    A branch added and then withdrawn here fired on 61x14 purely for being tall,
+    which would have made "partial" the near-universal state and taught readers
+    to skip the coverage line entirely.
+    """
+    import random
+    random.seed(3)
+    d = tmp_path / "d"
+    d.mkdir(parents=True, exist_ok=True)
+    rows = [",".join(f"c{j}" for j in range(14))]
+    for _ in range(200):
+        rows.append(",".join(str(round(random.uniform(1, 999), 4)) for _ in range(14)))
+    (d / "p.csv").write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+    scan = scan_dir(str(d), str(tmp_path / "out"), write_html=False)
+
+    assert scan["scan_status"] == "complete", _reasons(scan)
+    assert scan["coverage"]["truncated"] is False
+
+
+def test_a_dense_table_that_really_fills_a_cap_is_reported(tmp_path):
+    """The other side of the same coin: when a cap genuinely bites, say so."""
+    _panel(tmp_path / "d" / "p.csv", rows=200, cols=14)
+
     scan = scan_dir(str(tmp_path / "d"), str(tmp_path / "out"), write_html=False)
 
-    view = overview(scan)
+    assert "detector_finding_limit" in _reasons(scan), _reasons(scan)
+    assert scan["scan_status"] == "partial"
 
-    assert view["coverage"]["detector_caps_reported"] is True
-    assert not any("detector-level caps" in x for x in view["coverage"]["limitations"])
+
+def test_a_result_cap_equal_to_the_natural_output_still_reports(tmp_path):
+    """Documents a known boundary rather than leaving it to be rediscovered.
+
+    Reaching the cap on the final iteration is indistinguishable, at the break
+    site, from being cut short. It errs toward "there may be more", which is the
+    safe direction here — a false all-clear is the failure this tool cannot
+    afford. Narrowing it needs per-break knowledge of what remained unexamined.
+    """
+    import paperconan._audit as audit
+
+    natural = len(audit.detect_scaled_row_reuse(_two_sheets(), profile="review",
+                                                max_findings=10**6))
+    coverage = ScanCoverage(files_discovered=1)
+
+    audit.detect_scaled_row_reuse(_two_sheets(), profile="review",
+                                  max_findings=natural, coverage=coverage)
+
+    reasons = [i["reason"] for i in coverage.to_dict()["limitations"]]
+    assert "detector_finding_limit" in reasons, (
+        "if this stops firing the boundary was narrowed — update the docstring "
+        "on _note_detector_cap"
+    )

--- a/tests/test_detector_cap_coverage.py
+++ b/tests/test_detector_cap_coverage.py
@@ -230,9 +230,15 @@ def test_a_detector_below_its_cap_records_nothing(name):
 
     coverage = ScanCoverage(files_discovered=1)
 
-    getattr(audit, name)(_two_sheets(), profile="review", max_findings=10**6,
-                         coverage=coverage)
+    # _grids_for, not _two_sheets: that fixture yields nothing for three of the
+    # five detectors, so `_capped` was unreachable and this assertion held by
+    # construction. Making a detector report its finding limit whenever it found
+    # anything then left the suite green -- the exact bug named above.
+    grids = _grids_for(name)
+    found = getattr(audit, name)(grids, profile="review", max_findings=10**6,
+                                 coverage=coverage)
 
+    assert found, f"{name}'s fixture produces nothing, so 'below its cap' is vacuous"
     assert not coverage.to_dict()["limitations"], (
         f"{name} reported a cap it never reached"
     )
@@ -548,10 +554,21 @@ def test_the_caveat_makes_no_claim_the_list_is_exhaustive():
     scan = {"scan_status": "partial", "coverage": ScanCoverage(files_discovered=1).to_dict()}
     blob = " ".join(_coverage_for(scan, [], [], [], 100)["limitations"]).lower()
 
-    for claim in ("what is reported appears in this list",
-                  "all limitations are listed",
-                  "this list is complete"):
-        assert claim not in blob, f"the caveat asserts completeness it does not have: {claim!r}"
+    # Pinned exactly rather than screened against a list of phrasings. A
+    # blacklist only catches the three wordings someone thought of: rewriting the
+    # closing sentence into a fresh, unhedged completeness claim passed it. An
+    # exact match cannot be worded around, and forces a deliberate decision on
+    # every edit to text whose whole job is to not overstate coverage.
+    expected = (
+        "some detector caps are still not reported: a detector that skipped a "
+        "block for being too wide or too tall, or stopped at an internal limit, "
+        "may not appear above. This line does not enumerate what is not reported."
+    )
+    assert expected.lower() in blob, (
+        "the unreported-cap caveat changed. Re-read it before updating this "
+        "string: every clause must say what MAY be missing, and none may assert "
+        f"that the list is complete.\nnow: {blob!r}"
+    )
 
 
 # ---------- a known gap, held honestly ----------
@@ -833,14 +850,20 @@ def test_every_scan_line_quoted_in_the_skill_is_one_the_code_can_emit():
     import re
     from pathlib import Path
 
+    import paperconan._audit as audit
     from paperconan._workflow import _coverage_for
 
     coverage = ScanCoverage(files_discovered=2)
     coverage.mark_file_failed("big.xlsx", "file_too_large")
+    # Read from production, not hardcoded: with both sides self-supplied, moving
+    # a default left SKILL.md quoting a limit the code no longer emits while this
+    # test stayed green.
     coverage.add_limitation("detector", "detector_candidate_pool_limit",
-                            detector="detect_short_row_reuse", limit=400)
+                            detector="detect_short_row_reuse",
+                            limit=audit._SHORT_ROW_MAX_ROWS_PER_SHEET)
     coverage.add_limitation("detector", "detector_finding_limit",
-                            detector="detect_row_pair_digit_coupling", limit=25)
+                            detector="detect_row_pair_digit_coupling",
+                            limit=audit._ROW_PAIR_MAX_FINDINGS_PER_BLOCK)
     coverage.add_limitation("detector", "detector_compute_budget_limit",
                             detector="detect_row_relations")
     scan = {"scan_status": "partial", "coverage": coverage.to_dict()}
@@ -928,4 +951,59 @@ def test_every_limitation_reason_is_either_quoted_in_the_skill_or_listed_as_unqu
         f"{len(undecided)} limitation reason(s) are neither shown in SKILL.md nor "
         f"listed as deliberately unquoted: {undecided}. Add an example to the skill, "
         f"or add the reason to _SCAN_REASONS_NOT_IN_SKILL with a note saying why."
+    )
+
+
+def test_one_detector_hitting_two_limits_records_both():
+    """The `reason` half of the dedup key, which had no test.
+
+    `detector` is pinned by test_two_detectors_capped_at_once_are_both_named, so
+    dropping it turns the suite red. Dropping `reason` did not: nothing recorded
+    two different limits for the same detector, and detectors really do reach
+    several -- detect_recurring_row_vectors has two budgets, and a detector can
+    exhaust a budget and fill its result cap in one scan. Merging them leaves a
+    survivor that implies the other pass ran to completion, which is the silent
+    shortening this file exists to prevent.
+    """
+    coverage = ScanCoverage(files_discovered=1)
+    coverage.add_limitation("detector", "detector_compute_budget_limit",
+                            detector="detect_recurring_row_vectors")
+    coverage.add_limitation("detector", "detector_finding_limit",
+                            detector="detect_recurring_row_vectors", limit=60)
+    coverage.add_limitation("detector", "detector_candidate_pool_limit",
+                            detector="detect_recurring_row_vectors", limit=400)
+
+    reasons = {i["reason"] for i in coverage.to_dict()["limitations"]}
+
+    assert reasons == {"detector_compute_budget_limit", "detector_finding_limit",
+                       "detector_candidate_pool_limit"}, (
+        f"one detector's distinct limits collapsed into {reasons}; the survivor "
+        f"implies the other passes ran to completion"
+    )
+
+
+def test_two_budgets_in_one_detector_survive_a_real_scan(tmp_path, monkeypatch):
+    """The same property end-to-end, since the unit test above builds records by hand.
+
+    detect_recurring_row_vectors has a cross-figure budget and a within-row
+    budget. Starving both is the production shape that a `reason`-less dedup key
+    would collapse.
+    """
+    import paperconan._audit as audit
+    monkeypatch.setattr(audit, "_RECURRING_VEC_BUDGET", 1)
+    monkeypatch.setattr(audit, "_WITHIN_ROW_VEC_BUDGET", 1)
+
+    # Two figure-named files: the cross-figure pass is skipped outright unless two
+    # distinct figure keys are present, so a single panel can only ever starve the
+    # within-row budget and the test would pin half the property.
+    _panel(tmp_path / "d" / "Figure 1a.csv")
+    _panel(tmp_path / "d" / "Figure 2b.csv")
+    scan = scan_dir(str(tmp_path / "d"), str(tmp_path / "out"), write_html=False)
+
+    reasons = {i["reason"] for i in (scan.get("coverage") or {}).get("limitations") or []
+               if i.get("detector") == "detect_recurring_row_vectors"}
+
+    assert len(reasons) >= 2, (
+        f"both starved budgets collapsed to {reasons}; a reader is told one pass "
+        f"was bounded and cannot learn the other was too"
     )

--- a/tests/test_detector_cap_coverage.py
+++ b/tests/test_detector_cap_coverage.py
@@ -501,7 +501,9 @@ def test_the_unreported_cap_caveat_reaches_the_packet(tmp_path):
     assert any("still not reported" in x for x in packet["coverage"]["limitations"]), (
         packet["coverage"]["limitations"]
     )
-    assert packet["coverage"]["coverage_complete"] is False
+    # Not asserting coverage_complete: the blanket caveat is appended whenever
+    # DETECTOR_CAPS_REPORTED is False, which is hardcoded, so that flag is False
+    # on a wholly clean scan too and cannot discriminate.
 
 
 # ---------- the record cap itself ----------
@@ -708,6 +710,18 @@ def test_the_html_coverage_row_distinguishes_one_capped_detector_from_another(tm
     )
     assert "limit=60" in html, "the cap value did not reach the report"
 
+    # A pool record separately: `candidates` is the quantity that says how much
+    # was dropped, and rendering only `limit` shows the reader the cap back at
+    # themselves. Only detect_scaled_row_reuse emits it, so the two-record
+    # fixture above cannot cover it.
+    pool = ScanCoverage(files_discovered=1)
+    pool.add_limitation("detector", "detector_candidate_pool_limit",
+                        detector="detect_scaled_row_reuse", candidates=1800, limit=1500)
+    pool_html = _render_scan_status({"scan_status": "partial", "coverage": pool.to_dict()})
+    assert "1800" in pool_html, (
+        f"the pool size did not reach the report: {pool_html}"
+    )
+
 
 def test_a_truncated_candidate_pool_reports_the_pool_not_the_cap(tmp_path, capsys):
     """The one number on the record has to say how much was dropped.
@@ -841,4 +855,77 @@ def test_every_scan_line_quoted_in_the_skill_is_one_the_code_can_emit():
     assert not unemittable, (
         f"SKILL.md quotes {len(unemittable)} scan: line(s) the code does not emit: "
         f"{unemittable}\nemitted here: {sorted(emitted)}"
+    )
+
+
+# Reasons the skill deliberately does not quote. Listing them here rather than
+# leaving the check one-directional: an agent that meets an unfamiliar `scan:`
+# line is likelier to skim it as noise than to be misled by an invented one, so
+# omission is the more dangerous direction. Adding a reason to the code without
+# deciding which side it belongs on now fails the test below.
+_SCAN_REASONS_NOT_IN_SKILL = {
+    # Renders exactly like the quoted file line with the sheet name appended, and
+    # the bullet says so in prose.
+    "sheet_too_large",
+    # Provenance of a formula sidecar, not a bound on what was searched: no
+    # numeric coverage is lost, so it does not change how a result is read.
+    "formula_cache_missing",
+    "formula_cache_unreadable",
+    # Two of detect_recurring_row_vectors' budgets. They read as
+    # "detector cross figure budget limit ..." — recognisable from the quoted
+    # compute-budget example, and quoting every budget variant would bloat the
+    # bullet without teaching the agent anything new.
+    "detector_cross_figure_budget_limit",
+    "detector_within_row_budget_limit",
+}
+
+
+def test_every_limitation_reason_is_either_quoted_in_the_skill_or_listed_as_unquoted():
+    """The reverse direction: a reason the code can emit and nobody decided about.
+
+    The forward check stops SKILL.md inventing shapes. On its own it says nothing
+    about the ones the code emits and the skill omits -- and under a heading that
+    reads as an enumeration, an unlisted line is read as noise. This forces a
+    decision per reason rather than letting the set drift.
+    """
+    import ast
+    from pathlib import Path
+
+    # Extracted from the call sites, not by pattern-matching identifiers: the
+    # reason is a positional literal whose index depends on the helper, and a
+    # loose regex picks up unrelated names like a test's "file_a".
+    reason_arg = {"add_limitation": 1, "_note_detector_cap": 2,
+                  "mark_file_failed": 1, "mark_sheet_skipped": 2}
+    src = Path(__file__).resolve().parents[1] / "src" / "paperconan"
+    reasons = set()
+    for path in sorted(src.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            fn = node.func
+            name = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", None)
+            idx = reason_arg.get(name)
+            if idx is None or len(node.args) <= idx:
+                continue
+            arg = node.args[idx]
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                reasons.add(arg.value)
+
+    assert reasons, "no limitation reasons found; did the helpers get renamed?"
+
+    skill = (Path(__file__).resolve().parents[1] / "skills" / "paperconan"
+             / "SKILL.md").read_text(encoding="utf-8")
+
+    def shown(reason):
+        # _describe_scan_limitation renders a reason by stripping the _limit
+        # suffix and swapping underscores for spaces.
+        return reason.replace("_limit", "").replace("_", " ") in skill
+
+    undecided = sorted(r for r in reasons
+                       if r not in _SCAN_REASONS_NOT_IN_SKILL and not shown(r))
+    assert not undecided, (
+        f"{len(undecided)} limitation reason(s) are neither shown in SKILL.md nor "
+        f"listed as deliberately unquoted: {undecided}. Add an example to the skill, "
+        f"or add the reason to _SCAN_REASONS_NOT_IN_SKILL with a note saying why."
     )

--- a/tests/test_detector_cap_coverage.py
+++ b/tests/test_detector_cap_coverage.py
@@ -856,10 +856,15 @@ def test_every_scan_line_quoted_in_the_skill_is_one_the_code_can_emit():
     coverage = ScanCoverage(files_discovered=3)
     coverage.mark_file_failed("big.xlsx", "file_too_large")
     coverage.mark_file_failed("notes.xlsx", "unreadable")
+    coverage.add_limitation("file", "formula_cache_unreadable", file="m.xlsx")
+    # Field-for-field as _audit.py passes them: `count` is the population and
+    # `cells` a bounded example list. An earlier fixture passed cells=812 as an
+    # int, so the skill quoted a shape production cannot emit and the guard
+    # accepted it -- both sides supplying the same fiction.
     coverage.add_limitation("sheet", "formula_cache_missing", file="m.xlsx",
-                            sheet="Fig 3b", cells=812)
-    coverage.add_limitation("report", "report_block_limit", file="m.xlsx",
-                            sheet="Fig 3b", count=200)
+                            sheet="Fig 3b", count=812, cells=["C4", "C5", "C6"])
+    coverage.mark_blocks_skipped(3, scope="sheet", reason="report_block_limit",
+                                 file="m.xlsx", sheet="Fig 3b")
     # Read from production, not hardcoded: with both sides self-supplied, moving
     # a default left SKILL.md quoting a limit the code no longer emits while this
     # test stayed green.
@@ -898,10 +903,13 @@ _SCAN_REASONS_NOT_IN_SKILL = {
     # formula_cache_missing is NOT here: per _formula_cache.py a formula cell
     # with no cached value is invisible to the numeric audit, so it is a silent
     # under-read and the skill quotes it.
-    # Inspection itself failed, so how many cells went unread is unknown. Quoting
-    # a count would overstate what the record knows; the missing-cache line above
-    # it already teaches the agent what the class means.
-    "formula_cache_unreadable",
+    # The two bounds that stop the formula-cache inspection early. They render
+    # as "formula metadata byte limit ..." / "... sheet limit ...", both named in
+    # the skill's `formula cache unreadable` bullet as the same class -- the
+    # inspection did not complete, so whether cells went unread is unknown. A
+    # line each would repeat that with no new instruction.
+    "formula_metadata_byte_limit",
+    "formula_metadata_sheet_limit",
     # Two of detect_recurring_row_vectors' budgets. They read as
     # "detector cross figure budget limit ..." — recognisable from the quoted
     # compute-budget example, and quoting every budget variant would bloat the
@@ -928,7 +936,11 @@ def test_every_limitation_reason_is_either_quoted_in_the_skill_or_listed_as_unqu
     # loose regex picks up unrelated names like a test's "file_a".
     reason_arg = {"add_limitation": 1, "_note_detector_cap": 2,
                   "mark_file_failed": 1, "mark_sheet_skipped": 2,
-                  "mark_blocks_skipped": 2}
+                  "mark_blocks_skipped": 2,
+                  # Raised, not recorded: the exception carries the reason to
+                  # _audit's `exc.reason` forward, so its raise sites are where
+                  # those names are actually written.
+                  "OoxmlFormulaInspectionLimit": 0}
     # Reasons also arrive as keywords, and one is a non-literal (exc.reason).
     # Skipping either silently is how three reasons drifted past the first
     # version of this guard, so a non-literal is collected as a marker and has to
@@ -965,9 +977,12 @@ def test_every_limitation_reason_is_either_quoted_in_the_skill_or_listed_as_unqu
 
     # Non-literal reason arguments are accounted for rather than dropped: a
     # silent skip is how a reason reaches production without anyone deciding
-    # whether the skill should name it. These three are pass-throughs -- two
-    # helper forwards and _extract's exception, whose own reasons are literals
-    # collected at their raise sites -- so they introduce no new name.
+    # whether the skill should name it. `reason` is the parameter name on the
+    # four helpers that forward it (_coverage's three recorders and
+    # _note_detector_cap); `exc.reason` is _audit forwarding
+    # OoxmlFormulaInspectionLimit, whose own names are literals at the raise
+    # sites -- which are only collected because that constructor is in the map
+    # above. Neither introduces a name this walk has not already seen.
     expected_pass_throughs = {"reason", "exc.reason"}
     assert non_literal <= expected_pass_throughs, (
         f"a reason is built rather than written literally: "

--- a/tests/test_detector_cap_coverage.py
+++ b/tests/test_detector_cap_coverage.py
@@ -90,10 +90,10 @@ def _two_sheets():
 def test_each_capped_detector_reports_reaching_its_finding_limit(name):
     """Every capped detector is wired to the coverage object.
 
-    Uses max_findings=1 against a fixture rich enough that several of these
-    detectors produce more than one finding. Detectors the fixture cannot drive
-    past one are skipped rather than asserted vacuously — a detector that never
-    reaches its cap correctly records nothing.
+    Behavioural where the fixture can drive the detector past its cap;
+    structural where it cannot. Skipping the latter would make an unwired
+    detector look the same as an un-driven one, which is the gap this whole
+    change exists to close.
     """
     import paperconan._audit as audit
 
@@ -101,16 +101,28 @@ def test_each_capped_detector_reports_reaching_its_finding_limit(name):
 
     natural = len(getattr(audit, name)(_two_sheets(), profile="review",
                                        max_findings=10**6))
-    if natural < 2:
-        pytest.skip(f"{name} yields {natural} finding(s) on this fixture; "
-                    "cannot drive it past its cap")
+    if natural >= 2:
+        getattr(audit, name)(_two_sheets(), profile="review", max_findings=1,
+                             coverage=coverage)
+        reasons = [item["reason"] for item in coverage.to_dict()["limitations"]]
+        assert "detector_finding_limit" in reasons, (
+            f"{name} was cut short without recording it: {reasons}"
+        )
+        return
 
-    getattr(audit, name)(_two_sheets(), profile="review", max_findings=1,
-                         coverage=coverage)
+    # This fixture cannot drive the detector past its cap — its own gates
+    # (band separation, value frequency, precision) reject the shapes that
+    # would. Skipping here would be indistinguishable from the wiring being
+    # absent, so assert the wiring structurally instead: an unwired detector
+    # fails this, a merely un-driven one does not.
+    import inspect
 
-    reasons = [item["reason"] for item in coverage.to_dict()["limitations"]]
-    assert "detector_finding_limit" in reasons, (
-        f"{name} was cut short without recording it: {reasons}"
+    fn = getattr(audit, name)
+    assert "coverage" in inspect.signature(fn).parameters, f"{name} takes no coverage"
+    source = inspect.getsource(fn)
+    assert "_note_detector_cap" in source, f"{name} records no cap"
+    assert "_capped = _capped or len(findings) >= max_findings" in source, (
+        f"{name} does not set its result-cap flag at a break site"
     )
 
 
@@ -286,18 +298,25 @@ def test_a_result_cap_equal_to_the_natural_output_still_reports(tmp_path):
 
 # ---------- the three claims that outran their coverage ----------
 
+# (detector, budget constant, expected reason). detect_recurring_row_vectors has
+# two budgets with distinct reasons: sharing one would collapse them in the
+# coverage dedup key and the survivor would imply the other pass ran to
+# completion.
 _BUDGETS = (
-    ("detect_recurring_row_vectors", "_RECURRING_VEC_BUDGET"),
-    ("detect_scaled_row_reuse", "_SCALED_ROW_BUDGET"),
-    ("detect_short_row_reuse", "_SHORT_ROW_BUDGET"),
-    ("detect_within_row_shared_fraction", "_WITHIN_ROW_FRAC_BUDGET"),
-    ("detect_row_pair_shared_fraction", "_ROW_PAIR_FRAC_BUDGET"),
+    ("detect_recurring_row_vectors", "_RECURRING_VEC_BUDGET",
+     "detector_cross_figure_budget_limit"),
+    ("detect_recurring_row_vectors", "_WITHIN_ROW_VEC_BUDGET",
+     "detector_within_row_budget_limit"),
+    ("detect_scaled_row_reuse", "_SCALED_ROW_BUDGET", "detector_compute_budget_limit"),
+    ("detect_short_row_reuse", "_SHORT_ROW_BUDGET", "detector_compute_budget_limit"),
+    ("detect_within_row_shared_fraction", "_WITHIN_ROW_FRAC_BUDGET", "detector_compute_budget_limit"),
+    ("detect_row_pair_shared_fraction", "_ROW_PAIR_FRAC_BUDGET", "detector_compute_budget_limit"),
 )
 
 
-@pytest.mark.parametrize("detector,budget_const", _BUDGETS)
+@pytest.mark.parametrize("detector,budget_const,reason", _BUDGETS)
 def test_a_spent_budget_is_not_reported_as_a_result_cap(detector, budget_const,
-                                                        monkeypatch):
+                                                        reason, monkeypatch):
     """C1': a scripted rewrite folded two break conditions into one flag.
 
     A detector that exhausts its compute budget and returns nothing then
@@ -313,15 +332,19 @@ def test_a_spent_budget_is_not_reported_as_a_result_cap(detector, budget_const,
                                      max_findings=10**6, coverage=coverage)
 
     reasons = [i["reason"] for i in coverage.to_dict()["limitations"]]
-    assert not found, "budget of 1 should starve the detector"
-    assert "detector_finding_limit" not in reasons, (
-        f"{detector} produced nothing but reported a result cap: {reasons}"
-    )
+    # Some detectors have more than one budget, so starving one need not empty
+    # the result list. The invariant is the same either way: a spent budget is
+    # not a result cap, and must never be reported as one.
+    assert reason in reasons, f"{detector} spent its budget without saying so: {reasons}"
+    if not found:
+        assert "detector_finding_limit" not in reasons, (
+            f"{detector} produced nothing but reported a result cap: {reasons}"
+        )
 
 
-@pytest.mark.parametrize("detector,budget_const", _BUDGETS)
+@pytest.mark.parametrize("detector,budget_const,reason", _BUDGETS)
 def test_each_detector_reports_its_own_exhausted_budget(detector, budget_const,
-                                                        monkeypatch):
+                                                        reason, monkeypatch):
     """Pins the budget wiring itself — untestable while these were literals."""
     import paperconan._audit as audit
     monkeypatch.setattr(audit, budget_const, 1)
@@ -330,7 +353,26 @@ def test_each_detector_reports_its_own_exhausted_budget(detector, budget_const,
     getattr(audit, detector)(_two_sheets(), profile="review", coverage=coverage)
 
     named = [(i.get("detector"), i["reason"]) for i in coverage.to_dict()["limitations"]]
-    assert (detector, "detector_compute_budget_limit") in named, named
+    assert (detector, reason) in named, named
+
+
+def test_a_truncated_candidate_pool_is_not_called_a_budget_limit():
+    """Two causes, two names. The stderr line prints budget_exhausted=False while
+    the structured record used to say the budget was spent — sending a reader to
+    a knob that never moved."""
+    import paperconan._audit as audit
+
+    coverage = ScanCoverage(files_discovered=1)
+    audit.detect_scaled_row_reuse(_two_sheets(), profile="review",
+                                  max_candidates=3, max_findings=1,
+                                  coverage=coverage)
+
+    reasons = [i["reason"] for i in coverage.to_dict()["limitations"]]
+    if "detector_candidate_pool_limit" not in reasons:
+        pytest.skip("fixture no longer truncates the candidate pool")
+    assert "detector_compute_budget_limit" not in reasons, (
+        f"a full compute budget was reported as spent: {reasons}"
+    )
 
 
 def test_two_detectors_capped_at_once_are_both_named():

--- a/tests/test_detector_cap_coverage.py
+++ b/tests/test_detector_cap_coverage.py
@@ -33,6 +33,77 @@ def _panel(path, rows=40, cols=14):
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
+def _shared_tail_within_row():
+    """Cells in one row sharing a >=6-digit fractional tail, integer parts apart.
+
+    _WITHIN_ROW_FRAC_MIN_DIGITS is 6, so a shorter tail is not evidence and the
+    detector rejects it. Six such cells per row give the detector more than one
+    finding to report, which is what a result cap needs in order to bite.
+    """
+    rows = [[f"c{j}" for j in range(12)]]
+    tails = (0.316768, 0.847215, 0.529437, 0.163094)
+    for i in range(8):
+        tail = tails[i % len(tails)]
+        row = [round((j + 1) * 7 + tail, 6) for j in range(6)]
+        row += [round(1.0173 * (i + 1) * (j + 1), 6) for j in range(6)]
+        rows.append(row)
+    return rows
+
+
+def _shared_tail_across_rows():
+    """Row pairs sharing a fractional tail over >=_ROW_PAIR_MIN_RUN aligned columns."""
+    rows = [[f"c{j}" for j in range(12)]]
+    for i in range(8):
+        base = [round(0.1234 + j * 0.0917 + i * 0.0031, 6) for j in range(12)]
+        rows.append(base)
+        rows.append([round(v + 10 * (j + 1), 6) for j, v in enumerate(base)])
+    return rows
+
+
+def _repeated_short_rows():
+    """Short high-precision rows repeated verbatim, one repeat per band.
+
+    detect_short_row_reuse wants 3..11 columns at >=5 significant figures, and
+    _short_row_candidates drops any row _vector_is_patterned accepts -- so the
+    values have to be irregular, not a progression. Each pair is separated by a
+    label row so the two rows sit in different bands.
+    """
+    vectors = (
+        (13.40712, 27.91834, 8.52619, 41.06375, 19.73408, 33.28951),
+        (22.61483, 9.34026, 37.15792, 14.80613, 29.47158, 6.92374),
+        (31.08627, 17.25913, 44.63081, 11.39754, 26.81420, 38.54269),
+        (7.83415, 35.60298, 20.14763, 42.97531, 15.28640, 28.36107),
+    )
+    rows = [[f"c{j}" for j in range(6)]]
+    for i, vec in enumerate(vectors):
+        rows.append(list(vec))
+        rows.append([f"panel {i}", None, None, None, None, None])
+        rows.append(list(vec))
+    return rows
+
+
+_DETECTOR_GRIDS = {
+    "detect_within_row_shared_fraction": _shared_tail_within_row,
+    "detect_row_pair_shared_fraction": _shared_tail_across_rows,
+    "detect_short_row_reuse": _repeated_short_rows,
+}
+
+
+def _grids_for(name):
+    """The fixture that drives `name` past its cap.
+
+    Most detectors are driven by the shared _two_sheets() block. The two
+    shared-fraction detectors gate on fractional-digit agreement, which that
+    block does not produce, so they get a grid built to their own contract.
+    """
+    from paperconan._sheet import Sheet
+
+    build = _DETECTOR_GRIDS.get(name)
+    if build is None:
+        return _two_sheets()
+    return {(f"{s}.csv", s): Sheet.from_rows(build()) for s in ("Figure 1a", "Figure 2b")}
+
+
 def _reasons(scan):
     return [item.get("reason") for item in (scan.get("coverage") or {}).get("limitations") or []]
 
@@ -99,30 +170,22 @@ def test_each_capped_detector_reports_reaching_its_finding_limit(name):
 
     coverage = ScanCoverage(files_discovered=1)
 
-    natural = len(getattr(audit, name)(_two_sheets(), profile="review",
-                                       max_findings=10**6))
-    if natural >= 2:
-        getattr(audit, name)(_two_sheets(), profile="review", max_findings=1,
-                             coverage=coverage)
-        reasons = [item["reason"] for item in coverage.to_dict()["limitations"]]
-        assert "detector_finding_limit" in reasons, (
-            f"{name} was cut short without recording it: {reasons}"
-        )
-        return
+    grids = _grids_for(name)
+    natural = len(getattr(audit, name)(grids, profile="review", max_findings=10**6))
+    # Every capped detector gets a fixture that actually drives it past its cap.
+    # An earlier version fell back to asserting on inspect.getsource() when the
+    # shared fixture produced nothing; that check passed for a call with the
+    # wrong reason string and for one made provably unreachable, so two unwired
+    # detectors survived it.
+    assert natural >= 2, (
+        f"{name}'s fixture no longer produces enough findings to reach a cap "
+        f"(got {natural}); fix the fixture rather than weakening the assertion"
+    )
 
-    # This fixture cannot drive the detector past its cap — its own gates
-    # (band separation, value frequency, precision) reject the shapes that
-    # would. Skipping here would be indistinguishable from the wiring being
-    # absent, so assert the wiring structurally instead: an unwired detector
-    # fails this, a merely un-driven one does not.
-    import inspect
-
-    fn = getattr(audit, name)
-    assert "coverage" in inspect.signature(fn).parameters, f"{name} takes no coverage"
-    source = inspect.getsource(fn)
-    assert "_note_detector_cap" in source, f"{name} records no cap"
-    assert "_capped = _capped or len(findings) >= max_findings" in source, (
-        f"{name} does not set its result-cap flag at a break site"
+    getattr(audit, name)(grids, profile="review", max_findings=1, coverage=coverage)
+    reasons = [item["reason"] for item in coverage.to_dict()["limitations"]]
+    assert "detector_finding_limit" in reasons, (
+        f"{name} was cut short without recording it: {reasons}"
     )
 
 
@@ -172,11 +235,12 @@ def test_an_uncapped_scan_records_no_detector_limitation(tmp_path):
 def test_the_unreported_cap_caveat_stays_until_every_cap_is_wired():
     """Result caps are wired; many resource caps are not.
 
-    An audit of the detector layer found 17 that still report nowhere —
-    _MAX_BLOCK_COLS drops detect_relations entirely on a wide block while the
-    scan calls itself complete. Flipping this flag on partial wiring replaced an
-    over-broad but true caveat with a false all-clear, which is strictly worse
-    for a tool whose job is to not miss things.
+    _MAX_BLOCK_COLS drops detect_relations entirely on a wide block, and
+    detect_row_relations' row ceiling drops an exact relation at 61 rows -- both
+    while the scan calls itself complete. Flipping this flag on partial wiring
+    replaced an over-broad but true caveat with a false all-clear, which is
+    strictly worse for a tool whose job is to not miss things. (No count is
+    cited: an earlier version gave one that no reader could verify.)
     """
     from paperconan._workflow import DETECTOR_CAPS_REPORTED
 
@@ -368,8 +432,12 @@ def test_a_truncated_candidate_pool_is_not_called_a_budget_limit():
                                   coverage=coverage)
 
     reasons = [i["reason"] for i in coverage.to_dict()["limitations"]]
-    if "detector_candidate_pool_limit" not in reasons:
-        pytest.skip("fixture no longer truncates the candidate pool")
+    # Asserted, not skipped: a fixture that stops exercising the path is a test
+    # failure. Skipping here would pass just as happily if the wiring were
+    # deleted, which is the defect this test exists to catch.
+    assert "detector_candidate_pool_limit" in reasons, (
+        f"the truncated candidate pool was not recorded under its own name: {reasons}"
+    )
     assert "detector_compute_budget_limit" not in reasons, (
         f"a full compute budget was reported as spent: {reasons}"
     )
@@ -414,3 +482,86 @@ def test_the_unreported_cap_caveat_reaches_the_packet(tmp_path):
         packet["coverage"]["limitations"]
     )
     assert packet["coverage"]["coverage_complete"] is False
+
+
+# ---------- the record cap itself ----------
+
+def test_limitations_dropped_by_the_record_cap_are_disclosed(tmp_path, monkeypatch):
+    """The list is capped, so the packet must not imply it is exhaustive.
+
+    ScanCoverage stops retaining records past PAPERCONAN_MAX_LIMITATIONS and
+    counts the rest in `limitations_omitted`. The HTML report renders that
+    count; the workflow packet used to iterate `limitations` alone, so on a
+    scan with more limitations than the cap it silently showed a short list.
+    A reader deciding whether a paper's numbers are fully enumerated has no way
+    to tell a complete list from a truncated one.
+    """
+    monkeypatch.setenv("PAPERCONAN_MAX_LIMITATIONS", "3")
+    from paperconan._workflow import _coverage_for
+
+    coverage = ScanCoverage(files_discovered=1)
+    for i in range(10):
+        coverage.add_limitation("sheet", "sheet_unreadable_limit", file=f"f{i}.xlsx",
+                                sheet=f"S{i}")
+    scan = {"scan_status": "partial", "coverage": coverage.to_dict()}
+
+    cov = _coverage_for(scan, [], [], [], 100)
+    blob = " ".join(cov["limitations"])
+
+    assert coverage.to_dict()["limitations_omitted"] == 7, "fixture no longer overflows the cap"
+    assert "7" in blob and "cap" in blob.lower(), (
+        f"7 dropped limitations were not disclosed: {cov['limitations']}"
+    )
+
+
+def test_the_caveat_makes_no_claim_the_list_is_exhaustive():
+    """A hedge is honest; an unhedged positive claim about coverage is not.
+
+    Every other clause in the caveat says what *may* be missing. Any sentence
+    asserting that what is reported is all there is has to be true of the
+    capped, deduped list — and it is not.
+    """
+    from paperconan._workflow import _coverage_for
+
+    scan = {"scan_status": "partial", "coverage": ScanCoverage(files_discovered=1).to_dict()}
+    blob = " ".join(_coverage_for(scan, [], [], [], 100)["limitations"]).lower()
+
+    for claim in ("what is reported appears in this list",
+                  "all limitations are listed",
+                  "this list is complete"):
+        assert claim not in blob, f"the caveat asserts completeness it does not have: {claim!r}"
+
+
+# ---------- a known gap, held honestly ----------
+
+def test_a_block_past_the_row_cap_loses_relations_and_says_nothing(tmp_path):
+    """Pins a real blind spot so it cannot widen unnoticed.
+
+    detect_row_relations returns early above _ROW_REL_MAX_ROWS. That bound is a
+    cost cap, not a scope rule: a 61x14 block is well inside the detector's
+    orientation (14 >= _ROW_REL_MIN_COLS), and an exact relation there is lost
+    while scan_status stays "complete". The behaviour is deliberate for now --
+    the shape is common enough that reporting it would train readers to skip
+    the coverage line -- but it is a gap, and the workflow's caveat is what
+    currently covers it. If this test starts failing because the relation is
+    found, the cap was raised: delete the test.
+    """
+    import csv
+
+    def kinds_at(n_rows):
+        d = tmp_path / f"r{n_rows}"
+        d.mkdir(parents=True, exist_ok=True)
+        grid = [[round(3.7 * i + 1.13 * j, 4) for j in range(14)] for i in range(n_rows)]
+        grid[1] = [round(3.0 * v, 6) for v in grid[0]]
+        with open(d / "t.csv", "w", newline="") as fh:
+            csv.writer(fh).writerows(grid)
+        scan = scan_dir(str(d), str(d / "out"), write_html=False)
+        return {f.get("kind") for b in scan["relations_blocks"]
+                for f in (b.get("row_relations") or [])}, scan
+
+    under, _ = kinds_at(60)
+    over, scan_over = kinds_at(61)
+
+    assert "constant_ratio_row" in under, "fixture no longer plants a detectable relation"
+    assert "constant_ratio_row" not in over, "the row cap no longer drops it -- delete this test"
+    assert scan_over["scan_status"] == "complete", "the gap is now reported; update this test"

--- a/tests/test_detector_cap_coverage.py
+++ b/tests/test_detector_cap_coverage.py
@@ -853,8 +853,13 @@ def test_every_scan_line_quoted_in_the_skill_is_one_the_code_can_emit():
     import paperconan._audit as audit
     from paperconan._workflow import _coverage_for
 
-    coverage = ScanCoverage(files_discovered=2)
+    coverage = ScanCoverage(files_discovered=3)
     coverage.mark_file_failed("big.xlsx", "file_too_large")
+    coverage.mark_file_failed("notes.xlsx", "unreadable")
+    coverage.add_limitation("sheet", "formula_cache_missing", file="m.xlsx",
+                            sheet="Fig 3b", cells=812)
+    coverage.add_limitation("report", "report_block_limit", file="m.xlsx",
+                            sheet="Fig 3b", count=200)
     # Read from production, not hardcoded: with both sides self-supplied, moving
     # a default left SKILL.md quoting a limit the code no longer emits while this
     # test stayed green.
@@ -890,9 +895,12 @@ _SCAN_REASONS_NOT_IN_SKILL = {
     # Renders exactly like the quoted file line with the sheet name appended, and
     # the bullet says so in prose.
     "sheet_too_large",
-    # Provenance of a formula sidecar, not a bound on what was searched: no
-    # numeric coverage is lost, so it does not change how a result is read.
-    "formula_cache_missing",
+    # formula_cache_missing is NOT here: per _formula_cache.py a formula cell
+    # with no cached value is invisible to the numeric audit, so it is a silent
+    # under-read and the skill quotes it.
+    # Inspection itself failed, so how many cells went unread is unknown. Quoting
+    # a count would overstate what the record knows; the missing-cache line above
+    # it already teaches the agent what the class means.
     "formula_cache_unreadable",
     # Two of detect_recurring_row_vectors' budgets. They read as
     # "detector cross figure budget limit ..." — recognisable from the quoted
@@ -912,13 +920,20 @@ def test_every_limitation_reason_is_either_quoted_in_the_skill_or_listed_as_unqu
     decision per reason rather than letting the set drift.
     """
     import ast
+    import re
     from pathlib import Path
 
     # Extracted from the call sites, not by pattern-matching identifiers: the
     # reason is a positional literal whose index depends on the helper, and a
     # loose regex picks up unrelated names like a test's "file_a".
     reason_arg = {"add_limitation": 1, "_note_detector_cap": 2,
-                  "mark_file_failed": 1, "mark_sheet_skipped": 2}
+                  "mark_file_failed": 1, "mark_sheet_skipped": 2,
+                  "mark_blocks_skipped": 2}
+    # Reasons also arrive as keywords, and one is a non-literal (exc.reason).
+    # Skipping either silently is how three reasons drifted past the first
+    # version of this guard, so a non-literal is collected as a marker and has to
+    # be accounted for explicitly rather than vanishing.
+    non_literal = set()
     src = Path(__file__).resolve().parents[1] / "src" / "paperconan"
     reasons = set()
     for path in sorted(src.glob("*.py")):
@@ -929,21 +944,48 @@ def test_every_limitation_reason_is_either_quoted_in_the_skill_or_listed_as_unqu
             fn = node.func
             name = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", None)
             idx = reason_arg.get(name)
-            if idx is None or len(node.args) <= idx:
+            if idx is None:
                 continue
-            arg = node.args[idx]
+            arg = None
+            if len(node.args) > idx:
+                arg = node.args[idx]
+            else:
+                for kw in node.keywords:
+                    if kw.arg == "reason":
+                        arg = kw.value
+                        break
+            if arg is None:
+                continue
             if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
                 reasons.add(arg.value)
+            else:
+                non_literal.add(ast.unparse(arg))
 
     assert reasons, "no limitation reasons found; did the helpers get renamed?"
 
+    # Non-literal reason arguments are accounted for rather than dropped: a
+    # silent skip is how a reason reaches production without anyone deciding
+    # whether the skill should name it. These three are pass-throughs -- two
+    # helper forwards and _extract's exception, whose own reasons are literals
+    # collected at their raise sites -- so they introduce no new name.
+    expected_pass_throughs = {"reason", "exc.reason"}
+    assert non_literal <= expected_pass_throughs, (
+        f"a reason is built rather than written literally: "
+        f"{sorted(non_literal - expected_pass_throughs)}. This guard cannot see "
+        f"its value, so decide explicitly: give it a literal, or account for it "
+        f"here."
+    )
+
     skill = (Path(__file__).resolve().parents[1] / "skills" / "paperconan"
              / "SKILL.md").read_text(encoding="utf-8")
+    quoted_lines = re.findall(r"`(scan: [^`]+)`", skill)
 
     def shown(reason):
-        # _describe_scan_limitation renders a reason by stripping the _limit
-        # suffix and swapping underscores for spaces.
-        return reason.replace("_limit", "").replace("_", " ") in skill
+        # Matched inside a quoted `scan: ...` line, not as a bare substring:
+        # "unreadable" passed on an unrelated `unreadable_asset_ids` field
+        # elsewhere in the skill, so a whole unread file counted as documented.
+        phrase = reason.replace("_limit", "").replace("_", " ")
+        return any(phrase in line for line in quoted_lines)
 
     undecided = sorted(r for r in reasons
                        if r not in _SCAN_REASONS_NOT_IN_SKILL and not shown(r))

--- a/tests/test_detector_cap_coverage.py
+++ b/tests/test_detector_cap_coverage.py
@@ -104,6 +104,24 @@ def _grids_for(name):
     return {(f"{s}.csv", s): Sheet.from_rows(build()) for s in ("Figure 1a", "Figure 2b")}
 
 
+def _write_csv(path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(",".join("" if v is None else str(v) for v in r) for r in rows) + "\n",
+        encoding="utf-8")
+
+
+def _grid_for_pool_cap(detector):
+    """A grid with more candidate rows than the pool cap under test.
+
+    Each of these detectors builds its candidate list through its own gates, so
+    a grid that overflows one does not overflow the other.
+    """
+    if detector == "detect_row_pair_shared_fraction":
+        return _shared_tail_across_rows()
+    return _repeated_short_rows()
+
+
 def _reasons(scan):
     return [item.get("reason") for item in (scan.get("coverage") or {}).get("limitations") or []]
 
@@ -663,3 +681,82 @@ def test_a_tall_band_loses_scaled_row_reuse_and_says_nothing():
 
     assert under, "fixture no longer produces cross-sheet row reuse at 60 rows"
     assert not over, "the band ceiling no longer silences this detector -- update this test"
+
+
+def test_the_html_coverage_row_distinguishes_one_capped_detector_from_another(tmp_path):
+    """Detector records carry no file or sheet, so the name is all there is.
+
+    The dedup key was widened to keep each capped detector as its own record;
+    the renderer then dropped the field that made them distinguishable, so three
+    capped detectors rendered as three identical rows that read as a display
+    bug. Asserted on the rendered markup because the scan.json side was already
+    green while this was broken.
+    """
+    from paperconan._html import _render_scan_status
+
+    coverage = ScanCoverage(files_discovered=1)
+    coverage.add_limitation("detector", "detector_finding_limit",
+                            detector="detect_short_row_reuse", limit=60)
+    coverage.add_limitation("detector", "detector_finding_limit",
+                            detector="detect_scaled_row_reuse", limit=60)
+
+    html = _render_scan_status({"scan_status": "partial", "coverage": coverage.to_dict()})
+
+    assert "detect_short_row_reuse" in html and "detect_scaled_row_reuse" in html, (
+        "the reader cannot tell which detector was capped"
+    )
+    assert "limit=60" in html, "the cap value did not reach the report"
+
+
+def test_a_truncated_candidate_pool_reports_the_pool_not_the_cap(tmp_path):
+    """The one number on the record has to say how much was dropped.
+
+    len(cands) is read after the slice, so reporting it prints max_candidates
+    back at the reader -- the same value in every scan, and no way to recover
+    how large the pool actually was.
+    """
+    import paperconan._audit as audit
+
+    coverage = ScanCoverage(files_discovered=1)
+    grids = _grids_for("detect_scaled_row_reuse")
+    pool = len(audit._scaled_row_candidates(grids))
+
+    audit.detect_scaled_row_reuse(grids, profile="review", max_candidates=3,
+                                  max_findings=10**6, coverage=coverage)
+
+    record = next(i for i in coverage.to_dict()["limitations"]
+                  if i["reason"] == "detector_candidate_pool_limit")
+    assert pool > 3, "fixture no longer overflows the candidate cap"
+    assert record["candidates"] == pool, (
+        f"reported {record['candidates']} candidates for a pool of {pool}"
+    )
+    assert record["limit"] == 3
+
+
+@pytest.mark.parametrize("detector,knob,reason", [
+    ("detect_short_row_reuse", "_SHORT_ROW_MAX_ROWS_PER_SHEET",
+     "detector_candidate_pool_limit"),
+    ("detect_row_pair_shared_fraction", "_ROW_PAIR_MAX_ROWS_PER_SHEET",
+     "detector_candidate_pool_limit"),
+])
+def test_sibling_candidate_pool_caps_reach_coverage(tmp_path, monkeypatch,
+                                                    detector, knob, reason):
+    """The same construct as max_candidates, in the detectors that also have it.
+
+    One of these reported on stderr only and the other was silent everywhere,
+    so an identical event flipped scan_status in one detector and vanished in
+    two others.
+    """
+    import paperconan._audit as audit
+    monkeypatch.setattr(audit, knob, 2)
+
+    _write_csv(tmp_path / "d" / "p.csv", _grid_for_pool_cap(detector))
+    scan = scan_dir(str(tmp_path / "d"), str(tmp_path / "out"), write_html=False)
+
+    records = [i for i in (scan.get("coverage") or {}).get("limitations") or []
+               if i.get("detector") == detector and i.get("reason") == reason]
+    assert records, (
+        f"{detector}'s candidate pool was cut at {knob} without recording it: "
+        f"{_reasons(scan)}"
+    )
+    assert scan["scan_status"] != "complete"

--- a/tests/test_detector_cap_coverage.py
+++ b/tests/test_detector_cap_coverage.py
@@ -161,10 +161,11 @@ def _two_sheets():
 def test_each_capped_detector_reports_reaching_its_finding_limit(name):
     """Every capped detector is wired to the coverage object.
 
-    Behavioural where the fixture can drive the detector past its cap;
-    structural where it cannot. Skipping the latter would make an unwired
-    detector look the same as an un-driven one, which is the gap this whole
-    change exists to close.
+    Behavioural for all five: each gets a fixture built to its own gates and is
+    driven past its cap for real. An earlier version fell back to asserting on
+    inspect.getsource() where the shared fixture produced nothing, which made an
+    unwired detector look the same as an un-driven one -- and passed for a call
+    carrying the wrong reason string and for one made unreachable.
     """
     import paperconan._audit as audit
 
@@ -565,3 +566,100 @@ def test_a_block_past_the_row_cap_loses_relations_and_says_nothing(tmp_path):
     assert "constant_ratio_row" in under, "fixture no longer plants a detectable relation"
     assert "constant_ratio_row" not in over, "the row cap no longer drops it -- delete this test"
     assert scan_over["scan_status"] == "complete", "the gap is now reported; update this test"
+
+
+# ---------- the production wiring, not just the detector ----------
+
+_WIRED_AT_SCAN_DIR = (
+    "detect_row_relations",
+    "detect_recurring_row_vectors",
+    "detect_scaled_row_reuse",
+    "detect_short_row_reuse",
+    "detect_within_row_shared_fraction",
+    "detect_row_pair_shared_fraction",
+)
+
+
+@pytest.mark.parametrize("name", _WIRED_AT_SCAN_DIR)
+def test_scan_dir_hands_each_wired_detector_its_coverage(tmp_path, monkeypatch, name):
+    """The kwarg at the call site, not the parameter in the signature.
+
+    Every other test in this file calls the detectors directly with an explicit
+    coverage=, so all of them stayed green when `, coverage=coverage` was deleted
+    from four of the six scan_dir call sites. A detector that accepts coverage
+    and is never handed one reports nothing, which is the defect this file
+    exists to prevent -- so assert on what scan_dir actually passes.
+    """
+    import paperconan._audit as audit
+
+    seen = {}
+    original = getattr(audit, name)
+
+    def spy(*args, **kwargs):
+        seen["coverage"] = kwargs.get("coverage", "NOT PASSED")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(audit, name, spy)
+    _panel(tmp_path / "d" / "p.csv")
+    scan_dir(str(tmp_path / "d"), str(tmp_path / "out"), write_html=False)
+
+    assert seen, f"{name} was never called by scan_dir; this test cannot see its wiring"
+    assert isinstance(seen["coverage"], ScanCoverage), (
+        f"scan_dir called {name} with coverage={seen['coverage']!r}; a cap it hits "
+        f"would reach no channel"
+    )
+
+
+def test_the_packet_renders_limitations_as_sentences_not_dict_reprs(tmp_path):
+    """_describe_scan_limitation is only reachable through _coverage_for.
+
+    Tested in isolation it stays green while the packet goes back to emitting
+    `{'scope': 'detector', ...}` at the reader.
+    """
+    from paperconan._workflow import _coverage_for
+
+    coverage = ScanCoverage(files_discovered=1)
+    coverage.add_limitation("detector", "detector_finding_limit",
+                            detector="detect_short_row_reuse", limit=60)
+    scan = {"scan_status": "partial", "coverage": coverage.to_dict()}
+
+    blob = " ".join(_coverage_for(scan, [], [], [], 100)["limitations"])
+
+    assert "detect_short_row_reuse" in blob, "the detector name did not reach the packet"
+    for repr_marker in ("{", "'scope'", "'reason'"):
+        assert repr_marker not in blob, f"a Python repr reached the reader: {blob!r}"
+
+
+def test_a_tall_band_loses_scaled_row_reuse_and_says_nothing():
+    """The second site gated on _ROW_REL_MAX_ROWS, pinned like the first.
+
+    _scaled_row_candidates drops any band taller than the constant, so at 61
+    rows this detector goes silent entirely -- including identical_row_reuse,
+    verbatim row copies across sheets. A band's height says nothing about
+    whether one of its rows is a scalar multiple of a row in another sheet, so
+    this is a cost cap, not orientation. Deliberate for now and covered only by
+    the workflow's over-broad caveat; if it is ever raised or reported, this
+    test fails loudly and should be updated.
+    """
+    import paperconan._audit as audit
+    from paperconan._sheet import Sheet
+
+    vec = (13.40712, 27.91834, 8.52619, 41.06375, 19.73408, 33.28951, 22.61483,
+           9.34026, 37.15792, 14.80613, 29.47158, 6.92374, 31.08627, 17.25913)
+
+    def sheets(n_rows):
+        grids = {}
+        for idx, name in enumerate(("Figure 1a", "Figure 2b")):
+            rows = [[f"c{j}" for j in range(len(vec))]]
+            for i in range(n_rows):
+                rows.append([round(v * (1 + 0.031 * i) + 0.7 * i, 5) for v in vec])
+            if idx == 1:
+                rows[1] = [round(3.0 * v, 6) for v in rows[1]]
+            grids[(f"{name}.csv", name)] = Sheet.from_rows(rows)
+        return grids
+
+    under = audit.detect_scaled_row_reuse(sheets(60), profile="review", max_findings=10**6)
+    over = audit.detect_scaled_row_reuse(sheets(61), profile="review", max_findings=10**6)
+
+    assert under, "fixture no longer produces cross-sheet row reuse at 60 rows"
+    assert not over, "the band ceiling no longer silences this detector -- update this test"

--- a/tests/test_detector_cap_coverage.py
+++ b/tests/test_detector_cap_coverage.py
@@ -1,0 +1,196 @@
+"""Detector-level caps have to reach the scan's coverage.
+
+Several detectors stop at their own `max_findings` or compute budget. Until now
+they reported that to stderr at best, and for some paths to nothing at all — so
+`scan_status` stayed "complete" and every consumer downstream, including the
+layered views and the Agent workflow, reported full coverage over a block whose
+enumeration had been cut short.
+
+For a tool used to decide whether a paper's numbers need author clarification,
+a silently shortened search is the worst failure mode available: it looks
+exactly like a clean result.
+"""
+from __future__ import annotations
+
+import pytest
+
+from paperconan import scan_dir
+from paperconan._coverage import ScanCoverage
+
+
+def _panel(path, rows=40, cols=14):
+    """A block dense enough that the relation detectors have plenty to chew on."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    header = ",".join(f"c{j}" for j in range(cols))
+    lines = [header]
+    for i in range(rows):
+        vals = [round((i + 1) * (j + 1) * 1.017, 6) for j in range(cols)]
+        if cols > 5:
+            vals[5] = vals[2]
+        if cols > 9:
+            vals[9] = round(vals[3] * 1.13, 6)
+        lines.append(",".join(str(v) for v in vals))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _reasons(scan):
+    return [item.get("reason") for item in (scan.get("coverage") or {}).get("limitations") or []]
+
+
+# ---------- the compute budgets ----------
+
+def test_an_exhausted_row_relation_budget_reaches_coverage(tmp_path, monkeypatch):
+    """Previously printed "coverage bounded" to stderr and nowhere else."""
+    import paperconan._audit as audit
+    monkeypatch.setattr(audit, "_ROW_REL_BUDGET", 1)
+
+    _panel(tmp_path / "d" / "p.csv")
+    scan = scan_dir(str(tmp_path / "d"), str(tmp_path / "out"), write_html=False)
+
+    assert "detector_compute_budget_limit" in _reasons(scan), _reasons(scan)
+    assert scan["scan_status"] != "complete"
+    assert scan["coverage"]["truncated"] is True
+
+
+def test_a_block_too_tall_for_row_relations_is_recorded(tmp_path, monkeypatch):
+    """This path returned [] with no notice on any channel at all."""
+    import paperconan._audit as audit
+    monkeypatch.setattr(audit, "_ROW_REL_MAX_ROWS", 3)
+
+    _panel(tmp_path / "d" / "p.csv")
+    scan = scan_dir(str(tmp_path / "d"), str(tmp_path / "out"), write_html=False)
+
+    assert "detector_block_rows_limit" in _reasons(scan), _reasons(scan)
+    assert scan["scan_status"] != "complete"
+
+
+# ---------- the per-detector result caps ----------
+
+_CAPPED_DETECTORS = (
+    "detect_recurring_row_vectors",
+    "detect_scaled_row_reuse",
+    "detect_short_row_reuse",
+    "detect_within_row_shared_fraction",
+    "detect_row_pair_shared_fraction",
+)
+
+
+def _two_sheets():
+    from paperconan._sheet import Sheet
+
+    grids = {}
+    for sheet in ("a", "b"):
+        rows = [[f"c{j}" for j in range(12)]]
+        base = [round(0.1234567 + j * 0.0173219, 7) for j in range(12)]
+        for i in range(24):
+            if i % 4 == 0:
+                rows.append(list(base))                          # exact repeat
+            elif i % 4 == 1:
+                rows.append([round(v * 1.13, 7) for v in base])   # constant ratio
+            elif i % 4 == 2:
+                rows.append([round(v + 100, 7) for v in base])    # shared tail
+            else:
+                rows.append([round(v * (i + 1) * 1.017, 7) for v in base])
+        grids[(f"{sheet}.csv", sheet)] = Sheet.from_rows(rows)
+    return grids
+
+
+@pytest.mark.parametrize("name", _CAPPED_DETECTORS)
+def test_each_capped_detector_reports_reaching_its_finding_limit(name):
+    """Every capped detector is wired to the coverage object.
+
+    Uses max_findings=0 so the limit is reached regardless of what the fixture
+    happens to trigger. That verifies the wiring, not that a real corpus trips
+    it — the end-to-end case is covered separately below, for the one detector a
+    synthetic fixture can currently drive to its cap.
+    """
+    import paperconan._audit as audit
+
+    coverage = ScanCoverage(files_discovered=1)
+
+    getattr(audit, name)(_two_sheets(), profile="review", max_findings=0,
+                         coverage=coverage)
+
+    reasons = [item["reason"] for item in coverage.to_dict()["limitations"]]
+    assert "detector_finding_limit" in reasons, (
+        f"{name} reached its cap without recording it: {reasons}"
+    )
+
+
+def test_a_detector_that_actually_fills_its_cap_records_it():
+    """The end-to-end half: real findings, a real cap, a real limitation."""
+    import paperconan._audit as audit
+
+    coverage = ScanCoverage(files_discovered=1)
+
+    found = audit.detect_scaled_row_reuse(_two_sheets(), profile="review",
+                                          max_findings=1, coverage=coverage)
+
+    assert len(found) >= 1, "fixture no longer produces findings for this detector"
+    reasons = [item["reason"] for item in coverage.to_dict()["limitations"]]
+    assert "detector_finding_limit" in reasons
+
+
+@pytest.mark.parametrize("name", _CAPPED_DETECTORS)
+def test_a_detector_below_its_cap_records_nothing(name):
+    """The notice has to mean something: no cap reached, no limitation."""
+    import paperconan._audit as audit
+
+    coverage = ScanCoverage(files_discovered=1)
+
+    getattr(audit, name)(_two_sheets(), profile="review", max_findings=10**6,
+                         coverage=coverage)
+
+    assert not coverage.to_dict()["limitations"], (
+        f"{name} reported a cap it never reached"
+    )
+
+
+def test_an_uncapped_scan_records_no_detector_limitation(tmp_path):
+    """The notice must mean something: a normal scan must stay clean."""
+    _panel(tmp_path / "d" / "p.csv", rows=12, cols=4)
+
+    scan = scan_dir(str(tmp_path / "d"), str(tmp_path / "out"), write_html=False)
+
+    detector_reasons = [r for r in _reasons(scan)
+                        if "detector" in (r or "") or "cap" in (r or "")]
+    assert not detector_reasons, detector_reasons
+    assert scan["scan_status"] == "complete"
+
+
+# ---------- the workflow caveat can now be retired ----------
+
+def test_the_workflow_no_longer_declares_caps_unreported():
+    """With the caps wired through, the blanket caveat becomes false and the
+    packet can report real completeness again."""
+    from paperconan._workflow import DETECTOR_CAPS_REPORTED
+
+    assert DETECTOR_CAPS_REPORTED is True
+
+
+def test_a_scan_limitation_reads_as_a_sentence_not_a_python_repr():
+    """These land in a terminal; a dict repr is not something to hand a reader."""
+    from paperconan._workflow import _describe_scan_limitation
+
+    text = _describe_scan_limitation({
+        "scope": "detector", "reason": "detector_compute_budget_limit",
+        "detector": "detect_row_relations", "rows": 60, "cols": 14,
+    })
+
+    assert "{" not in text and "'" not in text
+    assert "detector compute budget limit" in text
+    assert "detect_row_relations" in text
+    assert "rows=60" in text
+
+
+def test_a_clean_scan_now_reaches_complete_coverage(tmp_path):
+    """The end of the chain: nothing dropped anywhere, so the view may say so."""
+    from paperconan._drill import overview
+
+    _panel(tmp_path / "d" / "p.csv", rows=12, cols=4)
+    scan = scan_dir(str(tmp_path / "d"), str(tmp_path / "out"), write_html=False)
+
+    view = overview(scan)
+
+    assert view["coverage"]["detector_caps_reported"] is True
+    assert not any("detector-level caps" in x for x in view["coverage"]["limitations"])

--- a/tests/test_detector_cap_coverage.py
+++ b/tests/test_detector_cap_coverage.py
@@ -67,7 +67,10 @@ def _two_sheets():
     from paperconan._sheet import Sheet
 
     grids = {}
-    for sheet in ("a", "b"):
+    # figure-shaped sheet names: the cross-figure pass is skipped entirely
+    # unless two distinct figure keys are present, which also means a fixture
+    # named "a"/"b" can only ever exercise the within-row pass.
+    for sheet in ("Figure 1a", "Figure 2b"):
         rows = [[f"c{j}" for j in range(12)]]
         base = [round(0.1234567 + j * 0.0173219, 7) for j in range(12)]
         for i in range(24):
@@ -279,3 +282,93 @@ def test_a_result_cap_equal_to_the_natural_output_still_reports(tmp_path):
         "if this stops firing the boundary was narrowed — update the docstring "
         "on _note_detector_cap"
     )
+
+
+# ---------- the three claims that outran their coverage ----------
+
+_BUDGETS = (
+    ("detect_recurring_row_vectors", "_RECURRING_VEC_BUDGET"),
+    ("detect_scaled_row_reuse", "_SCALED_ROW_BUDGET"),
+    ("detect_short_row_reuse", "_SHORT_ROW_BUDGET"),
+    ("detect_within_row_shared_fraction", "_WITHIN_ROW_FRAC_BUDGET"),
+    ("detect_row_pair_shared_fraction", "_ROW_PAIR_FRAC_BUDGET"),
+)
+
+
+@pytest.mark.parametrize("detector,budget_const", _BUDGETS)
+def test_a_spent_budget_is_not_reported_as_a_result_cap(detector, budget_const,
+                                                        monkeypatch):
+    """C1': a scripted rewrite folded two break conditions into one flag.
+
+    A detector that exhausts its compute budget and returns nothing then
+    reported "detector finding limit (limit=1000000)" — a claim about a cap it
+    never approached. Saying the wrong thing is worse than saying nothing, and
+    this was a regression: checking at function exit never did it.
+    """
+    import paperconan._audit as audit
+    monkeypatch.setattr(audit, budget_const, 1)
+
+    coverage = ScanCoverage(files_discovered=1)
+    found = getattr(audit, detector)(_two_sheets(), profile="review",
+                                     max_findings=10**6, coverage=coverage)
+
+    reasons = [i["reason"] for i in coverage.to_dict()["limitations"]]
+    assert not found, "budget of 1 should starve the detector"
+    assert "detector_finding_limit" not in reasons, (
+        f"{detector} produced nothing but reported a result cap: {reasons}"
+    )
+
+
+@pytest.mark.parametrize("detector,budget_const", _BUDGETS)
+def test_each_detector_reports_its_own_exhausted_budget(detector, budget_const,
+                                                        monkeypatch):
+    """Pins the budget wiring itself — untestable while these were literals."""
+    import paperconan._audit as audit
+    monkeypatch.setattr(audit, budget_const, 1)
+
+    coverage = ScanCoverage(files_discovered=1)
+    getattr(audit, detector)(_two_sheets(), profile="review", coverage=coverage)
+
+    named = [(i.get("detector"), i["reason"]) for i in coverage.to_dict()["limitations"]]
+    assert (detector, "detector_compute_budget_limit") in named, named
+
+
+def test_two_detectors_capped_at_once_are_both_named():
+    """C2': detector records carry no file or sheet, so a dedup key without the
+    detector name kept only the first and dropped the rest — while the caveat
+    told the reader result caps were reported."""
+    coverage = ScanCoverage(files_discovered=1)
+
+    coverage.add_limitation("detector", "detector_finding_limit",
+                            detector="detect_short_row_reuse", limit=60)
+    coverage.add_limitation("detector", "detector_finding_limit",
+                            detector="detect_row_pair_shared_fraction", limit=60)
+
+    named = {i.get("detector") for i in coverage.to_dict()["limitations"]}
+    assert named == {"detect_short_row_reuse", "detect_row_pair_shared_fraction"}, named
+
+
+def test_the_unreported_cap_caveat_reaches_the_packet(tmp_path):
+    """C3': the caveat was restored but its guard was not.
+
+    Asserting the constant is False does not keep the sentence in front of a
+    reader — deleting the block that appends it left the suite fully green,
+    which is one edit away from the gap the caveat exists to cover.
+    """
+    from paperconan._workflow import start_workflow
+
+    data = tmp_path / "data"
+    data.mkdir()
+    rows = ["a,b"] + [f"{i + 1},{(i + 1) * 2}" for i in range(12)]
+    (data / "p.csv").write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+    start_workflow(str(data), str(tmp_path / "out"))
+    import json
+    packet = json.loads(
+        (tmp_path / "out" / "steps" / "t000" / "candidate_packet.json").read_text()
+    )
+
+    assert any("still not reported" in x for x in packet["coverage"]["limitations"]), (
+        packet["coverage"]["limitations"]
+    )
+    assert packet["coverage"]["coverage_complete"] is False

--- a/tests/test_detector_cap_coverage.py
+++ b/tests/test_detector_cap_coverage.py
@@ -780,8 +780,9 @@ def test_the_row_pair_digit_coupling_block_cap_reaches_coverage(tmp_path):
     blind-spot note had been rewritten to claim was empty.
 
     No monkeypatching: 14 rows of 14 columns whose pairwise differences are
-    multiples of 10 produce all C(14,2)=91 pairs and hit the default cap of 25,
-    so this fires on an ordinary block and loses 66 findings.
+    multiples of 10 produce all C(14,2)=91 pairs and hit the default cap of 25.
+    That shape is synthetic -- random blocks of the same size yield nothing --
+    but the cap it reaches is the real default.
     """
     cols = 14
     base = [round(12.34 + j * 7.91, 2) for j in range(cols)]
@@ -799,5 +800,45 @@ def test_the_row_pair_digit_coupling_block_cap_reaches_coverage(tmp_path):
         f"the per-block result cap recorded nothing under its own reason: "
         f"{[(i.get('detector'), i.get('reason')) for i in (scan.get('coverage') or {}).get('limitations') or []]}"
     )
-    assert records[0]["found"] > records[0]["limit"], records[0]
+    assert records[0]["limit"] == 25, records[0]
+    assert "found" not in records[0], (
+        "a per-block count on a record that collapses scan-wide reads as a total"
+    )
     assert scan["scan_status"] != "complete"
+
+
+def test_every_scan_line_quoted_in_the_skill_is_one_the_code_can_emit():
+    """SKILL.md is what an agent reads to interpret a scan; its examples must be real.
+
+    Hand-written example strings in that file have been wrong repeatedly -- a
+    detail field the record does not carry, a shape the code cannot produce, a
+    remediation knob that does not exist. Each is invisible until an agent acts
+    on it. This renders the real thing through the real formatter and requires
+    every `scan: ...` line quoted in the skill to match exactly.
+    """
+    import re
+    from pathlib import Path
+
+    from paperconan._workflow import _coverage_for
+
+    coverage = ScanCoverage(files_discovered=2)
+    coverage.mark_file_failed("big.xlsx", "file_too_large")
+    coverage.add_limitation("detector", "detector_candidate_pool_limit",
+                            detector="detect_short_row_reuse", limit=400)
+    coverage.add_limitation("detector", "detector_finding_limit",
+                            detector="detect_row_pair_digit_coupling", limit=25)
+    coverage.add_limitation("detector", "detector_compute_budget_limit",
+                            detector="detect_row_relations")
+    scan = {"scan_status": "partial", "coverage": coverage.to_dict()}
+    emitted = {line for line in _coverage_for(scan, [], [], [], 100)["limitations"]
+               if line.startswith("scan:")}
+
+    skill = Path(__file__).resolve().parents[1] / "skills" / "paperconan" / "SKILL.md"
+    quoted = re.findall(r"`(scan: [^`]+)`", skill.read_text(encoding="utf-8"))
+
+    assert quoted, "no scan: examples found in SKILL.md; did the section move?"
+    unemittable = [q for q in quoted if q not in emitted]
+    assert not unemittable, (
+        f"SKILL.md quotes {len(unemittable)} scan: line(s) the code does not emit: "
+        f"{unemittable}\nemitted here: {sorted(emitted)}"
+    )

--- a/tests/test_drill.py
+++ b/tests/test_drill.py
@@ -507,8 +507,11 @@ def test_raising_the_limit_actually_reaches_the_declared_remainder(scan):
     )
     # gone once nothing is held back...
     assert not any("raise max_findings" in x for x in full["coverage"]["limitations"])
-    # ...but scan-wide caveats are not this layer's to drop
-    assert any("detector-level caps" in x for x in full["coverage"]["limitations"])
+    # ...but scan-wide caveats are not this layer's to drop. The fixture always
+    # carries unrouted families, so that is the standing representative here.
+    assert any("does not route" in x for x in full["coverage"]["limitations"]), (
+        f"L3 dropped the scan-wide caveats: {full['coverage']['limitations']}"
+    )
 
 
 def test_a_family_present_but_unreachable_is_named_in_coverage(scan):

--- a/tests/test_workflow_seed_integrity.py
+++ b/tests/test_workflow_seed_integrity.py
@@ -602,7 +602,15 @@ def test_an_incomplete_scan_makes_the_packet_declare_itself_incomplete(tmp_path,
     coverage = _packet(tmp_path / "out")["coverage"]
 
     assert coverage["scan_incomplete"] is True
-    assert coverage["coverage_complete"] is False
+    # Not `coverage_complete is False`: DETECTOR_CAPS_REPORTED is a hardcoded
+    # False, so the blanket caveat is always appended and that flag is always
+    # False -- it cannot discriminate. Assert the specific cap instead, which
+    # makes the monkeypatch above load-bearing: without it the budget is never
+    # exhausted and this line does not appear.
+    blob = " ".join(coverage["limitations"])
+    assert "detect_row_relations" in blob, (
+        f"the exhausted budget did not reach the packet by name: {coverage['limitations']}"
+    )
     assert any("scan was not complete" in x for x in coverage["limitations"])
 
 

--- a/tests/test_workflow_seed_integrity.py
+++ b/tests/test_workflow_seed_integrity.py
@@ -583,28 +583,41 @@ def test_the_profile_is_part_of_the_run_configuration(tmp_path):
             == _packet(tmp_path / "b")["clusters"])
 
 
-def test_coverage_cannot_claim_completeness_while_detector_caps_go_unreported(tmp_path):
-    """Several detectors stop at their own max_findings or compute budget and
-    report it to no channel at all — for some paths not even stderr.
-
-    A side field saying so is not enough: the CLI prints `limitations`, and a
-    reader who sees `coverage_complete: true` has no reason to look further. So
-    the caveat has to be a limitation, which makes `coverage_complete` false by
-    construction until the detector-layer PR flips the flag.
+def test_a_detector_cap_reaches_the_packet(tmp_path, monkeypatch):
+    """Detector caps used to reach no channel, so the packet carried a blanket
+    caveat instead. Now that they record into ScanCoverage, the packet must
+    carry the real one — and only when a cap actually bit.
     """
+    import paperconan._audit as audit
+    monkeypatch.setattr(audit, "_ROW_REL_BUDGET", 1)
+
+    data = tmp_path / "data"
+    rows = ["," .join(f"c{j}" for j in range(14))]
+    for i in range(40):
+        rows.append(",".join(str(round((i + 1) * (j + 1) * 1.017, 6)) for j in range(14)))
+    data.mkdir(parents=True, exist_ok=True)
+    (data / "p.csv").write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+    start_workflow(str(data), str(tmp_path / "out"))
+    coverage = _packet(tmp_path / "out")["coverage"]
+
+    assert coverage["detector_caps_reported"] is True
+    assert coverage["scan_incomplete"] is True
+    assert coverage["coverage_complete"] is False
+    assert any("scan was not complete" in x for x in coverage["limitations"])
+
+
+def test_a_clean_scan_no_longer_carries_a_blanket_caveat(tmp_path):
+    """The blanket 'detector caps are unreported' line was true of every scan
+    ever produced, so it said nothing about any particular one."""
     data = tmp_path / "data"
     _panel(data / "p.csv")
 
     start_workflow(str(data), str(tmp_path / "out"))
     coverage = _packet(tmp_path / "out")["coverage"]
 
-    assert coverage["detector_caps_reported"] is False
-    assert coverage["coverage_complete"] is False, (
-        "the packet claims complete coverage while detector caps are unreported"
-    )
-    assert any("detector-level caps" in x for x in coverage["limitations"]), (
-        "the caveat must reach the channel the CLI actually prints"
-    )
+    assert coverage["detector_caps_reported"] is True
+    assert not any("detector-level caps" in x for x in coverage["limitations"])
 
 
 def test_an_index_from_an_unsupported_schema_is_refused(tmp_path):

--- a/tests/test_workflow_seed_integrity.py
+++ b/tests/test_workflow_seed_integrity.py
@@ -583,7 +583,7 @@ def test_the_profile_is_part_of_the_run_configuration(tmp_path):
             == _packet(tmp_path / "b")["clusters"])
 
 
-def test_a_detector_cap_reaches_the_packet(tmp_path, monkeypatch):
+def test_an_incomplete_scan_makes_the_packet_declare_itself_incomplete(tmp_path, monkeypatch):
     """Detector caps used to reach no channel, so the packet carried a blanket
     caveat instead. Now that they record into ScanCoverage, the packet must
     carry the real one — and only when a cap actually bit.
@@ -604,8 +604,6 @@ def test_a_detector_cap_reaches_the_packet(tmp_path, monkeypatch):
     assert coverage["scan_incomplete"] is True
     assert coverage["coverage_complete"] is False
     assert any("scan was not complete" in x for x in coverage["limitations"])
-
-
 
 
 def test_an_index_from_an_unsupported_schema_is_refused(tmp_path):

--- a/tests/test_workflow_seed_integrity.py
+++ b/tests/test_workflow_seed_integrity.py
@@ -601,23 +601,11 @@ def test_a_detector_cap_reaches_the_packet(tmp_path, monkeypatch):
     start_workflow(str(data), str(tmp_path / "out"))
     coverage = _packet(tmp_path / "out")["coverage"]
 
-    assert coverage["detector_caps_reported"] is True
     assert coverage["scan_incomplete"] is True
     assert coverage["coverage_complete"] is False
     assert any("scan was not complete" in x for x in coverage["limitations"])
 
 
-def test_a_clean_scan_no_longer_carries_a_blanket_caveat(tmp_path):
-    """The blanket 'detector caps are unreported' line was true of every scan
-    ever produced, so it said nothing about any particular one."""
-    data = tmp_path / "data"
-    _panel(data / "p.csv")
-
-    start_workflow(str(data), str(tmp_path / "out"))
-    coverage = _packet(tmp_path / "out")["coverage"]
-
-    assert coverage["detector_caps_reported"] is True
-    assert not any("detector-level caps" in x for x in coverage["limitations"])
 
 
 def test_an_index_from_an_unsupported_schema_is_refused(tmp_path):


### PR DESCRIPTION
Narrowed after review. The first version of this branch made the report **less honest than main**; what lands here is only the part that is verified.

## What went wrong first time

I claimed six detectors reported nothing. That figure came from a prior review, not from an audit. The reviewer enumerated the detector layer independently: **17** resource caps report on no channel at all — including whole-detector skips. A 130-column block loses `detect_relations` entirely and the scan still reports `complete`.

On that partial wiring I flipped `DETECTOR_CAPS_REPORTED` to `True` and deleted the blanket caveat. For a wide supplement that caveat was true and load-bearing, so the branch traded an over-broad warning for a wrong all-clear — the exact failure this tool exists to prevent.

## What lands

- Result caps (`max_findings`) across five detectors, and the row-relation compute budget, now record through `ScanCoverage`. Reasons end in `_limit`, matching the convention `_coverage.py` already uses, so `scan_status` becomes `partial` and the reason reaches the layered views and the workflow packet with no change to either.
- Scan limitations render as sentences. They previously reached the terminal as Python dict reprs, which detector caps would have made common.
- `DETECTOR_CAPS_REPORTED` stays `False`; the caveat now names what is and is not covered rather than being blanket.
- A test pins the 110-vs-130-column gap. It fails loudly once that cap is wired, so the flag cannot be forgotten.

## Two corrections from the review

**The block-too-tall notice is withdrawn.** It fired on 61×14 — the commonest supplementary shape — which would have made `partial` near-universal and taught readers to skip the coverage line, defeating the point. It is also not truncation: `_scaled_row_candidates` gates on the same constant and calls it scope.

**The result-cap flag moved from function exit to the break sites.** At exit it could not distinguish "cut short" from "produced exactly the cap", and a plain 200-row table reported `partial`.

## Known limits, stated rather than papered over

- Reaching a cap on the final iteration still reports. Narrowing that needs per-break knowledge of what remained unexamined. It errs toward "there may be more", which is the safe direction here. Documented on `_note_detector_cap` and pinned by a test.
- Four of the five detectors skip their end-to-end assertion — this fixture cannot drive them past their cap. Skipped rather than asserted vacuously.
- The remaining ~16 caps are follow-up work, and that enumeration should be done first-hand.

## Validation

- Full suite: `1471 passed, 5 skipped`
- `tests/golden/` unchanged
- Verified: an ordinary 200×14 random table reports `complete`; a dense one that genuinely fills a cap reports `partial` naming the detector and limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)