### PR TITLE
docs: measure a detector change where the agent reads it, not where it fires

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,19 +66,26 @@ recipe for measuring it is given instead of the figure — see the last rule for
 - **Cost is what the AGENT sees, not what the detector emits.** The narrowing in this tool is
   deliberately in the reading, not the detecting: SKILL.md's "Reading A Scan In Layers" has the
   agent go `overview` -> `drill <n>` -> `drill --kind` -> `explain <id>`, and `overview` shows at
-  most `DEFAULT_MAX_LOCATIONS` panels. Between a detector's return value and that page sit
-  `_MAX_FINDINGS_PER_BLOCK` and `_MAX_TOTAL_FINDINGS`, which DROP findings and record how many;
-  the prefilter and the profile; clustering into panels; and `_interleave_by_family`, which gives
-  each family a slot near the top. Measured on one corpus paper, what a direct detector call
-  counts, what survives into `scan.json`, and how many locations `overview` lists were three
-  numbers an order of magnitude or more apart.
+  most `DEFAULT_MAX_LOCATIONS` panels. Between a detector's return value and that page sit the
+  prefilter and the profile, clustering into panels, `_interleave_by_family`, which gives each
+  family a slot near the top, and -- for the block-level findings only -- `_MAX_FINDINGS_PER_BLOCK`
+  and `_MAX_TOTAL_FINDINGS`, which DROP findings and record how many. `cross_sheet_findings` pass
+  through neither of those two; the sheet- and corpus-level detectors bound themselves with their
+  own `max_findings` arguments instead.
+  To see the size of the gap for yourself, take the densest paper you have, and count three
+  things: what a direct call to one detector returns, what survives into `scan.json`, and how
+  many locations `overview` lists. They are not the same number, and the reader meets the third.
   So measure: does the ranked location list change, does a known true signal stay in the shown
   set and at what rank, and how many steps reach it. Not the count a detector returned -- a probe
   calling one directly skips the stages that come after it, so its totals are not a cost any
   reader pays. How much it skips depends on which detector: the block-level ones return findings
   raw, while the sheet- and corpus-level ones call `apply_profile_to_findings` themselves before
   returning, so a probe over those has already had the profile applied and one over the others
-  has not. Check which you are calling rather than assuming a probe is uniformly upstream.
+  has not. Some fit neither description: the digit and decimal-tail passes take a column of
+  values rather than a block, and their families are listed in `_UNSEEDED_FAMILIES`, meaning the
+  seeding layer never routes them to a panel -- so no probe over them says anything about a page,
+  whatever it counts. Check what you are calling rather than assuming a probe is uniformly
+  upstream.
   Both halves of a trade have to be quoted at the same layer. `_interleave_by_family`'s docstring
   is the model: it says what a change did to a true signal's RANK against the default page.
   Two traps, both of which caught the first draft of this rule. **Severity demotion is not one of
@@ -92,9 +99,12 @@ recipe for measuring it is given instead of the figure — see the last rule for
   test asserts that more than one family is shown, which is a weaker guarantee than it sounds
   like. Both traps are the "mechanism attributed to the wrong component" failure the last rule
   warns about, reached by reasoning from a function's name instead of reading it.
-  Separately, compare per paper rather than on totals. One paper timed out under some settings
-  of a sweep and not others, which swung the sum by an order of magnitude for a reason that had
-  nothing to do with any setting, hiding a real and much smaller change underneath.
+  Separately, compare per paper, over the papers that completed under every setting, rather than
+  on totals. Corpus papers differ enormously in size, so a sum over them is mostly a statement
+  about the largest one: here a single paper timed out under some settings of a sweep and not
+  others, and its presence or absence in the total moved that total further than any setting did,
+  hiding a smaller real change underneath. To check whether your own sweep has this problem, sort
+  the per-paper counts and see how much of the sum the top one carries.
 - **A bench needs a true-positive stratum.** One made only of things that must not fire is passed
   perfectly by a detector that never fires. Include the relation the arm exists to catch, and
   freeze how much of it is currently found — including when that is "almost none", which is a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,30 +66,35 @@ recipe for measuring it is given instead of the figure — see the last rule for
 - **Cost is what the AGENT sees, not what the detector emits.** The narrowing in this tool is
   deliberately in the reading, not the detecting: SKILL.md's "Reading A Scan In Layers" has the
   agent go `overview` -> `drill <n>` -> `drill --kind` -> `explain <id>`, and `overview` shows at
-  most `DEFAULT_MAX_LOCATIONS` panels, interleaved by family so one dense family cannot take the
-  list. `_demote_dense_relations` already exists for exactly this: a flood of column relations in
-  one sheet is kept but dropped to low severity, because a correlated matrix is dense by
-  construction rather than by anything worth reporting. So a change that adds findings which
-  collapse into panels the agent already had, or into one new low-severity dense panel, has cost
-  the agent close to nothing, however large the raw delta reads.
-  Measure, therefore: does the ranked location list change, does a known true signal stay in the
-  shown set and at what rank, and how many steps reach it. Not the size of `scan.json`, and not
-  the count a detector returned. A probe that calls a detector directly bypasses the prefilter,
-  the profile, the per-block caps and the dense-sheet demotion, so its totals are not a cost the
-  reader would ever pay: a raw sweep here put one corpus paper tens of thousands of relations
-  above every other paper in its sample -- a number the READING layers exist to keep off the
-  page, though `scan.json` may well hold it, since the dense-sheet rule demotes rather than
-  drops. Worse, that one paper's presence or absence swamped the sweep's own totals: it timed
-  out under some settings and not others, so the sum swung by an order of magnitude for a
-  reason that had nothing to do with the setting, on top of a real and much smaller change
-  underneath. A per-paper comparison over papers that completed under every setting showed
-  the actual movement; the totals never would have.
-  Both halves of the trade have to be quoted at the same layer; a recall figure counted at the
-  detector against a cost figure counted at the detector is at least self-consistent, but
-  neither is the decision.
-  `_interleave_by_family` already argues this way in its own docstring, and is the model to
-  copy: it names what the change did to a true signal's RANK against the default page, not how
-  many findings existed.
+  most `DEFAULT_MAX_LOCATIONS` panels. Between a detector's return value and that page sit
+  `_MAX_FINDINGS_PER_BLOCK` and `_MAX_TOTAL_FINDINGS`, which DROP findings and record how many;
+  the prefilter and the profile; clustering into panels; and `_interleave_by_family`, which gives
+  each family a slot near the top. Measured on one corpus paper, what a direct detector call
+  counts, what survives into `scan.json`, and how many locations `overview` lists were three
+  numbers an order of magnitude or more apart.
+  So measure: does the ranked location list change, does a known true signal stay in the shown
+  set and at what rank, and how many steps reach it. Not the count a detector returned -- a probe
+  calling one directly skips the stages that come after it, so its totals are not a cost any
+  reader pays. How much it skips depends on which detector: the block-level ones return findings
+  raw, while the sheet- and corpus-level ones call `apply_profile_to_findings` themselves before
+  returning, so a probe over those has already had the profile applied and one over the others
+  has not. Check which you are calling rather than assuming a probe is uniformly upstream.
+  Both halves of a trade have to be quoted at the same layer. `_interleave_by_family`'s docstring
+  is the model: it says what a change did to a true signal's RANK against the default page.
+  Two traps, both of which caught the first draft of this rule. **Severity demotion is not one of
+  those stages.** `_demote_dense_relations` rewrites `severity` to low for a flooded sheet, but
+  `raw_severity` is frozen before it runs, and `_raw_severity_of` exists to say that the
+  rewritten field "must not drive routing" -- `overview`'s ordering, `strongest` and `high` all
+  read the raw one. A flood-demoted panel sits on the page looking like any other. The demotion
+  is real and it changes `report.html` and the packet; it does not change what the agent opens.
+  **And interleaving bounds domination rather than preventing it.** Given one saturated family
+  and two small ones it hands the saturated family most of a twenty-slot page; the repo's own
+  test asserts that more than one family is shown, which is a weaker guarantee than it sounds
+  like. Both traps are the "mechanism attributed to the wrong component" failure the last rule
+  warns about, reached by reasoning from a function's name instead of reading it.
+  Separately, compare per paper rather than on totals. One paper timed out under some settings
+  of a sweep and not others, which swung the sum by an order of magnitude for a reason that had
+  nothing to do with any setting, hiding a real and much smaller change underneath.
 - **A bench needs a true-positive stratum.** One made only of things that must not fire is passed
   perfectly by a detector that never fires. Include the relation the arm exists to catch, and
   freeze how much of it is currently found — including when that is "almost none", which is a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,9 +60,36 @@ for opt-in — a bench skipped by default is green while the detector moves, whi
 they were written to end. Each carries a `__main__` block that reprints its frozen tables
 paste-ready; regenerate that way rather than hand-editing a table.
 
-Four rules, each of which cost review rounds to learn. Where a claim below has a size, the
-recipe for measuring it is given instead of the figure — see the fourth rule for why:
+Five rules, each of which cost review rounds to learn. Where a claim below has a size, the
+recipe for measuring it is given instead of the figure — see the last rule for why:
 
+- **Cost is what the AGENT sees, not what the detector emits.** The narrowing in this tool is
+  deliberately in the reading, not the detecting: SKILL.md's "Reading A Scan In Layers" has the
+  agent go `overview` -> `drill <n>` -> `drill --kind` -> `explain <id>`, and `overview` shows at
+  most `DEFAULT_MAX_LOCATIONS` panels, interleaved by family so one dense family cannot take the
+  list. `_demote_dense_relations` already exists for exactly this: a flood of column relations in
+  one sheet is kept but dropped to low severity, because a correlated matrix is dense by
+  construction rather than by anything worth reporting. So a change that adds findings which
+  collapse into panels the agent already had, or into one new low-severity dense panel, has cost
+  the agent close to nothing, however large the raw delta reads.
+  Measure, therefore: does the ranked location list change, does a known true signal stay in the
+  shown set and at what rank, and how many steps reach it. Not the size of `scan.json`, and not
+  the count a detector returned. A probe that calls a detector directly bypasses the prefilter,
+  the profile, the per-block caps and the dense-sheet demotion, so its totals are not a cost the
+  reader would ever pay: a raw sweep here put one corpus paper tens of thousands of relations
+  above every other paper in its sample -- a number the READING layers exist to keep off the
+  page, though `scan.json` may well hold it, since the dense-sheet rule demotes rather than
+  drops. Worse, that one paper's presence or absence swamped the sweep's own totals: it timed
+  out under some settings and not others, so the sum swung by an order of magnitude for a
+  reason that had nothing to do with the setting, on top of a real and much smaller change
+  underneath. A per-paper comparison over papers that completed under every setting showed
+  the actual movement; the totals never would have.
+  Both halves of the trade have to be quoted at the same layer; a recall figure counted at the
+  detector against a cost figure counted at the detector is at least self-consistent, but
+  neither is the decision.
+  `_interleave_by_family` already argues this way in its own docstring, and is the model to
+  copy: it names what the change did to a true signal's RANK against the default page, not how
+  many findings existed.
 - **A bench needs a true-positive stratum.** One made only of things that must not fire is passed
   perfectly by a detector that never fires. Include the relation the arm exists to catch, and
   freeze how much of it is currently found — including when that is "almost none", which is a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,48 +63,27 @@ paste-ready; regenerate that way rather than hand-editing a table.
 Five rules, each of which cost review rounds to learn. Where a claim below has a size, the
 recipe for measuring it is given instead of the figure — see the last rule for why:
 
-- **Cost is what the AGENT sees, not what the detector emits.** The narrowing in this tool is
-  deliberately in the reading, not the detecting: SKILL.md's "Reading A Scan In Layers" has the
-  agent go `overview` -> `drill <n>` -> `drill --kind` -> `explain <id>`, and `overview` shows at
-  most `DEFAULT_MAX_LOCATIONS` panels. Between a detector's return value and that page sit the
-  prefilter and the profile, clustering into panels, `_interleave_by_family`, which gives each
-  family a slot near the top, and -- for the block-level findings only -- `_MAX_FINDINGS_PER_BLOCK`
-  and `_MAX_TOTAL_FINDINGS`, which DROP findings and record how many. `cross_sheet_findings` pass
-  through neither of those two; the sheet- and corpus-level detectors bound themselves with their
-  own `max_findings` arguments instead.
-  To see the size of the gap for yourself, take the densest paper you have, and count three
-  things: what a direct call to one detector returns, what survives into `scan.json`, and how
-  many locations `overview` lists. They are not the same number, and the reader meets the third.
-  So measure: does the ranked location list change, does a known true signal stay in the shown
-  set and at what rank, and how many steps reach it. Not the count a detector returned -- a probe
-  calling one directly skips the stages that come after it, so its totals are not a cost any
-  reader pays. How much it skips depends on which detector: the block-level ones return findings
-  raw, while the sheet- and corpus-level ones call `apply_profile_to_findings` themselves before
-  returning, so a probe over those has already had the profile applied and one over the others
-  has not. Some fit neither description: the digit and decimal-tail passes take a column of
-  values rather than a block, and their families are listed in `_UNSEEDED_FAMILIES`, meaning the
-  seeding layer never routes them to a panel -- so no probe over them says anything about a page,
-  whatever it counts. Check what you are calling rather than assuming a probe is uniformly
-  upstream.
-  Both halves of a trade have to be quoted at the same layer. `_interleave_by_family`'s docstring
-  is the model: it says what a change did to a true signal's RANK against the default page.
-  Two traps, both of which caught the first draft of this rule. **Severity demotion is not one of
-  those stages.** `_demote_dense_relations` rewrites `severity` to low for a flooded sheet, but
-  `raw_severity` is frozen before it runs, and `_raw_severity_of` exists to say that the
-  rewritten field "must not drive routing" -- `overview`'s ordering, `strongest` and `high` all
-  read the raw one. A flood-demoted panel sits on the page looking like any other. The demotion
-  is real and it changes `report.html` and the packet; it does not change what the agent opens.
-  **And interleaving bounds domination rather than preventing it.** Given one saturated family
-  and two small ones it hands the saturated family most of a twenty-slot page; the repo's own
-  test asserts that more than one family is shown, which is a weaker guarantee than it sounds
-  like. Both traps are the "mechanism attributed to the wrong component" failure the last rule
-  warns about, reached by reasoning from a function's name instead of reading it.
-  Separately, compare per paper, over the papers that completed under every setting, rather than
-  on totals. Corpus papers differ enormously in size, so a sum over them is mostly a statement
-  about the largest one: here a single paper timed out under some settings of a sweep and not
-  others, and its presence or absence in the total moved that total further than any setting did,
-  hiding a smaller real change underneath. To check whether your own sweep has this problem, sort
-  the per-paper counts and see how much of the sum the top one carries.
+- **Cost is what the AGENT sees, not what the detector emits.** The narrowing here is
+  deliberately in the reading: SKILL.md's "Reading A Scan In Layers" has the agent go
+  `overview` -> `drill <n>` -> `drill --kind` -> `explain <id>`, and `overview` shows at most
+  `DEFAULT_MAX_LOCATIONS` panels. So measure a change by what that page does: whether the ranked
+  location list moves, whether a known true signal is on it and at what rank, how many steps
+  reach it. Both halves of a trade have to be quoted at that same layer.
+  A count taken by calling a detector directly is not that. To see the size of the gap, take the
+  densest paper you have and count three things -- what one detector returns, what survives into
+  `scan.json`, what `overview` lists. Also compare per paper, over papers that completed under
+  every setting: corpus papers differ enormously in size, so a sum over them is largely a
+  statement about the biggest, and one paper timing out under some settings and not others can
+  move a total further than the settings do. Sort the per-paper counts and see how much of the
+  sum the top one carries.
+  Read the stage you want to credit before crediting it. Every draft of this rule so far has
+  credited a component that does not do the thing. Severity demotion does not gate the reading
+  layer: `raw_severity` is frozen before `_demote_dense_relations` runs, and `_raw_severity_of`
+  says in as many words that the rewritten field "must not drive routing". Family interleaving
+  bounds one family's share of the page rather than preventing it. And what a probe skips
+  depends on which detector it calls -- some apply the profile themselves before returning, and
+  some are never routed to a panel at all. Each was reached by reasoning from a name, and each
+  cost a review round.
 - **A bench needs a true-positive stratum.** One made only of things that must not fire is passed
   perfectly by a detector that never fires. Include the relation the arm exists to catch, and
   freeze how much of it is currently found — including when that is "almost none", which is a


### PR DESCRIPTION
The narrowing in this tool is deliberately in the reading. SKILL.md says so --
"Detectors deliberately run wide so real signals are not lost to a threshold,
so the narrowing happens here, in how you read" -- and the code backs it:
per-block caps, the prefilter, dense-sheet demotion that keeps a correlated
matrix's relations but drops them to low severity, and an overview bounded to
DEFAULT_MAX_LOCATIONS panels round-robined across families so one saturated
family cannot own the page.

A bench rule that scores a change on raw finding volume therefore contradicts
the product it is measuring, and this round it produced a wrong answer. A sweep
that called the detectors directly reported one corpus paper's relation count
far above every other paper in its sample. Running the real pipeline on the
same paper: the count that survives to scan.json is smaller by more than an
order of magnitude, almost all of it low severity, and what the agent actually
opens is a page of locations whose seventh and eighth entries each hold a
single signal, sitting beside a panel of a hundred and fifty. Nothing about
that paper was ever going to cost a reader what the sweep said it did.

So the fifth rule: quote both halves of a trade at the layer the reader meets.
Does the ranked location list change, does a known true signal stay on the
shown page and at what rank, how many steps reach it. `_interleave_by_family`
already argues exactly this way in its own docstring and is the model to copy.

Same round, same file: the sweep's totals also swung by an order of magnitude
between settings because one paper timed out under some of them, on top of a
real and much smaller change underneath. Compare per paper, over the papers
that completed under every setting.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

Prompted by a live case: a floor change measured at the detector looked like a
bad trade (several hundred extra findings for three recovered claims) and was
recommended against. Re-measured through `scan_dir` → `overview`, the same
change puts two of those three recorded misses on the first page where they had
been absent entirely, at a cost of one to three extra entries on a page of
twenty. The two layers gave opposite answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)