### PR TITLE
fix(detect): grade a repeated segment's floor by precision, not length alone

### DIFF
--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -3165,6 +3165,50 @@ def _vector_is_patterned(vec):
 # row (a wide genomics matrix) cannot balloon memory before the budget check fires.
 _WR_MAX_ROW_CELLS = int(os.environ.get("PAPERCONAN_WR_MAX_ROW_CELLS", "20000"))
 
+# How wide a repeated within-row segment must be. The floor here is ALREADY graded by what
+# the values are and not only by how many there are: an all-integer tuple needs k>=5 with
+# >=4 distinct values where anything else needs k>=4. The grading dimension was integer-ness
+# alone, and at the short end that orders the evidence backwards -- three values recorded to
+# several decimals, repeated exactly at two places, is far more agreement than four values
+# recorded to two decimals, which the same floor waves through. So precision is a second
+# dimension: a segment may be one column shorter when every cell in it was written finely
+# enough that the match cannot be read as coarse-grid coincidence.
+#
+# WITHIN-ROW ONLY. The cross-figure pass in the same function keeps `min_k`; its docstring
+# calls it the most false-positive-prone pass in the engine and it is not what any recorded
+# gap asks for.
+_WR_SEGMENT_MIN_COLS = int(os.environ.get("PAPERCONAN_WR_SEGMENT_MIN_COLS", "4"))
+# The shorter length a finely-recorded segment may use.
+_WR_SEGMENT_FINE_MIN_COLS = int(os.environ.get("PAPERCONAN_WR_SEGMENT_FINE_MIN_COLS", "3"))
+# Decimals every cell of a short segment must carry. Counted on the round-6 key the window
+# index is built from, so 6 is the most this can ask for; asking for more would reject
+# everything in silence.
+_WR_SEGMENT_FINE_MIN_FRAC_DIGITS = int(
+    os.environ.get("PAPERCONAN_WR_SEGMENT_FINE_MIN_FRAC_DIGITS", "5"))
+# Short windows get their OWN budget, and cannot spend the one the existing widths spend.
+# Sharing it meant each start position cost one window more, the shared budget ran out
+# sooner on a large sheet, and the pass reported LESS than before this capability existed --
+# measured, as a four-wide finding that vanished from a corpus file whose scan already
+# prints "within-row coverage bounded". A capability that subtracts coverage elsewhere is
+# not a capability. With a separate counter the wider widths deplete exactly as they did,
+# so their reach is unchanged whatever the short pass does.
+_WR_SHORT_SEGMENT_BUDGET = int(
+    os.environ.get("PAPERCONAN_WR_SHORT_SEGMENT_BUDGET", str(_WITHIN_ROW_VEC_BUDGET // 4)))
+
+
+def _wr_frac_digits(v):
+    """Decimals in `v` as the window index stores it (already rounded to 6)."""
+    text = f"{float(v):.6f}".rstrip("0")
+    return len(text.split(".")[1]) if "." in text else 0
+
+
+def _wr_segment_is_long_enough(vec):
+    """Is this repeated segment wide enough, given how finely its cells were recorded?"""
+    if len(vec) >= _WR_SEGMENT_MIN_COLS:
+        return True
+    return (len(vec) >= _WR_SEGMENT_FINE_MIN_COLS
+            and all(_wr_frac_digits(v) >= _WR_SEGMENT_FINE_MIN_FRAC_DIGITS for v in vec))
+
 
 def detect_recurring_row_vectors(grid_sheets, profile="review",
                                  min_k=4, max_k=8, max_rows=300, max_findings=20,
@@ -3282,6 +3326,7 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
     # be invisible. Same gates as the cross-figure path; the repeat corroborates itself, so one
     # figure namespace is enough.
     wr_budget = _WITHIN_ROW_VEC_BUDGET
+    wr_short_budget = _WR_SHORT_SEGMENT_BUDGET
     wr_cands = []
     for (fname, sname), sheet in grid_sheets.items():
         fk = figure_key(sname)
@@ -3293,24 +3338,46 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
                     seq.append((c, float(v)))
                     if len(seq) >= _WR_MAX_ROW_CELLS:  # cap width so one huge row can't OOM
                         break
-            if len(seq) < 2 * min_k:
+            # The within-row pass has its own shortest segment, so this precondition
+            # must use THAT: keeping `min_k` here would drop every row too narrow for
+            # two four-wide copies before a three-wide pair was ever considered.
+            if len(seq) < 2 * min(min_k, _WR_SEGMENT_FINE_MIN_COLS):
                 continue
             # per-row value frequency, keyed with the SAME quantization as the window (round-6)
             # so bucket and key agree at every magnitude: a value from a small quantized pool
             # (k/19 grid, dose plateau) recurs far more than the copies, unlike a copied segment.
             row_freq = Counter(round(v, 6) for _c, v in seq)
             wins = {}
+            wr_min_k = min(min_k, _WR_SEGMENT_FINE_MIN_COLS)
+            # Which cells were recorded finely enough for a SHORT segment to be allowed.
+            # Computed once per row so the check below costs a lookup, and consulted before
+            # a short window is indexed at all: widening the width range without this made
+            # every start position cost an extra window, the within-row budget ran out
+            # sooner on a large sheet, and the pass reported LESS than before the capability
+            # was added. Measured -- a four-wide finding disappeared from a corpus file that
+            # prints "within-row coverage bounded". A short window that cannot pass the
+            # precision gate later is work that buys nothing, so it is never indexed.
+            fine = [_wr_frac_digits(v) >= _WR_SEGMENT_FINE_MIN_FRAC_DIGITS for _c, v in seq]
             for start in range(len(seq)):
-                for k in range(min_k, max_k + 1):
+                for k in range(wr_min_k, max_k + 1):
                     if start + k > len(seq):
                         break
+                    if k < _WR_SEGMENT_MIN_COLS:
+                        # A short window that cannot clear the precision gate later is work
+                        # that buys nothing, so it is not indexed at all.
+                        if wr_short_budget <= 0 or not all(fine[start:start + k]):
+                            continue
+                        wr_short_budget -= 1
+                    else:
+                        wr_budget -= 1
                     wins.setdefault(tuple(round(seq[start + o][1], 6) for o in range(k)),
                                     []).append(start)
-                    wr_budget -= 1
                 if wr_budget <= 0:                     # gate INSIDE the loop, not per-row
                     break
             for vec, starts in wins.items():
                 if len(starts) < 2 or _vector_is_patterned(list(vec)) or len(set(vec)) < 3:
+                    continue
+                if not _wr_segment_is_long_enough(vec):
                     continue
                 all_int = all(abs(v - round(v)) < 1e-9 for v in vec)
                 if all_int and (len(vec) < 5 or len(set(vec)) < 4):
@@ -3342,6 +3409,11 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
               file=sys.stderr)
         _note_detector_cap(coverage, "detect_recurring_row_vectors",
                            "detector_within_row_budget_limit")
+    if wr_short_budget <= 0:
+        # Reported separately: this one bounds only the short-segment widths, and reading it
+        # as the line above would overstate what was left unscanned.
+        _note_detector_cap(coverage, "detect_recurring_row_vectors",
+                           "detector_within_row_short_budget_limit")
     # One physical repeat yields many overlapping windows (k=4..8) — keep the strongest (most
     # copies, then longest) per row, dropping >=50%-cell-overlap duplicates.
     wr_cands.sort(key=lambda x: (-len(x[5]), -len(x[0])))

--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -3416,7 +3416,15 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
                            "detector_within_row_short_budget_limit")
     # One physical repeat yields many overlapping windows (k=4..8) — keep the strongest (most
     # copies, then longest) per row, dropping >=50%-cell-overlap duplicates.
-    wr_cands.sort(key=lambda x: (-len(x[5]), -len(x[0])))
+    # Short candidates are ranked AFTER every wider one, then by the existing key. A
+    # three-wide window sitting inside a genuine four-wide repeat can occur at a third
+    # place the fourth column does not agree on, which gives it more copies -- so under
+    # the copies-first key alone it won the pool and the four-wide finding was dropped
+    # against it as an overlapping duplicate. The reader then lost the fourth column's
+    # agreement entirely: a shorter, weaker statement REPLACING a longer one rather than
+    # being added beside it. The leading term is constant False for every candidate at or
+    # above the ordinary width, so their order among themselves is untouched.
+    wr_cands.sort(key=lambda x: (len(x[0]) < _WR_SEGMENT_MIN_COLS, -len(x[5]), -len(x[0])))
     wr_kept = []
     for c in wr_cands:
         if any(c[1:5] == kc[1:5] and len(c[6] & kc[6]) >= 0.5 * min(len(c[6]), len(kc[6]))

--- a/tests/test_detector_cap_coverage.py
+++ b/tests/test_detector_cap_coverage.py
@@ -915,6 +915,9 @@ _SCAN_REASONS_NOT_IN_SKILL = {
     # bullet without teaching the agent anything new.
     "detector_cross_figure_budget_limit",
     "detector_within_row_budget_limit",
+    # The third: the short-segment widths carry their own counter so they cannot take
+    # reach from the widths above. Same class, same rendering, nothing new to instruct.
+    "detector_within_row_short_budget_limit",
 }
 
 

--- a/tests/test_detector_cap_coverage.py
+++ b/tests/test_detector_cap_coverage.py
@@ -397,6 +397,8 @@ _BUDGETS = (
      "detector_cross_figure_budget_limit"),
     ("detect_recurring_row_vectors", "_WITHIN_ROW_VEC_BUDGET",
      "detector_within_row_budget_limit"),
+    ("detect_recurring_row_vectors", "_WR_SHORT_SEGMENT_BUDGET",
+     "detector_within_row_short_budget_limit"),
     ("detect_scaled_row_reuse", "_SCALED_ROW_BUDGET", "detector_compute_budget_limit"),
     ("detect_short_row_reuse", "_SHORT_ROW_BUDGET", "detector_compute_budget_limit"),
     ("detect_within_row_shared_fraction", "_WITHIN_ROW_FRAC_BUDGET", "detector_compute_budget_limit"),

--- a/tests/test_within_row_repeated_segment.py
+++ b/tests/test_within_row_repeated_segment.py
@@ -9,6 +9,8 @@ verdict — same family, same gates (>=3 distinct values, no ladders), extended 
 """
 from __future__ import annotations
 
+import json
+
 from paperconan import scan_dir, write_html_report
 from paperconan._audit import detect_recurring_row_vectors
 from paperconan._sheet import Sheet
@@ -223,3 +225,92 @@ def test_scan_dir_surfaces_within_row_repeated_segment(tmp_path):
     res = scan_dir(str(data), str(tmp_path / "out"), write_html=True)
     assert [f for f in res.get("cross_sheet_findings", []) or []
             if f.get("kind") == "within_row_repeated_segment"]
+
+
+# --- the floor is graded by what the values are, not only by how many there are ---
+
+# Six decimals, no ladder, three distinct values: as a repeat, this is a lot of agreement.
+_FINE = [4.176382, 9.028415, 1.593047]
+# The same three numbers as a reader would meet them at two decimals. Same COUNT, far less
+# said -- which is the asymmetry a count-only floor cannot see.
+_COARSE = [round(v, 2) for v in _FINE]
+
+
+def _three_wide_row(segment):
+    """One row carrying `segment` twice at non-overlapping columns, spacers between."""
+    return [2.719281, *segment, 6.451927, 8.130644, *segment, 3.907516]
+
+
+def test_a_three_wide_high_precision_repeat_is_found():
+    """Three values recorded finely and repeated exactly is more agreement than four coarse
+    ones, and the length-only floor ranked it the other way: it rejected this and accepted
+    the coarser, longer run."""
+    findings = detect_recurring_row_vectors({
+        ("synthetic.xlsx", "Figure 1"): _row_sheet(_three_wide_row(_FINE)),
+    })
+
+    wr = [f for f in findings if f["kind"] == "within_row_repeated_segment"]
+    assert len(wr) == 1, f"expected the three-wide fine repeat, got {findings}"
+    assert wr[0]["vector"] == _FINE
+
+
+def test_a_three_wide_coarse_repeat_is_not_found():
+    """The control that makes the test above about PRECISION and not about length.
+
+    Same shape, same count, same positions -- only the number of recorded decimals differs.
+    If this fired too, the change would be 'shorten the floor', which is the thing measured
+    to cost more than it returns."""
+    findings = detect_recurring_row_vectors({
+        ("synthetic.xlsx", "Figure 1"): _row_sheet(_three_wide_row(_COARSE)),
+    })
+
+    assert [f for f in findings if f["kind"] == "within_row_repeated_segment"] == []
+
+
+def test_the_short_pass_cannot_spend_the_budget_the_wider_widths_use():
+    """Adding a width must not take reach away from the widths that were already there.
+
+    The within-row scan is bounded by a window budget, and the budget is charged per window
+    per start position. Charging the new short width to the SAME budget cost one window more
+    at every start, so a large sheet ran out sooner and the pass reported LESS than before
+    the capability existed -- measured, as a four-wide finding that disappeared from a corpus
+    file. The short width has its own counter now.
+
+    Checked at a budget just above what the wider widths need to reach the second copy: with
+    the counters separate the repeat is found, and it is not found when the short width is
+    allowed to spend from the same pot. A first version of this test set the SHORT budget to
+    zero instead, which the very code path it was guarding does not read -- it passed either
+    way, and the data it used had four decimals, too coarse for a short window to be indexed
+    at all. It was measuring nothing, twice over.
+    """
+    import os
+    import subprocess
+    import sys
+
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    # Every cell finely recorded, so short windows really are indexed; the repeated segment
+    # sits late in the row, where the budget decides whether the scan still reaches it.
+    filler = [round(1.0 + i * 0.7 + i * i * 1e-5, 6) for i in range(60)]
+    segment = [7.104391, 3.882057, 9.240118, 2.665903]
+    row = list(filler)
+    row[30:34] = segment
+    row[40:44] = segment
+    code = (
+        "import json, sys;"
+        "sys.path.insert(0, 'src');"
+        "from paperconan._audit import detect_recurring_row_vectors;"
+        "from paperconan._sheet import Sheet;"
+        f"row = {row!r};"
+        "rows = [['h'] + ['c%d' % i for i in range(len(row))], ['b'] + row];"
+        "out = detect_recurring_row_vectors({('s.xlsx', 'Fig. 1'): Sheet.from_rows(rows)});"
+        "print(json.dumps(sorted(len(f['vector']) for f in out"
+        " if f['kind'] == 'within_row_repeated_segment')))"
+    )
+    out = subprocess.check_output(
+        [sys.executable, "-c", code],
+        env={**os.environ, "PAPERCONAN_WITHIN_ROW_VEC_BUDGET": "210"},
+        text=True,
+        cwd=root,
+    )
+
+    assert json.loads(out.strip()) == [4], out

--- a/tests/test_within_row_repeated_segment.py
+++ b/tests/test_within_row_repeated_segment.py
@@ -314,3 +314,84 @@ def test_the_short_pass_cannot_spend_the_budget_the_wider_widths_use():
     )
 
     assert json.loads(out.strip()) == [4], out
+
+
+def test_a_short_candidate_does_not_replace_the_wider_repeat_it_sits_inside():
+    """A shorter statement must be added beside a longer one, never put in its place.
+
+    The candidate pool is ranked by copy count first. A three-wide window inside a genuine
+    four-wide repeat can also match at a third place where the fourth column disagrees, so
+    it has MORE copies than the four-wide vector, sorted ahead of it, and the four-wide
+    finding was then dropped against it as an overlapping duplicate. What reached the
+    reader was three values at three places -- with the fourth column's agreement, the
+    stronger half of the evidence, nowhere in the output.
+    """
+    wide = [4.176382, 9.028415, 1.593047, 6.702914]
+    row = (_fill(10, 3) + wide + _fill(6, 5) + wide + _fill(6, 7)
+           + wide[:3] + _fill(6, 9))
+
+    findings = detect_recurring_row_vectors({
+        ("synthetic.xlsx", "Figure 1"): _row_sheet(row),
+    })
+
+    wr = [f for f in findings if f["kind"] == "within_row_repeated_segment"]
+    assert wr, f"expected the four-wide repeat, got {findings}"
+    assert wr[0]["vector"] == wide, wr[0]["vector"]
+
+
+def test_a_coarse_row_does_not_spend_the_short_budget_before_a_fine_repeat_in_it():
+    """The precision check at window generation, not the one after it.
+
+    Both gates reject a coarse short segment, so removing either alone leaves the coarse
+    control test green -- but only the generation-time one keeps a doomed window from being
+    INDEXED, and therefore from spending the short budget. Without it a row of coarse
+    filler burns that budget before the scan reaches a genuine fine repeat late in the same
+    row, and the finding disappears: the capability subtracting coverage again, one layer
+    below where that was first found.
+    """
+    import os
+    import subprocess
+    import sys
+
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    coarse = [round(3.0 + i * 0.37, 2) for i in range(60)]
+    segment = [7.104391, 3.882057, 9.240118]
+    row = coarse + segment + [8.15, 2.94] + segment
+    code = (
+        "import json, sys;"
+        "sys.path.insert(0, 'src');"
+        "from paperconan._audit import detect_recurring_row_vectors;"
+        "from paperconan._sheet import Sheet;"
+        f"row = {row!r};"
+        "rows = [['h'] + ['c%d' % i for i in range(len(row))], ['b'] + row];"
+        "out = detect_recurring_row_vectors({('s.xlsx', 'Fig. 1'): Sheet.from_rows(rows)});"
+        "print(json.dumps(sorted(len(f['vector']) for f in out"
+        " if f['kind'] == 'within_row_repeated_segment')))"
+    )
+    out = subprocess.check_output(
+        [sys.executable, "-c", code],
+        env={**os.environ, "PAPERCONAN_WR_SHORT_SEGMENT_BUDGET": "50"},
+        text=True,
+        cwd=root,
+    )
+
+    assert 3 in json.loads(out.strip()), out
+
+
+def test_a_row_too_narrow_for_two_wide_copies_still_reaches_the_short_pass():
+    """The row-level precondition has to use the shortest width the pass will consider.
+
+    It asked for room for two copies at the ORDINARY width, so a row with just enough cells
+    for two three-wide copies was dropped before any short window was built -- the floor
+    change reaching the window loop but not the row that would have used it.
+    """
+    segment = [2.481937, 5.914026, 8.336571]
+    row = segment + segment   # six numeric cells: too narrow for two four-wide copies
+
+    findings = detect_recurring_row_vectors({
+        ("synthetic.xlsx", "Figure 1"): _row_sheet(row),
+    })
+
+    wr = [f for f in findings if f["kind"] == "within_row_repeated_segment"]
+    assert len(wr) == 1, f"expected the narrow-row repeat, got {findings}"
+    assert wr[0]["vector"] == segment


### PR DESCRIPTION
`detect_recurring_row_vectors` requires a repeated within-row segment to be at
least four columns wide. That floor is ALREADY graded by what the values are
and not only by how many there are -- an all-integer tuple needs five columns
with four distinct values where anything else needs four -- but the grading
dimension was integer-ness alone, and at the short end that orders the
evidence backwards.

Three values recorded to several decimals, repeated exactly at two places in
one row, is far more agreement than four values recorded to two decimals,
which the same floor waves through. Scored per cell the way
`_ratio_prediction_bits` does -- log2(spread/step) -- the short fine run in the
review corpus that prompted this outweighs the coarse longer run the floor
accepts, and it was the fine one that was rejected. Precision is now a second
grading dimension: a segment may be one column shorter when every cell in it
was written finely enough that the match cannot be read as coarse-grid
coincidence.

Within-row only. The cross-figure pass in the same function keeps `min_k`; its
own docstring calls it the most false-positive-prone pass in the engine, and no
recorded gap asks for it.

The short widths carry their own budget. Charging them to the shared one cost
a window at every start position, so a large sheet ran out sooner and the pass
reported LESS than before the capability existed -- measured on the corpus as a
four-wide finding that disappeared from a file whose scan already reports
bounded within-row coverage. A capability that subtracts coverage elsewhere is
not a capability. With separate counters the wider widths deplete exactly as
they did.

Three tests, each confirmed red by reverting the line it guards: the three-wide
fine repeat is found; the same shape at two decimals is still not, which is
what makes this about precision rather than about shortening a floor; and the
four-wide repeat survives a budget that the short pass would otherwise have
spent.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

Measured: recovers the one recorded corpus case (a three-wide repeat of finely
recorded values across two labelled groups, at the columns the adjudication
record names). On a sixty-paper sample it adds nothing and removes nothing —
though that is a detector-layer statement, and per the bench rules the cost
that decides a change is what the reading layer shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)