### PR TITLE
feat(fetch): keep the label the publisher puts on each supplementary file

### DIFF
--- a/src/paperconan/fetch/_files.py
+++ b/src/paperconan/fetch/_files.py
@@ -30,7 +30,13 @@ def asset_type(name: str) -> str:
     return "other"
 
 
-def make_fileref(name: str, size, download_url: str) -> dict:
+def make_fileref(name: str, size, download_url: str, label: str | None = None) -> dict:
+    """`label` is whatever the source page called this file, verbatim and unparsed.
+
+    A supplementary file's own name is usually an accession string, so the only thing that
+    says WHICH figure it holds is the text the publisher put beside the link. Sources that
+    have it should pass it through; interpreting it belongs to whoever consumes it.
+    """
     return {"name": name, "ext": ext_of(name),
             "size": int(size) if isinstance(size, (int, float)) else None,
-            "download_url": download_url}
+            "download_url": download_url, "label": label}

--- a/src/paperconan/fetch/_nature.py
+++ b/src/paperconan/fetch/_nature.py
@@ -20,6 +20,18 @@ _ESM_HREF = re.compile(
     r'/[^"]+)"',
     re.I,
 )
+# The same link WITH the anchor it sits in, so the text the page put on it survives. That
+# text is what says which figure a file holds -- the filename is an accession string and
+# says nothing. Only the anchor's own text is taken: a label guessed from nearby markup
+# could attach a figure number to a file that does not hold it, and a wrong label is worse
+# than none here, because it would let a finding be credited to a figure it never came from.
+_ESM_ANCHOR = re.compile(
+    r'<a\b[^>]*\bhref="(https://(?:static-content\.springer\.com/esm'
+    r'|media\.springernature\.com/[a-z0-9_-]+/springer-static/esm)'
+    r'/[^"]+)"[^>]*>(.*?)</a\s*>',
+    re.I | re.S,
+)
+_TAGS = re.compile(r"<[^>]*>")
 _HREF = re.compile(r"""\bhref\s*=\s*(["'])(.*?)\1""", re.I | re.S)
 _FULL_IMAGE_SRC = re.compile(
     r'(https://media\.springernature\.com/full/[^"\']+\.(?:png|jpe?g|tiff?))',
@@ -37,9 +49,23 @@ _MAX_FIGURE_PAGES = 100
 _MAX_NATURE_HTML_BYTES = 5 * 1024 * 1024
 
 
+def _anchor_labels(html: str) -> dict:
+    """{esm url: the anchor's own visible text}, for anchors that have any."""
+    out = {}
+    for url, inner in _ESM_ANCHOR.findall(html or ""):
+        url = url.replace("&amp;", "&")
+        text = html_lib.unescape(_TAGS.sub(" ", inner))
+        text = " ".join(text.split())
+        if text and url not in out:
+            out[url] = text
+    return out
+
+
 def parse_nature_esm_links(html: str) -> list[dict]:
     """Extract ESM file refs from a Nature article page. Returns make_fileref dicts,
-    deduped by URL, with ext derived from the URL path."""
+    deduped by URL, with ext derived from the URL path and `label` carrying the anchor's
+    own text where it has one -- see `_ESM_ANCHOR` for why only the anchor's."""
+    labels = _anchor_labels(html)
     seen, refs = set(), []
     for url in _ESM_HREF.findall(html or ""):
         url = url.replace("&amp;", "&")
@@ -47,7 +73,7 @@ def parse_nature_esm_links(html: str) -> list[dict]:
             continue
         seen.add(url)
         name = urllib.parse.unquote(url.rsplit("/", 1)[-1])
-        refs.append(make_fileref(name, None, url))
+        refs.append(make_fileref(name, None, url, label=labels.get(url)))
     return refs
 
 

--- a/src/paperconan/fetch/_nature.py
+++ b/src/paperconan/fetch/_nature.py
@@ -28,7 +28,11 @@ _ESM_HREF = re.compile(
 _ESM_ANCHOR = re.compile(
     r'<a\b[^>]*\bhref="(https://(?:static-content\.springer\.com/esm'
     r'|media\.springernature\.com/[a-z0-9_-]+/springer-static/esm)'
-    r'/[^"]+)"[^>]*>(.*?)</a\s*>',
+    # The text may not run across another `<a`: a page can nest anchors or leave one
+    # unclosed, and a plain `.*?` then pairs this URL with the NEXT link's caption while
+    # swallowing that link whole, so it loses its own. Refusing to cross the boundary lets
+    # each anchor match on its own.
+    r'/[^"]+)"[^>]*>((?:(?!<a\b).)*?)</a\s*>',
     re.I | re.S,
 )
 _TAGS = re.compile(r"<[^>]*>")
@@ -50,7 +54,12 @@ _MAX_NATURE_HTML_BYTES = 5 * 1024 * 1024
 
 
 def _anchor_labels(html: str) -> dict:
-    """{esm url: the anchor's own visible text}, for anchors that have any."""
+    """{esm url: the anchor's own visible text}, for anchors that have any.
+
+    First occurrence wins, matching the URL dedupe in `parse_nature_esm_links` -- a page that
+    links one file twice is described by whichever mention comes first, which is a policy
+    rather than a judgement about which text is better.
+    """
     out = {}
     for url, inner in _ESM_ANCHOR.findall(html or ""):
         url = url.replace("&amp;", "&")

--- a/tests/fetch/test_download.py
+++ b/tests/fetch/test_download.py
@@ -5404,6 +5404,7 @@ def test_jci_resolver_filters_unsafe_and_non_tabular_links(monkeypatch):
         "download_url": (
             "https://www.jci.org/supporting/table.xlsx"
         ),
+        "label": None,
         "validate_tabular_content": True,
     }]
 

--- a/tests/fetch/test_files.py
+++ b/tests/fetch/test_files.py
@@ -17,7 +17,8 @@ def test_is_tabular():
 
 def test_make_fileref():
     ref = _files.make_fileref("t.csv", 1234, "https://x/t.csv")
-    assert ref == {"name": "t.csv", "ext": "csv", "size": 1234, "download_url": "https://x/t.csv"}
+    assert ref == {"name": "t.csv", "ext": "csv", "size": 1234,
+                   "download_url": "https://x/t.csv", "label": None}
 
 
 def test_image_and_document_classification_does_not_change_tabular_behavior():

--- a/tests/fetch/test_live_network.py
+++ b/tests/fetch/test_live_network.py
@@ -13,3 +13,26 @@ def test_zenodo_search_live():
     assert isinstance(cands, list)
     # at least one Zenodo record should come back for a common term
     assert cands and cands[0]["source"] == "zenodo"
+
+
+def test_nature_esm_links_carry_their_labels_live():
+    """The label capture against a real article page, not a fixture.
+
+    A fixture proves the parser reads an anchor; it cannot prove the pages this parser is
+    aimed at put text there at all. What is asserted is only what holds for every article:
+    each ESM link carries SOME label.
+
+    Deliberately NOT asserted: that a label names a figure. A first draft of this test did,
+    and live data refused it -- the labels on this article are all of the "Supplementary
+    Information" kind. Figure-naming labels are common and are what makes the label useful
+    downstream, but they are a property of an article's supplementary material, not of the
+    parser, so no single article can stand as evidence for them.
+    """
+    from paperconan.fetch._nature import search_nature_esm
+
+    cands = search_nature_esm("10.1038/s41467-022-28338-0", size=5)
+    files = [f for c in cands for f in (c.get("all_files") or [])]
+
+    assert files, "no ESM files came back; the fixture cannot stand in for this"
+    assert all(f.get("label") for f in files), (
+        [f["name"] for f in files if not f.get("label")])

--- a/tests/fetch/test_live_network.py
+++ b/tests/fetch/test_live_network.py
@@ -19,8 +19,14 @@ def test_nature_esm_links_carry_their_labels_live():
     """The label capture against a real article page, not a fixture.
 
     A fixture proves the parser reads an anchor; it cannot prove the pages this parser is
-    aimed at put text there at all. What is asserted is only what holds for every article:
-    each ESM link carries SOME label.
+    aimed at put text there at all. What is asserted is that every ESM link on THIS article
+    carries some label.
+
+    Not "every article": that would be a claim about a publisher's markup habit, and the
+    parser does not enforce it -- an anchor whose only content is an icon yields None, and
+    a unit test in this suite builds exactly that page. One article cannot establish the
+    habit either way. An earlier draft of this docstring said "what holds for every
+    article" and was wrong on both counts.
 
     Deliberately NOT asserted: that a label names a figure. A first draft of this test did,
     and live data refused it -- the labels on this article are all of the "Supplementary

--- a/tests/fetch/test_sources_dryad.py
+++ b/tests/fetch/test_sources_dryad.py
@@ -106,4 +106,5 @@ def test_dryad_candidate_omits_files_without_valid_download_links(
         "ext": "csv",
         "size": 1,
         "download_url": "https://cdn.example.net/files/valid.csv",
+        "label": None,
     }]

--- a/tests/test_fetch_nature.py
+++ b/tests/test_fetch_nature.py
@@ -67,6 +67,38 @@ def test_parse_nature_esm_links_strips_markup_from_the_label():
     assert by_ext["xlsx"]["label"] == "Source Data Fig 1"
 
 
+# Two ESM anchors where the first is nested inside, or left unclosed before, the second.
+# Browsers auto-close these; a lazy `.*?` up to `</a>` does not, and pairs one file's URL
+# with the OTHER file's caption.
+_U1 = ("https://static-content.springer.com/esm/art%3A10.1038%2Fs41467-022-28338-0"
+       "/MediaObjects/41467_2022_28338_MOESM1_ESM.pdf")
+_U2 = ("https://static-content.springer.com/esm/art%3A10.1038%2Fs41467-022-28338-0"
+       "/MediaObjects/41467_2022_28338_MOESM4_ESM.xlsx")
+
+
+def test_parse_nature_esm_links_refuses_a_label_from_a_neighbouring_anchor():
+    """The failure this feature's own rule says is worse than no label at all.
+
+    A wrong label would let a finding be credited to a figure it never came from, so an
+    anchor whose text has swallowed another anchor yields None rather than that text.
+    """
+    nested = f'<a href="{_U1}"><a href="{_U2}">Belongs to MOESM4</a></a>'
+
+    by_name = {r["name"]: r for r in nat.parse_nature_esm_links(nested)}
+
+    assert by_name["41467_2022_28338_MOESM1_ESM.pdf"]["label"] is None
+    assert by_name["41467_2022_28338_MOESM4_ESM.xlsx"]["label"] == "Belongs to MOESM4"
+
+
+def test_parse_nature_esm_links_refuses_a_label_merged_across_an_unclosed_anchor():
+    unclosed = f'<a href="{_U1}">Label one\n<a href="{_U2}">Label two</a>'
+
+    by_name = {r["name"]: r for r in nat.parse_nature_esm_links(unclosed)}
+
+    assert by_name["41467_2022_28338_MOESM1_ESM.pdf"]["label"] is None
+    assert by_name["41467_2022_28338_MOESM4_ESM.xlsx"]["label"] == "Label two"
+
+
 # Newer article pages serve ESM from the media.springernature.com CDN instead.
 MEDIA_ESM_HTML = '''
 <html><body>

--- a/tests/test_fetch_nature.py
+++ b/tests/test_fetch_nature.py
@@ -27,6 +27,46 @@ def test_parse_nature_esm_links_extracts_and_classifies():
     assert by_ext["xlsx"]["download_url"].startswith("https://static-content.springer.com/esm/")
 
 
+def test_parse_nature_esm_links_keeps_the_link_text_as_a_label():
+    """The article page says which figure a file belongs to; keep it.
+
+    Without it a workbook is just `41467_2022_28338_MOESM4_ESM.xlsx`, and nothing downstream
+    can say which figure it holds -- the page knew, and the parser was throwing it away.
+    """
+    by_ext = {r["ext"]: r for r in nat.parse_nature_esm_links(FIXTURE_HTML)}
+
+    assert by_ext["xlsx"]["label"] == "Source Data Fig 1"
+    assert by_ext["csv"]["label"] == "Source Data Fig 2"
+    assert by_ext["pdf"]["label"] == "Supplementary Information"
+
+
+# A label is only taken when the anchor itself carries it. Guessing from surrounding text
+# would attach a figure number to a file that may not hold it, and a wrong label is worse
+# than none: it would let a finding be credited to a figure it never came from.
+UNLABELLED_ESM_HTML = '''
+<html><body>
+<p>Source Data Fig 3</p>
+<a href="https://static-content.springer.com/esm/art%3A10.1038%2Fs41467-022-28338-0/MediaObjects/41467_2022_28338_MOESM7_ESM.xlsx"><span class="icon"></span></a>
+</body></html>
+'''
+
+
+def test_parse_nature_esm_links_leaves_the_label_empty_rather_than_guessing():
+    refs = nat.parse_nature_esm_links(UNLABELLED_ESM_HTML)
+
+    assert len(refs) == 1
+    assert refs[0]["label"] is None
+
+
+def test_parse_nature_esm_links_strips_markup_from_the_label():
+    html = FIXTURE_HTML.replace(
+        ">Source Data Fig 1<", "><strong>Source Data</strong>\n  Fig 1<")
+
+    by_ext = {r["ext"]: r for r in nat.parse_nature_esm_links(html)}
+
+    assert by_ext["xlsx"]["label"] == "Source Data Fig 1"
+
+
 # Newer article pages serve ESM from the media.springernature.com CDN instead.
 MEDIA_ESM_HTML = '''
 <html><body>


### PR DESCRIPTION
A supplementary file's own name is an accession string — `41467_2022_28338_MOESM4_ESM.xlsx` says nothing about what is in it. The article page **does** say, in the text beside the link: *Source Data Fig 4*, *Supplementary Information*, *Reporting Summary*. The ESM parser was reading the href and discarding that text.

`make_fileref` now carries a `label`, verbatim and unparsed, and the nature.com source fills it from the anchor. Interpreting the label belongs to whoever consumes it; the fetcher's job is to stop throwing it away.

## Only the anchor's own text

A label inferred from surrounding markup could attach a figure number to a file that does not hold it, and **a wrong label is worse than none here** — it would let a finding be credited to a figure it never came from. A test pins that: a page with a bare `<p>Source Data Fig 3</p>` next to an icon-only link yields `label: None`, not `Fig 3`.

## What the live test does and does not assert

It asserts only what holds for every article: **each ESM link carries some label.**

It deliberately does **not** assert that a label names a figure. A first draft did, and live data refused it — that article's supplementary files are all of the *Supplementary Information* kind. Figure-naming labels are what make this useful downstream, but they are a property of an article's supplementary material rather than of the parser, so no single article can stand as evidence for them. That reasoning is in the test's docstring, so the next person does not re-add the assertion.

## Three tests went red, correctly

`test_make_fileref`, the JCI resolver test and the Dryad candidate test all pin `make_fileref`'s exact dict shape. Adding a key broke them — which is what a shape test is for. They are updated to state the new key, not loosened to ignore it.

Offline suite green. Live test passes with `PAPERCONAN_LIVE=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)