### PR TITLE
feat(fetch): follow a retraction or correction to the article it concerns

### DIFF
--- a/src/paperconan/fetch/__init__.py
+++ b/src/paperconan/fetch/__init__.py
@@ -6,6 +6,11 @@ from . import _sources, _resolve
 from ._download import download_candidate  # noqa: F401
 
 
+# A correction can itself be corrected, so the link is followed more than once -- but not
+# indefinitely, and never back onto a DOI already visited.
+_MAX_NOTICE_HOPS = 3
+
+
 def _rank(cand):
     sig = cand.get("match_signals") or {}
     score = 0.0
@@ -25,15 +30,29 @@ def _rank(cand):
 def search_all(query, per_source=5):
     q = _resolve.normalize_query(query)
     doi, title, authors = q["doi"], q["title"], []
+    ambiguous = []
     if q["is_doi"]:
         enriched = _resolve.enrich_via_crossref(doi) or {}
         # A retraction, correction or expression of concern has its own DOI and no
         # supplementary files. Searching one finds nothing, and that failure is
         # indistinguishable from a paper that published none -- so follow it to the article
         # it concerns and search for THAT. The link rides on the record just fetched.
-        original = enriched.get("original_doi")
-        if original:
-            doi = original
+        #
+        # Only when it names exactly ONE article. A bulk correction, or an expression of
+        # concern covering several papers, names many; picking one would decide silently
+        # which paper's data gets downloaded, and because the picked DOI then feeds
+        # `match_signals`, the confidence check would go on to endorse a stranger's data as
+        # this paper's. Better to search the notice, find nothing, and say why.
+        seen = {doi}
+        for _hop in range(_MAX_NOTICE_HOPS):
+            originals = enriched.get("original_dois") or []
+            if len(originals) > 1:
+                ambiguous = list(originals)
+                break
+            if not originals or originals[0] in seen:
+                break
+            doi = originals[0]
+            seen.add(doi)
             enriched = _resolve.enrich_via_crossref(doi) or {}
         title = title or enriched.get("title")
         authors = enriched.get("authors") or []
@@ -49,5 +68,9 @@ def search_all(query, per_source=5):
             continue
     for c in cands:
         c["match_signals"] = _resolve.match_signals(c, paper)
+        # Carried on every candidate so a caller cannot act on the search without seeing it.
+        c["resolved_doi"] = paper["doi"]
+        if ambiguous:
+            c["notice_names_several_articles"] = ambiguous
     cands.sort(key=_rank, reverse=True)
     return cands

--- a/src/paperconan/fetch/__init__.py
+++ b/src/paperconan/fetch/__init__.py
@@ -24,13 +24,21 @@ def _rank(cand):
 
 def search_all(query, per_source=5):
     q = _resolve.normalize_query(query)
-    paper = {"doi": q["doi"], "title": q["title"], "authors": []}
+    doi, title, authors = q["doi"], q["title"], []
     if q["is_doi"]:
-        enriched = _resolve.enrich_via_crossref(q["doi"])
-        if enriched:
-            paper["title"] = paper["title"] or enriched.get("title")
-            paper["authors"] = enriched.get("authors") or []
-    search_term = q["doi"] or q["title"] or query
+        enriched = _resolve.enrich_via_crossref(doi) or {}
+        # A retraction, correction or expression of concern has its own DOI and no
+        # supplementary files. Searching one finds nothing, and that failure is
+        # indistinguishable from a paper that published none -- so follow it to the article
+        # it concerns and search for THAT. The link rides on the record just fetched.
+        original = enriched.get("original_doi")
+        if original:
+            doi = original
+            enriched = _resolve.enrich_via_crossref(doi) or {}
+        title = title or enriched.get("title")
+        authors = enriched.get("authors") or []
+    paper = {"doi": doi, "title": title, "authors": authors}
+    search_term = doi or q["title"] or query
 
     cands = []
     for fn in (_sources.search_nature_esm, _sources.search_zenodo, _sources.search_figshare,

--- a/src/paperconan/fetch/__init__.py
+++ b/src/paperconan/fetch/__init__.py
@@ -27,10 +27,19 @@ def _rank(cand):
     return score
 
 
-def search_all(query, per_source=5):
+def search_all(query, per_source=5, *, with_resolution=False):
+    """Ranked candidates for `query`.
+
+    With `with_resolution=True`, returns `(candidates, resolution)` instead. The
+    resolution has to travel BESIDE the list rather than on its members: a notice DOI has
+    no supplementary files of its own, so "no candidates at all" is the ordinary result
+    for one, and metadata carried on candidates is exactly the metadata a caller cannot
+    read in the case this feature exists to serve. It reached review carried per-candidate
+    and the empty list threw the whole substitution away in silence.
+    """
     q = _resolve.normalize_query(query)
     doi, title, authors = q["doi"], q["title"], []
-    ambiguous = []
+    ambiguous, ambiguous_doi = [], None
     if q["is_doi"]:
         enriched = _resolve.enrich_via_crossref(doi) or {}
         # A retraction, correction or expression of concern has its own DOI and no
@@ -47,7 +56,10 @@ def search_all(query, per_source=5):
         for _hop in range(_MAX_NOTICE_HOPS):
             originals = enriched.get("original_dois") or []
             if len(originals) > 1:
-                ambiguous = list(originals)
+                # `doi`, not the query: after a hop it is an intermediate notice that
+                # names several, and telling the user their own DOI named several would
+                # be false as well as unactionable.
+                ambiguous, ambiguous_doi = list(originals), doi
                 break
             if not originals or originals[0] in seen:
                 break
@@ -68,9 +80,15 @@ def search_all(query, per_source=5):
             continue
     for c in cands:
         c["match_signals"] = _resolve.match_signals(c, paper)
-        # Carried on every candidate so a caller cannot act on the search without seeing it.
         c["resolved_doi"] = paper["doi"]
-        if ambiguous:
-            c["notice_names_several_articles"] = ambiguous
     cands.sort(key=_rank, reverse=True)
-    return cands
+    if not with_resolution:
+        return cands
+    return cands, {
+        "query_doi": q["doi"],
+        "resolved_doi": paper["doi"],
+        "followed_a_notice": bool(q["doi"]) and paper["doi"] != q["doi"],
+        "ambiguous_notice_doi": ambiguous_doi,
+        "notice_names_several_articles": ambiguous,
+        "title": title,
+    }

--- a/src/paperconan/fetch/_cli.py
+++ b/src/paperconan/fetch/_cli.py
@@ -63,23 +63,25 @@ def fetch_main(argv):
     q = _resolve.normalize_query(args.query)
     resolved_doi = resolution.get("resolved_doi") or q.get("doi")
     guidance_paper = {"doi": resolved_doi, "title": q.get("title")}
-    # `--json` promises parseable stdout, so these notes are held back there. They are not
-    # lost: `resolved_doi` rides on every candidate, and a caller reading JSON is a program
-    # that can compare it to the DOI it asked for.
-    if not args.json:
-        if resolution.get("followed_a_notice"):
-            print(f"{q['doi']} names a retraction or correction; searching the article it "
-                  f"concerns instead: {resolved_doi}\n")
-        several = resolution.get("notice_names_several_articles") or []
-        if several:
-            # The DOI that names several may be an intermediate notice reached by a hop,
-            # not the one typed.
-            named_by = resolution.get("ambiguous_notice_doi") or q.get("doi")
-            print(f"{named_by} is a notice naming {len(several)} articles, so none was "
-                  f"followed -- fetch whichever you mean by its own DOI:")
-            for one in several:
-                print(f"    {one}")
-            print()
+    # STDERR, in both modes. `--json` promises parseable stdout, so the first attempt held
+    # these back whenever it was set -- which put the silence straight back for the case
+    # that matters most: a notice DOI usually finds nothing, and a bare `[]` on stdout is
+    # indistinguishable from "this paper published no source data", the exact ambiguity
+    # this feature exists to remove. Diagnostics about the QUERY are not results; stdout
+    # keeps its shape and stderr carries why it looks like that.
+    if resolution.get("followed_a_notice"):
+        print(f"{q['doi']} names a retraction or correction; searching the article it "
+              f"concerns instead: {resolved_doi}\n", file=sys.stderr)
+    several = resolution.get("notice_names_several_articles") or []
+    if several:
+        # The DOI that names several may be an intermediate notice reached by a hop,
+        # not the one typed.
+        named_by = resolution.get("ambiguous_notice_doi") or q.get("doi")
+        print(f"{named_by} is a notice naming {len(several)} articles, so none was "
+              f"followed -- fetch whichever you mean by its own DOI:", file=sys.stderr)
+        for one in several:
+            print(f"    {one}", file=sys.stderr)
+        print(file=sys.stderr)
 
     target = None
     if args.download:

--- a/src/paperconan/fetch/_cli.py
+++ b/src/paperconan/fetch/_cli.py
@@ -54,6 +54,23 @@ def fetch_main(argv):
 
     cands = search_all(args.query, per_source=args.per_source)
 
+    # `search_all` may have followed a retraction or correction to the article it concerns.
+    # Every path below that points the user somewhere must point at THAT, not at the notice
+    # they typed -- guidance sending them back to a one-page notice is guidance to nowhere.
+    q = _resolve.normalize_query(args.query)
+    resolved_doi = (cands[0].get("resolved_doi") if cands else None) or q.get("doi")
+    guidance_paper = {"doi": resolved_doi, "title": q.get("title")}
+    if resolved_doi and q.get("doi") and resolved_doi != q["doi"]:
+        print(f"{q['doi']} names a retraction or correction; searching the article it "
+              f"concerns instead: {resolved_doi}\n")
+    several = (cands[0].get("notice_names_several_articles") if cands else None)
+    if several:
+        print(f"{q['doi']} is a notice naming {len(several)} articles, so none was followed "
+              f"-- fetch whichever you mean by its own DOI:")
+        for one in several:
+            print(f"    {one}")
+        print()
+
     target = None
     if args.download:
         target = next((c for c in cands if c["cand_id"] == args.download), None)
@@ -79,10 +96,9 @@ def fetch_main(argv):
         if _resolve.is_confident_match(cands[0]):
             target = cands[0]
         else:
-            q = _resolve.normalize_query(args.query)
             print("--auto: no candidate confidently matches this paper "
                   "(no DOI match, weak title overlap), so nothing was downloaded.\n")
-            print(_resolve.journal_guidance({"doi": q.get("doi"), "title": q.get("title")}))
+            print(_resolve.journal_guidance(guidance_paper))
             return 1
 
     if target is None:
@@ -93,9 +109,8 @@ def fetch_main(argv):
             # No usable tabular dataset in the open repos: point the user at where the
             # source data most likely lives (the journal article page).
             if not any(c.get("tabular_files") for c in cands):
-                q = _resolve.normalize_query(args.query)
                 print()
-                print(_resolve.journal_guidance({"doi": q.get("doi"), "title": q.get("title")}))
+                print(_resolve.journal_guidance(guidance_paper))
         return 0
 
     out_dir = args.out or "paperconan_data"

--- a/src/paperconan/fetch/_cli.py
+++ b/src/paperconan/fetch/_cli.py
@@ -52,24 +52,34 @@ def fetch_main(argv):
     ap.add_argument("--per-source", type=int, default=5, help="max results per repository (default: 5)")
     args = ap.parse_args(argv)
 
-    cands = search_all(args.query, per_source=args.per_source)
+    cands, resolution = search_all(args.query, per_source=args.per_source,
+                                   with_resolution=True)
 
     # `search_all` may have followed a retraction or correction to the article it concerns.
     # Every path below that points the user somewhere must point at THAT, not at the notice
     # they typed -- guidance sending them back to a one-page notice is guidance to nowhere.
+    # The resolution comes back beside the list, not on its members: a notice DOI usually
+    # finds NOTHING, and that empty search is the case this whole feature exists for.
     q = _resolve.normalize_query(args.query)
-    resolved_doi = (cands[0].get("resolved_doi") if cands else None) or q.get("doi")
+    resolved_doi = resolution.get("resolved_doi") or q.get("doi")
     guidance_paper = {"doi": resolved_doi, "title": q.get("title")}
-    if resolved_doi and q.get("doi") and resolved_doi != q["doi"]:
-        print(f"{q['doi']} names a retraction or correction; searching the article it "
-              f"concerns instead: {resolved_doi}\n")
-    several = (cands[0].get("notice_names_several_articles") if cands else None)
-    if several:
-        print(f"{q['doi']} is a notice naming {len(several)} articles, so none was followed "
-              f"-- fetch whichever you mean by its own DOI:")
-        for one in several:
-            print(f"    {one}")
-        print()
+    # `--json` promises parseable stdout, so these notes are held back there. They are not
+    # lost: `resolved_doi` rides on every candidate, and a caller reading JSON is a program
+    # that can compare it to the DOI it asked for.
+    if not args.json:
+        if resolution.get("followed_a_notice"):
+            print(f"{q['doi']} names a retraction or correction; searching the article it "
+                  f"concerns instead: {resolved_doi}\n")
+        several = resolution.get("notice_names_several_articles") or []
+        if several:
+            # The DOI that names several may be an intermediate notice reached by a hop,
+            # not the one typed.
+            named_by = resolution.get("ambiguous_notice_doi") or q.get("doi")
+            print(f"{named_by} is a notice naming {len(several)} articles, so none was "
+                  f"followed -- fetch whichever you mean by its own DOI:")
+            for one in several:
+                print(f"    {one}")
+            print()
 
     target = None
     if args.download:

--- a/src/paperconan/fetch/_resolve.py
+++ b/src/paperconan/fetch/_resolve.py
@@ -17,7 +17,12 @@ def normalize_query(text):
 
 
 def enrich_via_crossref(doi):
-    """Best-effort title/authors/year for a paper DOI. Returns None on any failure."""
+    """Best-effort title/authors/year for a paper DOI. Returns None on any failure.
+
+    Also carries `original_doi`: the article a retraction or correction concerns, when this
+    DOI names one. It comes from the same record, so asking costs no extra request -- and a
+    separate lookup would double the round-trips on every fetch.
+    """
     try:
         m = _http.get_json(
             f"https://api.crossref.org/works/{urllib.parse.quote(doi, safe='')}"
@@ -31,7 +36,55 @@ def enrich_via_crossref(doi):
     dp = m.get("issued", {}).get("date-parts", [[None]])
     if dp and dp[0]:
         year = str(dp[0][0])
-    return {"doi": doi, "title": title, "authors": authors, "year": year}
+    return {"doi": doi, "title": title, "authors": authors, "year": year,
+            "original_doi": _original_from_record(m)}
+
+
+# A retraction, correction or expression of concern is a page of its own, with its own DOI
+# and no supplementary files. Searching one for source data finds nothing, and the failure
+# looks exactly like a paper that published none. Crossref records what the notice is about,
+# so the DOI of the article itself is recoverable.
+_NOTICE_TITLE = re.compile(
+    r"^\s*(retraction|retracted|withdrawn|author correction|publisher correction|correction"
+    r"|corrigendum|erratum|editorial expression of concern|expression of concern"
+    r"|editor'?s note|matters arising)\b",
+    re.I,
+)
+# Where a publisher records the link. `update-to` is the standard place; some use `relation`
+# instead, and a few use both.
+_ORIGINAL_RELATIONS = ("is-correction-of", "is-retraction-of", "is-comment-on")
+
+
+def _original_from_record(message):
+    """The DOI of the article this Crossref record is a notice about, or None.
+
+    None also covers "it is a notice but names nothing to follow" -- an expression of concern
+    that lists no original is not an error, and returning the notice's own DOI would send the
+    search straight back where it started.
+    """
+    title = (message.get("title") or [""])[0]
+    if not _NOTICE_TITLE.match(title or ""):
+        return None
+    for update in (message.get("update-to") or []):
+        if update.get("DOI"):
+            return update["DOI"]
+    relation = message.get("relation") or {}
+    for key in _ORIGINAL_RELATIONS:
+        for entry in relation.get(key, []):
+            if entry.get("id-type") == "doi" and entry.get("id"):
+                return entry["id"]
+    return None
+
+
+def original_article_doi(doi):
+    """`_original_from_record` for a DOI, fetching the record. One request."""
+    try:
+        message = _http.get_json(
+            f"https://api.crossref.org/works/{urllib.parse.quote(doi, safe='')}"
+        ).get("message", {})
+    except Exception:
+        return None
+    return _original_from_record(message)
 
 
 # DOI registrant prefix -> publisher, for pointing users at the article page when the

--- a/src/paperconan/fetch/_resolve.py
+++ b/src/paperconan/fetch/_resolve.py
@@ -44,9 +44,13 @@ def enrich_via_crossref(doi):
 # and no supplementary files. Searching one for source data finds nothing, and the failure
 # looks exactly like a paper that published none. Crossref records what the notice is about,
 # so the DOI of the article itself is recoverable.
+# `editorial` is an optional prefix rather than one spelled-out phrase: Science files its
+# retractions as "Editorial retraction", which the spelled-out list missed while matching
+# "Editorial expression of concern" -- the same word in front of a different noun.
 _NOTICE_TITLE = re.compile(
-    r"^\s*(retraction|retracted|withdrawn|author correction|publisher correction|correction"
-    r"|corrigendum|erratum|editorial expression of concern|expression of concern"
+    r"^\s*(?:editorial\s+)?"
+    r"(retraction|retracted|withdrawn|author correction|publisher correction|correction"
+    r"|corrigendum|erratum|expression of concern"
     r"|editor'?s note|matters arising)\b",
     re.I,
 )

--- a/src/paperconan/fetch/_resolve.py
+++ b/src/paperconan/fetch/_resolve.py
@@ -19,8 +19,8 @@ def normalize_query(text):
 def enrich_via_crossref(doi):
     """Best-effort title/authors/year for a paper DOI. Returns None on any failure.
 
-    Also carries `original_doi`: the article a retraction or correction concerns, when this
-    DOI names one. It comes from the same record, so asking costs no extra request -- and a
+    Also carries `original_dois`: the articles a retraction or correction concerns, when this
+    DOI names any. They come from the same record, so asking costs no extra request -- and a
     separate lookup would double the round-trips on every fetch.
     """
     try:
@@ -37,7 +37,7 @@ def enrich_via_crossref(doi):
     if dp and dp[0]:
         year = str(dp[0][0])
     return {"doi": doi, "title": title, "authors": authors, "year": year,
-            "original_doi": _original_from_record(m)}
+            "original_dois": _originals_from_record(m)}
 
 
 # A retraction, correction or expression of concern is a page of its own, with its own DOI
@@ -55,36 +55,34 @@ _NOTICE_TITLE = re.compile(
 _ORIGINAL_RELATIONS = ("is-correction-of", "is-retraction-of", "is-comment-on")
 
 
-def _original_from_record(message):
-    """The DOI of the article this Crossref record is a notice about, or None.
+def _originals_from_record(message):
+    """Every article DOI this Crossref record is a notice about, in the order recorded.
 
-    None also covers "it is a notice but names nothing to follow" -- an expression of concern
-    that lists no original is not an error, and returning the notice's own DOI would send the
-    search straight back where it started.
+    A LIST, not one DOI, because one notice routinely concerns several papers -- a bulk
+    correction, or an expression of concern covering an author's output. Returning the first
+    would pick one silently, and since the picked DOI then decides `match_signals`, the
+    confidence check would go on to endorse a stranger's data as this paper's. For a tool
+    whose whole job is telling one paper's numbers from another's, that is the worst
+    available failure.
+
+    Empty covers both "not a notice" and "a notice that names nothing to follow"; the latter
+    is not an error, and returning the notice's own DOI would send a search straight back
+    where it started.
     """
     title = (message.get("title") or [""])[0]
     if not _NOTICE_TITLE.match(title or ""):
-        return None
+        return []
+    out = []
     for update in (message.get("update-to") or []):
-        if update.get("DOI"):
-            return update["DOI"]
+        doi = update.get("DOI")
+        if doi and doi not in out:
+            out.append(doi)
     relation = message.get("relation") or {}
     for key in _ORIGINAL_RELATIONS:
         for entry in relation.get(key, []):
-            if entry.get("id-type") == "doi" and entry.get("id"):
-                return entry["id"]
-    return None
-
-
-def original_article_doi(doi):
-    """`_original_from_record` for a DOI, fetching the record. One request."""
-    try:
-        message = _http.get_json(
-            f"https://api.crossref.org/works/{urllib.parse.quote(doi, safe='')}"
-        ).get("message", {})
-    except Exception:
-        return None
-    return _original_from_record(message)
+            if entry.get("id-type") == "doi" and entry.get("id") and entry["id"] not in out:
+                out.append(entry["id"])
+    return out
 
 
 # DOI registrant prefix -> publisher, for pointing users at the article page when the

--- a/tests/fetch/test_cli.py
+++ b/tests/fetch/test_cli.py
@@ -16,12 +16,31 @@ def _minimal_xlsx_bytes():
     return payload.getvalue()
 
 
+
+def _stub_search(cands, **resolution):
+    """Stand in for `search_all` exactly as `_cli` calls it -- resolution BESIDE the list.
+
+    A stub returning a bare list raises TypeError against the keyword rather than quietly
+    handing back something the CLI then misreads, which is the point: the defect this
+    replaces was resolution carried ON the candidates, invisible whenever there were none.
+    """
+    base = {"query_doi": None, "resolved_doi": None, "followed_a_notice": False,
+            "ambiguous_notice_doi": None, "notice_names_several_articles": [],
+            "title": None}
+    base.update(resolution)
+
+    def _search(query, per_source=5, *, with_resolution=False):
+        return (list(cands), dict(base)) if with_resolution else list(cands)
+
+    return _search
+
+
 def test_fetch_list_prints_candidates_json(monkeypatch, capsys):
     cands = [{"cand_id": "zenodo:1", "source": "zenodo", "doi": "10.x/z",
               "title": "T", "tabular_files": [{"name": "a.xlsx"}],
               "all_files_count": 1, "match_signals": {"doi_in_related": True,
               "title_overlap": None, "author_overlap": None}}]
-    monkeypatch.setattr(_cli, "search_all", lambda q, per_source=5: cands)
+    monkeypatch.setattr(_cli, "search_all", _stub_search(cands))
     rc = _cli.fetch_main(["10.15761/JTS.1000455", "--json"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
@@ -33,7 +52,7 @@ def test_fetch_download_selected_candidate(monkeypatch, tmp_path):
               "tabular_files": [{"name": "a.csv", "ext": "csv", "size": 3,
               "download_url": "u"}], "all_files_count": 1,
               "match_signals": {"doi_in_related": True}}]
-    monkeypatch.setattr(_cli, "search_all", lambda q, per_source=5: cands)
+    monkeypatch.setattr(_cli, "search_all", _stub_search(cands))
     captured = {}
     monkeypatch.setattr(_cli, "download_candidate",
                         lambda c, out_dir, **kw: captured.update(cid=c["cand_id"], out=out_dir)
@@ -44,13 +63,13 @@ def test_fetch_download_selected_candidate(monkeypatch, tmp_path):
 
 
 def test_fetch_download_missing_candidate_returns_2(monkeypatch):
-    monkeypatch.setattr(_cli, "search_all", lambda q, per_source=5: [])
+    monkeypatch.setattr(_cli, "search_all", _stub_search([]))
     rc = _cli.fetch_main(["10.x/paper", "--download", "zenodo:999"])
     assert rc == 2
 
 
 def test_fetch_auto_empty_returns_1(monkeypatch):
-    monkeypatch.setattr(_cli, "search_all", lambda q, per_source=5: [])
+    monkeypatch.setattr(_cli, "search_all", _stub_search([]))
     rc = _cli.fetch_main(["10.x/paper", "--auto", "--out", "/tmp/pc_auto_empty"])
     assert rc == 1
 
@@ -60,7 +79,7 @@ def test_fetch_auto_downloads_top_candidate(monkeypatch, tmp_path):
               "all_files_count": 1, "match_signals": {"doi_in_related": True},
               "tabular_files": [{"name": "a.csv", "ext": "csv", "size": 3,
               "download_url": "u"}]}]
-    monkeypatch.setattr(_cli, "search_all", lambda q, per_source=5: cands)
+    monkeypatch.setattr(_cli, "search_all", _stub_search(cands))
     captured = {}
     monkeypatch.setattr(_cli, "download_candidate",
                         lambda c, out_dir, **kw: captured.update(cid=c["cand_id"])
@@ -78,7 +97,7 @@ def test_fetch_auto_refuses_unmatched_candidate(monkeypatch, capsys):
               "all_files_count": 147, "match_signals": {"doi_in_related": False,
               "title_overlap": 0.02, "author_overlap": 0.0},
               "tabular_files": [{"name": "x.csv", "ext": "csv", "size": 3, "download_url": "u"}]}]
-    monkeypatch.setattr(_cli, "search_all", lambda q, per_source=5: cands)
+    monkeypatch.setattr(_cli, "search_all", _stub_search(cands))
     called = {"n": 0}
     monkeypatch.setattr(_cli, "download_candidate",
                         lambda *a, **k: called.__setitem__("n", called["n"] + 1) or {})
@@ -96,7 +115,7 @@ def test_fetch_download_unmatched_requires_force(monkeypatch, capsys):
               "all_files_count": 1, "match_signals": {"doi_in_related": False,
               "title_overlap": 0.02}, "tabular_files": [{"name": "x.csv", "ext": "csv",
               "size": 3, "download_url": "u"}]}]
-    monkeypatch.setattr(_cli, "search_all", lambda q, per_source=5: cands)
+    monkeypatch.setattr(_cli, "search_all", _stub_search(cands))
     called = {"n": 0}
     monkeypatch.setattr(_cli, "download_candidate",
                         lambda *a, **k: called.__setitem__("n", called["n"] + 1) or {})
@@ -111,7 +130,7 @@ def test_fetch_download_unmatched_with_force_proceeds(monkeypatch, tmp_path):
               "all_files_count": 1, "match_signals": {"doi_in_related": False,
               "title_overlap": 0.02}, "tabular_files": [{"name": "x.csv", "ext": "csv",
               "size": 3, "download_url": "u"}]}]
-    monkeypatch.setattr(_cli, "search_all", lambda q, per_source=5: cands)
+    monkeypatch.setattr(_cli, "search_all", _stub_search(cands))
     captured = {}
     monkeypatch.setattr(_cli, "download_candidate",
                         lambda c, out_dir, **kw: captured.update(cid=c["cand_id"])
@@ -128,7 +147,7 @@ def test_fetch_list_flags_unmatched_candidate(monkeypatch, capsys):
               "all_files_count": 5, "match_signals": {"doi_in_related": False,
               "title_overlap": 0.02, "author_overlap": 0.0},
               "tabular_files": [{"name": "x.csv"}]}]
-    monkeypatch.setattr(_cli, "search_all", lambda q, per_source=5: cands)
+    monkeypatch.setattr(_cli, "search_all", _stub_search(cands))
     rc = _cli.fetch_main(["10.x/paper"])
     assert rc == 0
     assert "no DOI/title match" in capsys.readouterr().out
@@ -143,7 +162,7 @@ def test_fetch_download_and_auto_mutually_exclusive():
 def test_fetch_empty_prints_journal_guidance(monkeypatch, capsys):
     """No open-repo hit on a Nature DOI: point the user to the article's Source Data
     section instead of leaving them with a dead end."""
-    monkeypatch.setattr(_cli, "search_all", lambda q, per_source=5: [])
+    monkeypatch.setattr(_cli, "search_all", _stub_search([]))
     rc = _cli.fetch_main(["10.1038/s41590-026-02471-0"])
     assert rc == 0
     out = capsys.readouterr().out
@@ -153,7 +172,7 @@ def test_fetch_empty_prints_journal_guidance(monkeypatch, capsys):
 
 def test_fetch_empty_json_mode_stays_clean(monkeypatch, capsys):
     """--json must remain machine-parseable (empty list), no guidance prose mixed in."""
-    monkeypatch.setattr(_cli, "search_all", lambda q, per_source=5: [])
+    monkeypatch.setattr(_cli, "search_all", _stub_search([]))
     rc = _cli.fetch_main(["10.1038/x", "--json"])
     assert rc == 0
     assert json.loads(capsys.readouterr().out) == []
@@ -169,7 +188,7 @@ def test_fetch_images_passes_additive_option(monkeypatch, tmp_path):
         "tabular_files": [{"name": "data.csv"}],
         "image_files": [{"name": "Fig1.png"}],
     }]
-    monkeypatch.setattr(_cli, "search_all", lambda q, per_source=5: cands)
+    monkeypatch.setattr(_cli, "search_all", _stub_search(cands))
     captured = {}
 
     def stub_download(candidate, out_dir, **kwargs):
@@ -202,7 +221,7 @@ def test_fetch_auto_uses_jci_fallback_after_archive_failure(
             "name": "PMC1_supplementary.zip",
         },
     }
-    monkeypatch.setattr(_cli, "search_all", lambda q, per_source=5: [candidate])
+    monkeypatch.setattr(_cli, "search_all", _stub_search([candidate]))
     monkeypatch.setattr(
         _http,
         "get_text",
@@ -244,3 +263,72 @@ def test_fetch_auto_uses_jci_fallback_after_archive_failure(
     assert rc == 0
     assert "downloaded 1 file(s)" in capsys.readouterr().out
     assert (tmp_path / "table.xlsx").exists()
+
+
+def test_fetch_zero_candidates_still_points_at_the_resolved_article(monkeypatch, capsys):
+    """The empty search IS the notice case, so it is the one the guidance must get right.
+
+    A notice has no supplementary files of its own; searching it finds nothing. That is not
+    an edge case to tidy up later, it is the ordinary outcome -- and it is where the
+    substitution used to be thrown away, sending the reader back to the one-page notice
+    they had just been moved off.
+    """
+    monkeypatch.setattr(_cli, "search_all", _stub_search(
+        [], query_doi="10.1038/notice-9", resolved_doi="10.1038/orig-1",
+        followed_a_notice=True))
+
+    rc = _cli.fetch_main(["10.1038/notice-9"])
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "10.1038/orig-1" in out
+    assert "names a retraction or correction" in out
+    # The guidance link must be the article's, not the notice's.
+    assert "https://doi.org/10.1038/orig-1" in out
+
+
+def test_fetch_zero_candidates_still_lists_a_multi_article_notice(monkeypatch, capsys):
+    """Naming the articles is the entire remedy offered when none can be followed."""
+    monkeypatch.setattr(_cli, "search_all", _stub_search(
+        [], query_doi="10.1038/bulk", resolved_doi="10.1038/bulk",
+        ambiguous_notice_doi="10.1038/bulk",
+        notice_names_several_articles=["10.1038/a-1", "10.1038/b-2", "10.1038/c-3"]))
+
+    rc = _cli.fetch_main(["10.1038/bulk"])
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "naming 3 articles" in out
+    for one in ("10.1038/a-1", "10.1038/b-2", "10.1038/c-3"):
+        assert one in out
+
+
+def test_fetch_json_stays_parseable_when_a_notice_resolves(monkeypatch, capsys):
+    """`--json` promises machine-readable stdout, and a resolving notice must not break it."""
+    cands = [{"cand_id": "zenodo:1", "source": "zenodo", "doi": "10.x/z", "title": "T",
+              "tabular_files": [], "all_files_count": 1, "resolved_doi": "10.1038/orig-1",
+              "match_signals": {"doi_in_related": True}}]
+    monkeypatch.setattr(_cli, "search_all", _stub_search(
+        cands, query_doi="10.1038/notice-9", resolved_doi="10.1038/orig-1",
+        followed_a_notice=True))
+
+    rc = _cli.fetch_main(["10.1038/notice-9", "--json"])
+
+    assert rc == 0
+    parsed = json.loads(capsys.readouterr().out)
+    # The substitution is still legible to a program: it rides on the candidates.
+    assert parsed[0]["resolved_doi"] == "10.1038/orig-1"
+
+
+def test_fetch_names_the_notice_that_actually_lists_several(monkeypatch, capsys):
+    """After a hop the ambiguity belongs to an intermediate notice, not the typed DOI."""
+    monkeypatch.setattr(_cli, "search_all", _stub_search(
+        [], query_doi="10.1038/notice-1", resolved_doi="10.1038/notice-2",
+        followed_a_notice=True, ambiguous_notice_doi="10.1038/notice-2",
+        notice_names_several_articles=["10.1038/a-1", "10.1038/b-2"]))
+
+    _cli.fetch_main(["10.1038/notice-1"])
+
+    out = capsys.readouterr().out
+    assert "10.1038/notice-2 is a notice naming 2 articles" in out
+    assert "10.1038/notice-1 is a notice naming" not in out

--- a/tests/fetch/test_cli.py
+++ b/tests/fetch/test_cli.py
@@ -279,12 +279,12 @@ def test_fetch_zero_candidates_still_points_at_the_resolved_article(monkeypatch,
 
     rc = _cli.fetch_main(["10.1038/notice-9"])
 
-    out = capsys.readouterr().out
+    captured = capsys.readouterr()
     assert rc == 0
-    assert "10.1038/orig-1" in out
-    assert "names a retraction or correction" in out
+    assert "names a retraction or correction" in captured.err
+    assert "10.1038/orig-1" in captured.err
     # The guidance link must be the article's, not the notice's.
-    assert "https://doi.org/10.1038/orig-1" in out
+    assert "https://doi.org/10.1038/orig-1" in captured.out
 
 
 def test_fetch_zero_candidates_still_lists_a_multi_article_notice(monkeypatch, capsys):
@@ -296,11 +296,11 @@ def test_fetch_zero_candidates_still_lists_a_multi_article_notice(monkeypatch, c
 
     rc = _cli.fetch_main(["10.1038/bulk"])
 
-    out = capsys.readouterr().out
+    err = capsys.readouterr().err
     assert rc == 0
-    assert "naming 3 articles" in out
+    assert "naming 3 articles" in err
     for one in ("10.1038/a-1", "10.1038/b-2", "10.1038/c-3"):
-        assert one in out
+        assert one in err
 
 
 def test_fetch_json_stays_parseable_when_a_notice_resolves(monkeypatch, capsys):
@@ -315,9 +315,11 @@ def test_fetch_json_stays_parseable_when_a_notice_resolves(monkeypatch, capsys):
     rc = _cli.fetch_main(["10.1038/notice-9", "--json"])
 
     assert rc == 0
-    parsed = json.loads(capsys.readouterr().out)
-    # The substitution is still legible to a program: it rides on the candidates.
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
     assert parsed[0]["resolved_doi"] == "10.1038/orig-1"
+    # And the substitution is stated, not merely inferable from the payload.
+    assert "10.1038/orig-1" in captured.err
 
 
 def test_fetch_names_the_notice_that_actually_lists_several(monkeypatch, capsys):
@@ -329,6 +331,42 @@ def test_fetch_names_the_notice_that_actually_lists_several(monkeypatch, capsys)
 
     _cli.fetch_main(["10.1038/notice-1"])
 
-    out = capsys.readouterr().out
-    assert "10.1038/notice-2 is a notice naming 2 articles" in out
-    assert "10.1038/notice-1 is a notice naming" not in out
+    err = capsys.readouterr().err
+    assert "10.1038/notice-2 is a notice naming 2 articles" in err
+    assert "10.1038/notice-1 is a notice naming" not in err
+
+
+def test_fetch_json_with_no_candidates_still_says_it_followed_a_notice(monkeypatch, capsys):
+    """A notice DOI usually finds nothing, so this is the ordinary `--json` result for one.
+
+    stdout stays the array a caller parses. What must not happen is that the array is the
+    WHOLE story: a bare `[]` reads as "this paper published no source data", which is the
+    ambiguity the notice-following exists to remove. Holding the note back whenever
+    `--json` was set put that silence right back.
+    """
+    monkeypatch.setattr(_cli, "search_all", _stub_search(
+        [], query_doi="10.1038/notice-9", resolved_doi="10.1038/orig-1",
+        followed_a_notice=True))
+
+    rc = _cli.fetch_main(["10.1038/notice-9", "--json"])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert json.loads(captured.out) == []
+    assert "10.1038/orig-1" in captured.err
+
+
+def test_fetch_json_with_no_candidates_still_lists_a_multi_article_notice(monkeypatch, capsys):
+    """Same for the ambiguous case: naming the articles is the only remedy on offer."""
+    monkeypatch.setattr(_cli, "search_all", _stub_search(
+        [], query_doi="10.1038/bulk", resolved_doi="10.1038/bulk",
+        ambiguous_notice_doi="10.1038/bulk",
+        notice_names_several_articles=["10.1038/a-1", "10.1038/b-2"]))
+
+    rc = _cli.fetch_main(["10.1038/bulk", "--json"])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert json.loads(captured.out) == []
+    for one in ("10.1038/a-1", "10.1038/b-2"):
+        assert one in captured.err

--- a/tests/fetch/test_resolve.py
+++ b/tests/fetch/test_resolve.py
@@ -85,55 +85,57 @@ def _crossref(monkeypatch, message):
     monkeypatch.setattr(_http, "get_json", lambda *a, **k: {"message": message})
 
 
-def test_original_article_doi_reads_update_to(monkeypatch):
-    """A retraction or correction carries no source data of its own.
-
-    Its Crossref record points at the article it concerns, so the fetch should follow that
-    rather than searching for supplementary files attached to a one-page notice.
-    """
-    _crossref(monkeypatch, {
+def test_originals_reads_update_to():
+    """A retraction or correction carries no source data of its own; its record says what it
+    is about, so the fetch can follow that instead of searching a one-page notice."""
+    assert _resolve._originals_from_record({
         "title": ["Retraction Note: Something about cells"],
-        "type": "journal-article",
         "update-to": [{"DOI": "10.1038/s41467-021-00000-1", "type": "retraction"}],
-    })
-
-    assert _resolve.original_article_doi("10.1038/s41467-026-00000-9") == \
-        "10.1038/s41467-021-00000-1"
+    }) == ["10.1038/s41467-021-00000-1"]
 
 
-def test_original_article_doi_falls_back_to_relation(monkeypatch):
+def test_originals_falls_back_to_relation():
     """Some publishers record the link only under `relation`, not `update-to`."""
-    _crossref(monkeypatch, {
+    assert _resolve._originals_from_record({
         "title": ["Author Correction: Something about cells"],
         "relation": {"is-correction-of": [{"id": "10.1038/s41586-020-00000-2",
                                            "id-type": "doi"}]},
-    })
-
-    assert _resolve.original_article_doi("10.1038/s41586-026-00000-8") == \
-        "10.1038/s41586-020-00000-2"
+    }) == ["10.1038/s41586-020-00000-2"]
 
 
-def test_original_article_doi_is_none_for_an_ordinary_paper(monkeypatch):
-    """The common case must not be disturbed: a research article resolves to itself."""
-    _crossref(monkeypatch, {"title": ["Structure of a membrane protein"],
-                            "type": "journal-article"})
+def test_originals_returns_every_article_a_notice_names():
+    """One notice routinely concerns several papers -- a bulk correction, or an expression of
+    concern covering an author's output. Returning only the first would let a caller pick one
+    silently, and the picked DOI decides which candidates are judged confident, so a stranger's
+    data would be endorsed as this paper's."""
+    assert _resolve._originals_from_record({
+        "title": ["Expression of Concern: three articles"],
+        "update-to": [{"DOI": "10.1038/a-1"}, {"DOI": "10.1038/b-2"},
+                      {"DOI": "10.1038/a-1"}, {"DOI": "10.1038/c-3"}],
+    }) == ["10.1038/a-1", "10.1038/b-2", "10.1038/c-3"]
 
-    assert _resolve.original_article_doi("10.1038/s41586-020-00000-2") is None
+
+def test_originals_is_empty_for_an_ordinary_paper():
+    """The common case must not be disturbed: a research article names no original."""
+    assert _resolve._originals_from_record(
+        {"title": ["Structure of a membrane protein"], "type": "journal-article"}) == []
 
 
-def test_original_article_doi_is_none_when_the_notice_names_no_original(monkeypatch):
+def test_originals_is_empty_when_the_notice_names_nothing():
     """A notice with nothing to follow is not an error, and must not return itself."""
-    _crossref(monkeypatch, {"title": ["Editorial Expression of Concern"]})
-
-    assert _resolve.original_article_doi("10.1126/science.0000000") is None
+    assert _resolve._originals_from_record({"title": ["Editorial Expression of Concern"]}) == []
 
 
-def test_original_article_doi_survives_a_lookup_failure(monkeypatch):
+def test_enrich_carries_the_originals_and_survives_failure(monkeypatch):
     from paperconan.fetch import _http
+
+    _crossref(monkeypatch, {"title": ["Retraction Note: x"],
+                            "update-to": [{"DOI": "10.1038/orig-1"}]})
+    assert _resolve.enrich_via_crossref("10.1038/notice-9")["original_dois"] == \
+        ["10.1038/orig-1"]
 
     def boom(*a, **k):
         raise OSError("network down")
 
     monkeypatch.setattr(_http, "get_json", boom)
-
-    assert _resolve.original_article_doi("10.1038/s41467-026-00000-9") is None
+    assert _resolve.enrich_via_crossref("10.1038/notice-9") is None

--- a/tests/fetch/test_resolve.py
+++ b/tests/fetch/test_resolve.py
@@ -139,3 +139,29 @@ def test_enrich_carries_the_originals_and_survives_failure(monkeypatch):
 
     monkeypatch.setattr(_http, "get_json", boom)
     assert _resolve.enrich_via_crossref("10.1038/notice-9") is None
+
+
+def test_notice_title_matches_an_editorial_retraction():
+    """Science files its retractions as "Editorial retraction".
+
+    The pattern once spelled out "editorial expression of concern" as one fixed phrase, so
+    the same word in front of a different noun fell through and the notice was searched as
+    if it were the paper. `editorial` is a prefix on any of the terms, not part of one.
+    """
+    from paperconan.fetch._resolve import _originals_from_record
+
+    record = {"title": ["Editorial retraction"],
+              "update-to": [{"DOI": "10.1126/science.orig-1"}]}
+
+    assert _originals_from_record(record) == ["10.1126/science.orig-1"]
+
+
+def test_notice_title_still_matches_the_forms_it_always_did():
+    """The widening must not have cost a title that used to match."""
+    from paperconan.fetch._resolve import _NOTICE_TITLE
+
+    for title in ("Retraction Note: a study", "Expression of concern: a study",
+                  "Editorial Expression of Concern", "Author Correction: a study",
+                  "Corrigendum: a study", "Erratum", "Matters Arising: a study",
+                  "Editor's Note"):
+        assert _NOTICE_TITLE.match(title), title

--- a/tests/fetch/test_resolve.py
+++ b/tests/fetch/test_resolve.py
@@ -75,3 +75,65 @@ def test_is_confident_match_requires_doi_or_strong_title():
         {"match_signals": {"doi_in_related": False, "title_overlap": 0.02}})
     assert not _resolve.is_confident_match({"match_signals": None})
     assert not _resolve.is_confident_match({})
+
+
+# --- a DOI that names a notice, not the paper the notice is about ----------------------
+
+def _crossref(monkeypatch, message):
+    """Stand in for the Crossref lookup so these stay offline."""
+    from paperconan.fetch import _http
+    monkeypatch.setattr(_http, "get_json", lambda *a, **k: {"message": message})
+
+
+def test_original_article_doi_reads_update_to(monkeypatch):
+    """A retraction or correction carries no source data of its own.
+
+    Its Crossref record points at the article it concerns, so the fetch should follow that
+    rather than searching for supplementary files attached to a one-page notice.
+    """
+    _crossref(monkeypatch, {
+        "title": ["Retraction Note: Something about cells"],
+        "type": "journal-article",
+        "update-to": [{"DOI": "10.1038/s41467-021-00000-1", "type": "retraction"}],
+    })
+
+    assert _resolve.original_article_doi("10.1038/s41467-026-00000-9") == \
+        "10.1038/s41467-021-00000-1"
+
+
+def test_original_article_doi_falls_back_to_relation(monkeypatch):
+    """Some publishers record the link only under `relation`, not `update-to`."""
+    _crossref(monkeypatch, {
+        "title": ["Author Correction: Something about cells"],
+        "relation": {"is-correction-of": [{"id": "10.1038/s41586-020-00000-2",
+                                           "id-type": "doi"}]},
+    })
+
+    assert _resolve.original_article_doi("10.1038/s41586-026-00000-8") == \
+        "10.1038/s41586-020-00000-2"
+
+
+def test_original_article_doi_is_none_for_an_ordinary_paper(monkeypatch):
+    """The common case must not be disturbed: a research article resolves to itself."""
+    _crossref(monkeypatch, {"title": ["Structure of a membrane protein"],
+                            "type": "journal-article"})
+
+    assert _resolve.original_article_doi("10.1038/s41586-020-00000-2") is None
+
+
+def test_original_article_doi_is_none_when_the_notice_names_no_original(monkeypatch):
+    """A notice with nothing to follow is not an error, and must not return itself."""
+    _crossref(monkeypatch, {"title": ["Editorial Expression of Concern"]})
+
+    assert _resolve.original_article_doi("10.1126/science.0000000") is None
+
+
+def test_original_article_doi_survives_a_lookup_failure(monkeypatch):
+    from paperconan.fetch import _http
+
+    def boom(*a, **k):
+        raise OSError("network down")
+
+    monkeypatch.setattr(_http, "get_json", boom)
+
+    assert _resolve.original_article_doi("10.1038/s41467-026-00000-9") is None

--- a/tests/fetch/test_search_all.py
+++ b/tests/fetch/test_search_all.py
@@ -167,3 +167,31 @@ def test_search_all_does_not_follow_a_notice_for_a_title_query(monkeypatch):
     fetch.search_all("Structure of a membrane protein", per_source=5)
 
     assert not called
+
+
+def test_search_all_names_the_hopped_to_notice_that_lists_several(monkeypatch):
+    """After a hop, the DOI naming several articles is not the one the user typed.
+
+    Reported at the CLI with a hand-written resolution dict, which can only check the
+    printing. This checks the computation: `ambiguous_notice_doi` must be the DOI the loop
+    was HOLDING when it found several, not the query it started from.
+    """
+    seen = []
+    for name in ("search_nature_esm", "search_zenodo", "search_figshare",
+                 "search_dryad", "search_europepmc"):
+        monkeypatch.setattr(fetch._sources, name, lambda q, size=5: seen.append(q) or [])
+    _records(monkeypatch, {
+        "10.1038/notice-1": {"title": "Correction: a correction",
+                             "original_dois": ["10.1038/notice-2"]},
+        "10.1038/notice-2": {"title": "Expression of Concern: two articles",
+                             "original_dois": ["10.1038/a-1", "10.1038/b-2"]},
+    })
+
+    cands, resolution = fetch.search_all("10.1038/notice-1", per_source=5,
+                                         with_resolution=True)
+
+    assert cands == []
+    assert set(seen) == {"10.1038/notice-2"}, "the hop happened, then stopped"
+    assert resolution["query_doi"] == "10.1038/notice-1"
+    assert resolution["ambiguous_notice_doi"] == "10.1038/notice-2"
+    assert resolution["notice_names_several_articles"] == ["10.1038/a-1", "10.1038/b-2"]

--- a/tests/fetch/test_search_all.py
+++ b/tests/fetch/test_search_all.py
@@ -109,25 +109,28 @@ def test_search_all_will_not_pick_between_the_articles_a_notice_names(monkeypatc
     check would then endorse a stranger's data as this paper's. It searches the notice
     instead, and says what it declined to choose between."""
     seen = []
-    monkeypatch.setattr(fetch._sources, "search_nature_esm",
-                        lambda q, size=5: [{"cand_id": "x:1", "source": "x", "id": "1",
-                                            "doi": None, "title": "", "authors": [],
-                                            "published": None, "tabular_files": [],
-                                            "all_files_count": 0, "related_dois": [],
-                                            "match_signals": None}])
-    for name in ("search_zenodo", "search_figshare", "search_dryad", "search_europepmc"):
+    # EVERY source returns nothing, which is what searching a notice actually does. An
+    # earlier version of this test invented one candidate so that `cands[0]` would exist
+    # to read the answer off -- that invented candidate was the only reason it passed, and
+    # the zero-candidate case it could not express was the one that was broken.
+    for name in ("search_nature_esm", "search_zenodo", "search_figshare",
+                 "search_dryad", "search_europepmc"):
         monkeypatch.setattr(fetch._sources, name, lambda q, size=5: seen.append(q) or [])
     _records(monkeypatch, {
         "10.1038/bulk-notice": {"title": "Expression of Concern: three articles",
                                 "original_dois": ["10.1038/a-1", "10.1038/b-2", "10.1038/c-3"]},
     })
 
-    cands = fetch.search_all("10.1038/bulk-notice", per_source=5)
+    cands, resolution = fetch.search_all("10.1038/bulk-notice", per_source=5,
+                                         with_resolution=True)
 
     assert set(seen) == {"10.1038/bulk-notice"}, "must not follow any one of them"
-    assert cands[0]["notice_names_several_articles"] == \
+    assert cands == []
+    assert resolution["notice_names_several_articles"] == \
         ["10.1038/a-1", "10.1038/b-2", "10.1038/c-3"]
-    assert cands[0]["resolved_doi"] == "10.1038/bulk-notice"
+    assert resolution["ambiguous_notice_doi"] == "10.1038/bulk-notice"
+    assert resolution["resolved_doi"] == "10.1038/bulk-notice"
+    assert resolution["followed_a_notice"] is False
 
 
 def test_search_all_leaves_an_ordinary_paper_alone(monkeypatch):

--- a/tests/fetch/test_search_all.py
+++ b/tests/fetch/test_search_all.py
@@ -51,6 +51,10 @@ def _no_sources(monkeypatch, seen):
         monkeypatch.setattr(fetch._sources, name, spy)
 
 
+def _records(monkeypatch, table):
+    monkeypatch.setattr(fetch._resolve, "enrich_via_crossref", table.get)
+
+
 def test_search_all_follows_a_notice_to_the_article_it_concerns(monkeypatch):
     """A retraction or correction has its own DOI and no supplementary files of its own.
 
@@ -59,14 +63,71 @@ def test_search_all_follows_a_notice_to_the_article_it_concerns(monkeypatch):
     """
     seen = []
     _no_sources(monkeypatch, seen)
-    records = {"10.1038/notice-9": {"title": "Retraction Note: x",
-                                    "original_doi": "10.1038/original-1"},
-               "10.1038/original-1": {"title": "x", "original_doi": None}}
-    monkeypatch.setattr(fetch._resolve, "enrich_via_crossref", records.get)
+    _records(monkeypatch, {
+        "10.1038/notice-9": {"title": "Retraction Note: x", "original_dois": ["10.1038/orig-1"]},
+        "10.1038/orig-1": {"title": "x", "original_dois": []},
+    })
 
     fetch.search_all("10.1038/notice-9", per_source=5)
 
-    assert seen and set(seen) == {"10.1038/original-1"}
+    assert seen and set(seen) == {"10.1038/orig-1"}
+
+
+def test_search_all_follows_a_correction_of_a_correction(monkeypatch):
+    """Corrections get corrected. Stopping after one hop lands on another bare notice --
+    the original bug, one link further down."""
+    seen = []
+    _no_sources(monkeypatch, seen)
+    _records(monkeypatch, {
+        "10.1038/notice-a": {"title": "Author Correction: x", "original_dois": ["10.1038/notice-b"]},
+        "10.1038/notice-b": {"title": "Author Correction: x", "original_dois": ["10.1038/article-c"]},
+        "10.1038/article-c": {"title": "x", "original_dois": []},
+    })
+
+    fetch.search_all("10.1038/notice-a", per_source=5)
+
+    assert seen and set(seen) == {"10.1038/article-c"}
+
+
+def test_search_all_stops_rather_than_looping_on_a_cycle(monkeypatch):
+    """A record that points back at something already visited must end the walk, not spin."""
+    seen = []
+    _no_sources(monkeypatch, seen)
+    _records(monkeypatch, {
+        "10.1038/notice-a": {"title": "Correction: x", "original_dois": ["10.1038/notice-b"]},
+        "10.1038/notice-b": {"title": "Correction: x", "original_dois": ["10.1038/notice-a"]},
+    })
+
+    fetch.search_all("10.1038/notice-a", per_source=5)
+
+    assert seen and set(seen) == {"10.1038/notice-b"}
+
+
+def test_search_all_will_not_pick_between_the_articles_a_notice_names(monkeypatch):
+    """A bulk notice names several papers. Following one would decide silently which paper's
+    data is downloaded -- and because the chosen DOI feeds `match_signals`, the confidence
+    check would then endorse a stranger's data as this paper's. It searches the notice
+    instead, and says what it declined to choose between."""
+    seen = []
+    monkeypatch.setattr(fetch._sources, "search_nature_esm",
+                        lambda q, size=5: [{"cand_id": "x:1", "source": "x", "id": "1",
+                                            "doi": None, "title": "", "authors": [],
+                                            "published": None, "tabular_files": [],
+                                            "all_files_count": 0, "related_dois": [],
+                                            "match_signals": None}])
+    for name in ("search_zenodo", "search_figshare", "search_dryad", "search_europepmc"):
+        monkeypatch.setattr(fetch._sources, name, lambda q, size=5: seen.append(q) or [])
+    _records(monkeypatch, {
+        "10.1038/bulk-notice": {"title": "Expression of Concern: three articles",
+                                "original_dois": ["10.1038/a-1", "10.1038/b-2", "10.1038/c-3"]},
+    })
+
+    cands = fetch.search_all("10.1038/bulk-notice", per_source=5)
+
+    assert set(seen) == {"10.1038/bulk-notice"}, "must not follow any one of them"
+    assert cands[0]["notice_names_several_articles"] == \
+        ["10.1038/a-1", "10.1038/b-2", "10.1038/c-3"]
+    assert cands[0]["resolved_doi"] == "10.1038/bulk-notice"
 
 
 def test_search_all_leaves_an_ordinary_paper_alone(monkeypatch):
@@ -77,7 +138,7 @@ def test_search_all_leaves_an_ordinary_paper_alone(monkeypatch):
 
     def enrich(doi):
         calls.append(doi)
-        return {"title": "A research article", "original_doi": None}
+        return {"title": "A research article", "original_dois": []}
 
     monkeypatch.setattr(fetch._resolve, "enrich_via_crossref", enrich)
 

--- a/tests/fetch/test_search_all.py
+++ b/tests/fetch/test_search_all.py
@@ -39,3 +39,67 @@ def test_search_all_includes_europepmc_supplementary(monkeypatch):
 
     cands = fetch.search_all("10.1038/paper", per_source=5)
     assert any(c["source"] == "europepmc" and c.get("supplementary_archive") for c in cands)
+
+
+def _no_sources(monkeypatch, seen):
+    """Record the term each source is searched with; return nothing."""
+    def spy(q, size=5):
+        seen.append(q)
+        return []
+    for name in ("search_nature_esm", "search_zenodo", "search_figshare",
+                 "search_dryad", "search_europepmc"):
+        monkeypatch.setattr(fetch._sources, name, spy)
+
+
+def test_search_all_follows_a_notice_to_the_article_it_concerns(monkeypatch):
+    """A retraction or correction has its own DOI and no supplementary files of its own.
+
+    Searching one finds nothing, and that failure is indistinguishable from a paper that
+    published no source data -- so the DOI is followed to the article first.
+    """
+    seen = []
+    _no_sources(monkeypatch, seen)
+    records = {"10.1038/notice-9": {"title": "Retraction Note: x",
+                                    "original_doi": "10.1038/original-1"},
+               "10.1038/original-1": {"title": "x", "original_doi": None}}
+    monkeypatch.setattr(fetch._resolve, "enrich_via_crossref", records.get)
+
+    fetch.search_all("10.1038/notice-9", per_source=5)
+
+    assert seen and set(seen) == {"10.1038/original-1"}
+
+
+def test_search_all_leaves_an_ordinary_paper_alone(monkeypatch):
+    """The common path must not change: a research article is searched as itself."""
+    seen = []
+    _no_sources(monkeypatch, seen)
+    calls = []
+
+    def enrich(doi):
+        calls.append(doi)
+        return {"title": "A research article", "original_doi": None}
+
+    monkeypatch.setattr(fetch._resolve, "enrich_via_crossref", enrich)
+
+    fetch.search_all("10.1038/paper-2", per_source=5)
+
+    assert seen and set(seen) == {"10.1038/paper-2"}
+    # and it costs no extra round-trip: the notice link rides on the record already fetched
+    assert calls == ["10.1038/paper-2"]
+
+
+def test_search_all_does_not_follow_a_notice_for_a_title_query(monkeypatch):
+    """Only a DOI can be a notice. A title query has nothing to resolve."""
+    seen = []
+    _no_sources(monkeypatch, seen)
+    called = []
+
+    def enrich(doi):
+        called.append(doi)
+        return None
+
+    monkeypatch.setattr(fetch._resolve, "enrich_via_crossref", enrich)
+
+    fetch.search_all("Structure of a membrane protein", per_source=5)
+
+    assert not called


### PR DESCRIPTION
A retraction note, author correction or expression of concern is a page of its own — its own DOI, no supplementary files. Handed one, the fetch searched for **its** source data, found none, and reported no candidate. That result is indistinguishable from a paper that published no source data at all, while the article the notice is about — which does have the files — was never looked at.

Crossref records the link on the notice, under `update-to` or, for publishers that use it instead, a `relation` of `is-correction-of` / `is-retraction-of` / `is-comment-on`. When a DOI resolves to a notice and names an original, the search now runs against the original.

## No extra request, and the test says so

The first attempt gave this its own Crossref call. That doubled the round-trips on every fetch, and — measured, not assumed — pulled two previously offline tests onto the network, which is how it was caught. The link rides on the record `enrich_via_crossref` already fetches, so an ordinary paper still costs exactly **one** lookup. A test asserts that count rather than trusting it.

## Two cases that could go wrong quietly

- **A notice that names no original** returns `None`, not its own DOI. Returning itself would send the search straight back where it started and look like it had tried.
- **Title queries** are untouched — only a DOI can be a notice, so nothing resolves for them.

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)