### PR TITLE
fix(detect): stop a wider finding swallowing an occurrence it does not cover

### DIFF
--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -3202,6 +3202,29 @@ def _wr_frac_digits(v):
     return len(text.split(".")[1]) if "." in text else 0
 
 
+def _wr_has_occurrence_outside(cand, kept_cells):
+    """Does this candidate repeat somewhere the kept finding does not reach?
+
+    The dedup exists to fold the many overlapping windows ONE physical repeat produces into
+    a single finding, and it measures overlap against the smaller cell set. A short segment
+    that is part of a wider repeat and ALSO occurs a third time elsewhere overlaps on its
+    other places by more than enough to be dropped whole -- taking with it a place that
+    duplicates nothing. That place then reaches no report and no coverage note, which is
+    worse than reporting it and being wrong: a reader can dismiss a finding they can see.
+
+    An occurrence with no cell in common with the kept finding is not the same repeat, so a
+    candidate holding one is not that finding's duplicate. Occurrences that merely overlap
+    partially do not count -- those are the shifted windows the fold is for.
+    """
+    fname, sname, _fk, row = cand[1], cand[2], cand[3], cand[4]
+    vec_len, starts, seq_cols = len(cand[0]), cand[5], cand[7]
+    for columns in seq_cols:
+        cells = {(fname, sname, row, col) for col in columns}
+        if not (cells & kept_cells):
+            return True
+    return False
+
+
 def _wr_segment_is_long_enough(vec):
     """Is this repeated segment wide enough, given how finely its cells were recorded?"""
     if len(vec) >= _WR_SEGMENT_MIN_COLS:
@@ -3428,6 +3451,7 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
     wr_kept = []
     for c in wr_cands:
         if any(c[1:5] == kc[1:5] and len(c[6] & kc[6]) >= 0.5 * min(len(c[6]), len(kc[6]))
+               and not _wr_has_occurrence_outside(c, kc[6])
                for kc in wr_kept):
             continue
         wr_kept.append(c)

--- a/tests/test_within_row_repeated_segment.py
+++ b/tests/test_within_row_repeated_segment.py
@@ -395,3 +395,34 @@ def test_a_row_too_narrow_for_two_wide_copies_still_reaches_the_short_pass():
     wr = [f for f in findings if f["kind"] == "within_row_repeated_segment"]
     assert len(wr) == 1, f"expected the narrow-row repeat, got {findings}"
     assert wr[0]["vector"] == segment
+
+
+def test_a_wider_finding_does_not_swallow_an_occurrence_it_does_not_cover():
+    """Collapsing one physical repeat is right; dropping a second one is not.
+
+    The dedup folds the many overlapping windows a single long repeat produces into one
+    finding, and measures overlap against the SMALLER cell set. A short segment that is
+    part of a wider repeat AND occurs a third time somewhere the wider one does not reach
+    overlaps the wider finding on two of its three places -- enough to be dropped whole. The
+    third place goes with it, and it is not a duplicate of anything: it is a place the
+    reader is never told about, and no coverage note says so. A false positive an agent can
+    discard costs it a moment; evidence that never arrives cannot be judged at all.
+    """
+    s0, s1, s2 = 4.176382, 9.028415, 1.593047
+    wide = [6.702914, s0, s1, s2]
+    head = _fill(10, 3) + wide + _fill(20, 5)
+    row = head + [s0, s1, s2] + _fill(18, 7) + wide + _fill(6, 9)
+    # Derived, not written down: `_row_sheet` puts a label in column 0 and the finding
+    # reports 1-based columns, so a hand-counted literal here is two off-by-ones deep and
+    # would be wrong in a way that reads as a detector defect.
+    lone = {len(head) + 1 + offset + 1 for offset in range(3)}
+
+    findings = [f for f in detect_recurring_row_vectors({
+        ("synthetic.xlsx", "Figure 1"): _row_sheet(row),
+    }) if f["kind"] == "within_row_repeated_segment"]
+
+    covered = [set(o["columns"]) for f in findings for o in f["occurrences"]]
+    assert any(lone <= c for c in covered), (
+        f"the independent occurrence at columns {sorted(lone)} is in no finding; "
+        f"reported: {[(len(f['vector']), [o['range'] for o in f['occurrences']]) for f in findings]}"
+    )


### PR DESCRIPTION
fix(detect): stop a wider finding swallowing an occurrence it does not cover

The dedup folds the many overlapping windows one physical repeat produces into
a single finding, measuring overlap against the SMALLER cell set. A short
segment that is part of a wider repeat AND occurs again somewhere the wider one
does not reach overlaps on its other places by more than enough to be dropped
whole -- and the place that duplicates nothing goes with it, reaching no report
and no coverage note.

That is worse than a false positive. A finding a reader can see is a finding
they can dismiss in a moment; evidence that never arrives cannot be judged at
all, and nothing on the page says it was left out.

An occurrence sharing no cell with the kept finding is not the same repeat, so
a candidate holding one is not that finding's duplicate. Partial overlap still
folds -- those are the shifted windows the fold exists for.

Found by review of the precision-graded floor, as a pre-existing asymmetry that
the short-segment pass had newly made reachable.

Measured over fourteen corpus papers through `scan_dir` and `overview`: no
change to any first page, and no change to the number of within-row repeated
segments reported. That is a cost of nothing on this sample rather than
evidence the case occurs in it -- the shape needs a coincidence none of those
papers holds, and the constructed test is what shows the behaviour.

The test derives its expected columns from the fixture instead of naming them.
Written by hand they were wrong twice over -- the row helper puts a label in
column 0 and findings report 1-based columns -- and a test red for that reason
reads exactly like a detector defect.

---

**Measured, and the measurement is not a payoff.** Across the corpus -- 114
papers holding tabular source, compared against `main` from two fixed worktrees
so a branch switch could not move either side mid-run -- **no paper's output
changes at all**. An earlier comparison appeared to find one; that was my own
error, comparing trees that differed by a different PR, caught by re-running the
same code twice and getting two answers.

So the shape this fixes is constructible but not observed here. The argument for
merging it is not recall, it is the asymmetry: a false positive reaches the page
where a reader can dismiss it in a moment, while this dropped a genuine
occurrence with no coverage note at all — nothing on the page says anything was
left out, so there is nothing to judge. The bounded cost (nothing, on 114
papers) is what makes that argument cheap to accept, not what makes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)