### PR TITLE
fix(detect): record when the within-row fold drops a repeat it does not cover

### DIFF
--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -124,6 +124,12 @@ Three things to hold onto while reading:
     a detector stopped emitting at its cap.
   - `scan: detector compute budget limit in detect_row_relations` — a detector ran
     out of its work budget.
+  - `scan: detector within row folded independent repeat in detect_recurring_row_vectors (count=2)`
+    — not a truncation but an omission:
+    the within-row pass folds the overlapping windows one physical repeat
+    produces into a single finding, and this many of the folded candidates also
+    repeated somewhere the surviving finding does not cover. That place is on no
+    page. The count is all the record holds; finding it means reading the row.
 
   Any of these means `scan_status` is not `complete` (`partial`, or `failed` when
   nothing could be read at all) and the search was cut short, so a

--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -135,10 +135,14 @@ Three things to hold onto while reading:
   nothing could be read at all), so a quiet result on that input is not evidence
   of a clean one. The rest of this paragraph is about the lines that were CUT
   SHORT, which is every one above except `detector within row folded independent
-  repeat`. That one is not a truncation: nothing was left unexamined, so no cap
-  governs it and no narrower input recovers anything, and its remedy is the one
-  its own bullet gives — reading the row. (Named rather than positioned, so that
-  appending a bullet cannot make this sentence quietly wrong about two of them.)
+  repeat`. (Named rather than positioned, so that appending a bullet cannot make
+  this sentence quietly wrong about two of them.) That one reports an omission
+  rather than a truncation: nothing was left unexamined, and reading the row is
+  its remedy. But it is not independent of the caps either — it compares against
+  the findings that were EMITTED, so when `detector finding limit` appears on the
+  same detector in the same scan, a narrower input can emit more and change
+  whether this line appears at all. Seen on a real supplement. Read the two
+  together when both are present.
   Detector lines name
   **no file or sheet**: the record does not carry one, so the line cannot tell you
   *where* the truncation bit — it may have been one block or many. Re-running

--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -133,10 +133,13 @@ Three things to hold onto while reading:
 
   Any of these means `scan_status` is not `complete` (`partial`, or `failed` when
   nothing could be read at all), so a quiet result on that input is not evidence
-  of a clean one. All but the last were cut short — the rest of this paragraph is
-  about those. The folded-repeat line is not a truncation: nothing was left
-  unexamined, so no cap governs it and no narrower input recovers anything. Its
-  remedy is the one its own bullet gives, reading the row. Detector lines name
+  of a clean one. The rest of this paragraph is about the lines that were CUT
+  SHORT, which is every one above except `detector within row folded independent
+  repeat`. That one is not a truncation: nothing was left unexamined, so no cap
+  governs it and no narrower input recovers anything, and its remedy is the one
+  its own bullet gives — reading the row. (Named rather than positioned, so that
+  appending a bullet cannot make this sentence quietly wrong about two of them.)
+  Detector lines name
   **no file or sheet**: the record does not carry one, so the line cannot tell you
   *where* the truncation bit — it may have been one block or many. Re-running
   unchanged proves nothing: the scan is deterministic, so it reproduces the same

--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -128,12 +128,15 @@ Three things to hold onto while reading:
     — not a truncation but an omission:
     the within-row pass folds the overlapping windows one physical repeat
     produces into a single finding, and this many of the folded candidates also
-    repeated somewhere the surviving finding does not cover. That place is on no
-    page. The count is all the record holds; finding it means reading the row.
+    repeated at a place no finding on this page covers at all. The count is all
+    the record holds; finding the place means reading the row.
 
   Any of these means `scan_status` is not `complete` (`partial`, or `failed` when
-  nothing could be read at all) and the search was cut short, so a
-  quiet result on that input is not evidence of a clean one. Detector lines name
+  nothing could be read at all), so a quiet result on that input is not evidence
+  of a clean one. All but the last were cut short — the rest of this paragraph is
+  about those. The folded-repeat line is not a truncation: nothing was left
+  unexamined, so no cap governs it and no narrower input recovers anything. Its
+  remedy is the one its own bullet gives, reading the row. Detector lines name
   **no file or sheet**: the record does not carry one, so the line cannot tell you
   *where* the truncation bit — it may have been one block or many. Re-running
   unchanged proves nothing: the scan is deterministic, so it reproduces the same

--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -3426,7 +3426,7 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
     # above the ordinary width, so their order among themselves is untouched.
     wr_cands.sort(key=lambda x: (len(x[0]) < _WR_SEGMENT_MIN_COLS, -len(x[5]), -len(x[0])))
     wr_kept = []
-    folded_independent = 0
+    wr_folded = []
     for c in wr_cands:
         absorbed = next((kc for kc in wr_kept
                          if c[1:5] == kc[1:5]
@@ -3445,11 +3445,20 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
             # not be one. What is fixed here is the silence: the drop is recorded, so a
             # reader is told the pass held something back rather than being shown a page
             # that looks complete.
-            if any(not ({(c[1], c[2], c[4], col) for col in cols} & absorbed[6])
-                   for cols in c[7]):
-                folded_independent += 1
+            wr_folded.append(c)
             continue
         wr_kept.append(c)
+    # Against everything KEPT, and only once the keeping is finished. Testing against the
+    # one candidate that absorbed it answers a narrower question than the note asks: an
+    # occurrence can miss its absorber entirely and still sit inside a different finding
+    # that reached the page, and review measured that mistake on a third of the flagged
+    # occurrences in adversarial rows. "Somewhere the report does not cover" is a claim
+    # about the report, so it has to be asked of the whole of it.
+    kept_cells = set().union(*(kc[6] for kc in wr_kept)) if wr_kept else set()
+    folded_independent = sum(
+        1 for c in wr_folded
+        if any(not ({(c[1], c[2], c[4], col) for col in cols} & kept_cells)
+               for cols in c[7]))
     if folded_independent:
         _note_detector_cap(coverage, "detect_recurring_row_vectors",
                            "detector_within_row_folded_independent_repeat",

--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -3426,11 +3426,34 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
     # above the ordinary width, so their order among themselves is untouched.
     wr_cands.sort(key=lambda x: (len(x[0]) < _WR_SEGMENT_MIN_COLS, -len(x[5]), -len(x[0])))
     wr_kept = []
+    folded_independent = 0
     for c in wr_cands:
-        if any(c[1:5] == kc[1:5] and len(c[6] & kc[6]) >= 0.5 * min(len(c[6]), len(kc[6]))
-               for kc in wr_kept):
+        absorbed = next((kc for kc in wr_kept
+                         if c[1:5] == kc[1:5]
+                         and len(c[6] & kc[6]) >= 0.5 * min(len(c[6]), len(kc[6]))), None)
+        if absorbed is not None:
+            # The fold is right for the shifted windows one physical repeat produces, and
+            # those are what it almost always sees. It is NOT right when the folded
+            # candidate also repeats somewhere the kept finding never reaches: that place
+            # corroborates nothing already on the page, and it leaves with the candidate.
+            #
+            # Selection is deliberately unchanged. Rescuing such a candidate whole was
+            # tried and withdrawn: it enters `wr_kept` carrying its overlapping
+            # occurrences too, becomes a suppressor for later candidates, and drops
+            # findings the fold used to keep -- silently, and without moving the finding
+            # count, so a count-based check cannot see it. A cure for a silent loss must
+            # not be one. What is fixed here is the silence: the drop is recorded, so a
+            # reader is told the pass held something back rather than being shown a page
+            # that looks complete.
+            if any(not ({(c[1], c[2], c[4], col) for col in cols} & absorbed[6])
+                   for cols in c[7]):
+                folded_independent += 1
             continue
         wr_kept.append(c)
+    if folded_independent:
+        _note_detector_cap(coverage, "detect_recurring_row_vectors",
+                           "detector_within_row_folded_independent_repeat",
+                           count=folded_independent)
     for vec, fn, sn, fk, r, chosen, _cells, source_columns in wr_kept:
         occurrences = []
         for zero_based_columns in source_columns:

--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -3292,6 +3292,11 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
 
     findings = []
     _capped = False   # set only where a loop is actually abandoned
+    # Cells of every finding this call emits, from BOTH passes. The within-row note below
+    # asks what the reader can see, and the two kinds share this list, this `max_findings`
+    # and one page -- scoping it to the within-row pass alone called a place uncovered
+    # while its cross-figure sibling was reporting it.
+    reported_cells = set()
     for vec, places, namespaces, sites, _cells in kept:
         sheets_hit = sorted({p[1] for p in places})
         loc = "; ".join(sheets_hit[:6])
@@ -3315,6 +3320,7 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
             severity="high" if (len(vec) >= 5 and len(sites) >= 3) else "medium",
             rule=(f"the {len(vec)}-value vector {list(vec)} recurs at {len(sites)} places across "
                   f"{len(namespaces)} figures ({loc})")))
+        reported_cells |= _cells
         if len(findings) >= max_findings:
             _capped = True
             break
@@ -3448,13 +3454,6 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
             wr_folded.append(c)
             continue
         wr_kept.append(c)
-    # Against everything KEPT, and only once the keeping is finished. Testing against the
-    # one candidate that absorbed it answers a narrower question than the note asks: an
-    # occurrence can miss its absorber entirely and still sit inside a different finding
-    # that reached the page, and review measured that mistake on a third of the flagged
-    # occurrences in adversarial rows. "Somewhere the report does not cover" is a claim
-    # about the report, so it has to be asked of the whole of it.
-    reported_cells = set()
     for vec, fn, sn, fk, r, chosen, _cells, source_columns in wr_kept:
         occurrences = []
         for zero_based_columns in source_columns:

--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -3454,15 +3454,7 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
     # that reached the page, and review measured that mistake on a third of the flagged
     # occurrences in adversarial rows. "Somewhere the report does not cover" is a claim
     # about the report, so it has to be asked of the whole of it.
-    kept_cells = set().union(*(kc[6] for kc in wr_kept)) if wr_kept else set()
-    folded_independent = sum(
-        1 for c in wr_folded
-        if any(not ({(c[1], c[2], c[4], col) for col in cols} & kept_cells)
-               for cols in c[7]))
-    if folded_independent:
-        _note_detector_cap(coverage, "detect_recurring_row_vectors",
-                           "detector_within_row_folded_independent_repeat",
-                           count=folded_independent)
+    reported_cells = set()
     for vec, fn, sn, fk, r, chosen, _cells, source_columns in wr_kept:
         occurrences = []
         for zero_based_columns in source_columns:
@@ -3498,9 +3490,25 @@ def detect_recurring_row_vectors(grid_sheets, profile="review",
             rule=(f"the {len(vec)}-value segment {[round(float(v), 6) for v in vec]} repeats at "
                   f"{len(chosen)} non-overlapping positions within row {r + 1} of {sn} "
                   f"({coordinate_text})")))
+        reported_cells |= _cells
         if len(findings) >= max_findings:
             _capped = True
             break
+
+    # Asked of what REACHED the reader, and so only once that is settled. Asking it of
+    # everything the fold selected is a wider set: the loop above stops at `max_findings`,
+    # so a selected candidate can contribute cells to the answer and never appear on any
+    # page. The note then stays silent about a place nothing covers -- a false all-clear,
+    # which is the direction `_note_detector_cap` exists to avoid, and review found real
+    # papers hitting that cap on this detector.
+    folded_independent = sum(
+        1 for c in wr_folded
+        if any(not ({(c[1], c[2], c[4], col) for col in cols} & reported_cells)
+               for cols in c[7]))
+    if folded_independent:
+        _note_detector_cap(coverage, "detect_recurring_row_vectors",
+                           "detector_within_row_folded_independent_repeat",
+                           count=folded_independent)
 
     if _capped:
         _note_detector_cap(coverage, "detect_recurring_row_vectors", "detector_finding_limit",

--- a/tests/test_detector_cap_coverage.py
+++ b/tests/test_detector_cap_coverage.py
@@ -877,6 +877,11 @@ def test_every_scan_line_quoted_in_the_skill_is_one_the_code_can_emit():
                             limit=audit._ROW_PAIR_MAX_FINDINGS_PER_BLOCK)
     coverage.add_limitation("detector", "detector_compute_budget_limit",
                             detector="detect_row_relations")
+    # Not a truncation: the within-row fold dropped candidates that also repeated
+    # outside the finding that absorbed them. Quoted in the skill because it says
+    # something an agent can act on -- read the row -- rather than "there may be more".
+    coverage.add_limitation("detector", "detector_within_row_folded_independent_repeat",
+                            detector="detect_recurring_row_vectors", count=2)
     scan = {"scan_status": "partial", "coverage": coverage.to_dict()}
     emitted = {line for line in _coverage_for(scan, [], [], [], 100)["limitations"]
                if line.startswith("scan:")}

--- a/tests/test_within_row_repeated_segment.py
+++ b/tests/test_within_row_repeated_segment.py
@@ -442,3 +442,31 @@ def test_a_plain_fold_records_nothing():
 
     reasons = [item.get("reason") for item in coverage.to_dict()["limitations"]]
     assert "detector_within_row_folded_independent_repeat" not in reasons, reasons
+
+
+def test_no_note_when_the_folded_repeat_is_covered_by_a_different_finding():
+    """"Somewhere the report does not cover" is a claim about the whole report.
+
+    A row can hold two kept findings that share a tail. The short tail candidate is
+    absorbed by whichever the fold reaches first, and its other occurrences sit inside the
+    OTHER one -- which is on the page. Asking only the absorber says those places are
+    covered nowhere, which is false, and it is the note's entire content. Measured on
+    adversarial rows, that phrasing of the question was wrong for a third of what it
+    flagged.
+    """
+    from paperconan._coverage import ScanCoverage
+
+    t0, t1, t2 = 4.176382, 9.028415, 1.593047
+    k1 = [6.702914, t0, t1, t2]
+    k2 = [3.314159, t0, t1, t2]
+    row = (_fill(8, 3) + k1 + _fill(6, 5) + k1 + _fill(6, 7)
+           + k2 + _fill(6, 9) + k2 + _fill(6, 11))
+    coverage = ScanCoverage(files_discovered=1)
+
+    findings = [f for f in detect_recurring_row_vectors(
+        {("synthetic.xlsx", "Figure 1"): _row_sheet(row)}, coverage=coverage,
+    ) if f["kind"] == "within_row_repeated_segment"]
+
+    assert [len(f["vector"]) for f in findings] == [4, 4], findings
+    reasons = [item.get("reason") for item in coverage.to_dict()["limitations"]]
+    assert "detector_within_row_folded_independent_repeat" not in reasons, reasons

--- a/tests/test_within_row_repeated_segment.py
+++ b/tests/test_within_row_repeated_segment.py
@@ -503,3 +503,43 @@ def test_the_note_still_fires_when_the_finding_cap_truncates_the_page():
     reasons = [item.get("reason") for item in coverage.to_dict()["limitations"]]
     assert "detector_finding_limit" in reasons, reasons
     assert "detector_within_row_folded_independent_repeat" in reasons, reasons
+
+
+def test_a_sibling_pass_on_the_same_page_counts_as_coverage():
+    """Both passes of this detector reach one page, so the note has to look at both.
+
+    `detect_recurring_row_vectors` emits two kinds into one list under one `max_findings`:
+    the cross-figure vector and its within-row sibling. Asking only what the within-row
+    pass reported called a place uncovered while the cross-figure finding was reporting it
+    -- the same "which set is the page" error as the two rounds before it, one set further
+    out. Here the folded three-tuple's independent occurrence lies inside the five-value
+    vector the cross-figure pass reports, so nothing is uncovered and nothing is noted.
+    """
+    from paperconan._coverage import ScanCoverage
+    from paperconan._sheet import Sheet
+
+    tail = [4.176382, 9.028415, 1.593047]
+    vector = tail + [7.334215, 2.481937]      # what the cross-figure pass reports
+    wide = [6.702914] + tail                  # the within-row repeat that absorbs the tail
+
+    def sheet(name, seed, carries_the_row=False):
+        body = (_fill(6, seed) + wide + _fill(8, seed + 1) + vector
+                + _fill(8, seed + 2) + wide + _fill(6, seed + 3)
+                if carries_the_row else
+                _fill(6, seed) + vector + _fill(6, seed + 1))
+        rows = [[name] + [f"c{i}" for i in range(len(body))], ["b"] + body]
+        rows.extend([f"x{k}"] + _fill(len(body), seed + 9 + k) for k in range(3))
+        return Sheet.from_rows(rows)
+
+    grid = {("f.xlsx", "Figure 1"): sheet("Figure 1", 10, carries_the_row=True),
+            ("f.xlsx", "Figure 2"): sheet("Figure 2", 20),
+            ("f.xlsx", "Figure 3"): sheet("Figure 3", 30)}
+    coverage = ScanCoverage(files_discovered=1)
+
+    findings = detect_recurring_row_vectors(grid, coverage=coverage)
+
+    kinds = {f["kind"] for f in findings}
+    assert "recurring_row_vector" in kinds, kinds
+    assert "within_row_repeated_segment" in kinds, kinds
+    reasons = [item.get("reason") for item in coverage.to_dict()["limitations"]]
+    assert "detector_within_row_folded_independent_repeat" not in reasons, reasons

--- a/tests/test_within_row_repeated_segment.py
+++ b/tests/test_within_row_repeated_segment.py
@@ -395,3 +395,50 @@ def test_a_row_too_narrow_for_two_wide_copies_still_reaches_the_short_pass():
     wr = [f for f in findings if f["kind"] == "within_row_repeated_segment"]
     assert len(wr) == 1, f"expected the narrow-row repeat, got {findings}"
     assert wr[0]["vector"] == segment
+
+
+def test_folding_a_repeat_that_occurs_elsewhere_is_recorded():
+    """Selection is unchanged; the silence is what this fixes.
+
+    The fold collapses the overlapping windows one physical repeat produces, which is
+    right. It is not right when the folded candidate also repeats where the surviving
+    finding never reaches: that place corroborates nothing on the page and leaves with the
+    candidate. Rescuing the candidate whole was tried and withdrawn -- it then suppressed
+    later candidates and dropped findings the fold used to keep, without moving the finding
+    count, so the cure had the disease. What is recorded instead is that the pass held
+    something back, which is the difference between a page that is incomplete and a page
+    that looks complete.
+    """
+    from paperconan._coverage import ScanCoverage
+
+    s0, s1, s2 = 4.176382, 9.028415, 1.593047
+    wide = [6.702914, s0, s1, s2]
+    row = (_fill(10, 3) + wide + _fill(20, 5) + [s0, s1, s2]
+           + _fill(18, 7) + wide + _fill(6, 9))
+    coverage = ScanCoverage(files_discovered=1)
+
+    findings = [f for f in detect_recurring_row_vectors(
+        {("synthetic.xlsx", "Figure 1"): _row_sheet(row)}, coverage=coverage,
+    ) if f["kind"] == "within_row_repeated_segment"]
+
+    # Unchanged: one finding, the wider repeat, exactly as before this note existed.
+    assert [len(f["vector"]) for f in findings] == [4]
+    reasons = [item.get("reason") for item in coverage.to_dict()["limitations"]]
+    assert "detector_within_row_folded_independent_repeat" in reasons, reasons
+
+
+def test_a_plain_fold_records_nothing():
+    """The control. A long repeat yields many shifted windows over the SAME places, and
+    folding those is the pass working -- if that were recorded too, the note would appear
+    on ordinary input and mean nothing."""
+    from paperconan._coverage import ScanCoverage
+
+    segment = [7.104391, 3.882057, 9.240118, 2.665903, 5.417620]
+    row = _fill(8, 3) + segment + _fill(6, 5) + segment + _fill(8, 7)
+    coverage = ScanCoverage(files_discovered=1)
+
+    detect_recurring_row_vectors(
+        {("synthetic.xlsx", "Figure 1"): _row_sheet(row)}, coverage=coverage)
+
+    reasons = [item.get("reason") for item in coverage.to_dict()["limitations"]]
+    assert "detector_within_row_folded_independent_repeat" not in reasons, reasons

--- a/tests/test_within_row_repeated_segment.py
+++ b/tests/test_within_row_repeated_segment.py
@@ -470,3 +470,36 @@ def test_no_note_when_the_folded_repeat_is_covered_by_a_different_finding():
     assert [len(f["vector"]) for f in findings] == [4, 4], findings
     reasons = [item.get("reason") for item in coverage.to_dict()["limitations"]]
     assert "detector_within_row_folded_independent_repeat" not in reasons, reasons
+
+
+def test_the_note_still_fires_when_the_finding_cap_truncates_the_page():
+    """The question is about the page, and the page can be shorter than the selection.
+
+    The emission loop stops at `max_findings`. A candidate the fold selected but the cap
+    never emitted has cells, and counting those as coverage let the note stay silent about
+    a place nothing on the page covers -- a false all-clear, which is the direction
+    `_note_detector_cap` exists to avoid. Review found real papers hitting that cap on this
+    detector, so the precondition is not hypothetical.
+    """
+    from paperconan._coverage import ScanCoverage
+
+    t0, t1, t2 = 4.176382, 9.028415, 1.593047
+    other = [8.111213, 3.222324, 6.755435, 1.994546]
+    k2 = [2.717654, t0, t1, t2]
+    k3 = [5.313131, t0, t1, t2]
+    # `other` has the most copies, so it takes the single reported slot; k2 and k3 are
+    # selected and never emitted, and the shared tail is folded against one of them.
+    row = (_fill(6, 3) + other + _fill(5, 5) + other + _fill(5, 7) + other
+           + _fill(5, 9) + k2 + _fill(5, 11) + k2
+           + _fill(5, 13) + k3 + _fill(5, 15) + k3 + _fill(6, 17))
+    coverage = ScanCoverage(files_discovered=1)
+
+    findings = [f for f in detect_recurring_row_vectors(
+        {("synthetic.xlsx", "Figure 1"): _row_sheet(row)},
+        max_findings=1, coverage=coverage,
+    ) if f["kind"] == "within_row_repeated_segment"]
+
+    assert [f["vector"] for f in findings] == [other], findings
+    reasons = [item.get("reason") for item in coverage.to_dict()["limitations"]]
+    assert "detector_finding_limit" in reasons, reasons
+    assert "detector_within_row_folded_independent_repeat" in reasons, reasons


### PR DESCRIPTION
fix(detect): record when the within-row fold drops a repeat it does not cover

The fold collapses the many overlapping windows one physical repeat produces
into a single finding, which is right and is almost always what it sees. It is
not right when the folded candidate ALSO repeats somewhere the surviving
finding never reaches: that place corroborates nothing on the page, and it
leaves with the candidate -- with nothing anywhere saying so.

Changing what the fold KEEPS was tried first and withdrawn. Rescuing such a
candidate whole puts it in the kept list carrying its overlapping occurrences
too, where it becomes a suppressor for later candidates and drops findings the
fold used to keep. Review constructed a row where that loses two cells that
main reports, under a tuple that itself recurs twice, and the finding count
does not move -- so a check on counts cannot see it. A cure for a silent loss
must not be one, and that version also reported the same cells under two
findings, which is what the fold exists to prevent.

So selection is untouched, byte for byte. What changes is that the drop is
recorded: `scan_status` goes to partial and the reason reaches every consumer
that renders coverage, including the layered views an agent reads. The count is
all the record carries; finding the place means reading the row. That is a
smaller claim than the first attempt made and it is one the code can keep.

The reason is quoted in SKILL.md rather than filed with the budget limits,
because it says something different: not "the search stopped early" but "the
search found this and did not show it". The skill's example is rendered through
the real formatter by the guard that checks it, so it cannot drift into a shape
production does not emit.

Two tests, each red without the line it guards: the note appears when a folded
candidate repeats outside its absorber, and does NOT appear for an ordinary
fold of shifted windows over the same places -- without that control the note

Replaces #68, whose approach changed what the fold keeps and was withdrawn for
the reason described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)