### PR TITLE
fix(detect): drop a noise floor that outlier rows could turn around

### DIFF
--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -725,12 +725,33 @@ def _attach_evidence(findings, sheet, r0, r1, c0, c1, header):
 
 # ---------- detectors ----------
 
-def _isclose_rowwise(actual, expected, rtol=1e-9):
+def _isclose_rowwise(actual, expected, rtol=1e-9, *, noise_floor=None):
     """Return row-wise closeness at each row's own numeric scale.
 
     A single coordinate/metadata row can be orders of magnitude larger than
     the measurement rows. A block-wide absolute tolerance lets those small
     measurement rows drift substantially while still passing a relation check.
+
+    That is what this function is for, and it used to carry a second, block-wide
+    term anyway -- `eps * median(row_scale) * 64`, a float noise floor for the
+    whole comparison. It defeated the paragraph above whenever a MAJORITY of rows
+    were the large ones, because the median moved with them: the floor grew to
+    their scale and swallowed real differences on the small rows. Measured, it
+    reported two columns equal that differ by five per cent.
+
+    Removing it moved one test in the suite. That was not evidence nothing needed
+    it: review found a case the suite had a test for but did not stress -- a
+    least-squares fit whose intercept is estimated from block-wide sums. Where a
+    majority of rows are large, the fit's error is a fixed absolute quantity from
+    those rows, and it lands undiminished on the small ones, whose own scale
+    cannot cover it. A genuine `y = 3x + 11` over such a block was reported by the
+    old code and missed by the new, in most draws at wide magnitude spreads.
+
+    So the floor is not gone, it is `noise_floor`, passed only by the branch that
+    computes such an expectation and derived from the magnitude that drives its
+    error. Comparing two STORED columns takes none: there is no arithmetic to have
+    gone wrong, and carrying one there is what let a majority of outlier rows
+    license a real five per cent difference on the rest.
     """
     actual = np.asarray(actual, dtype=float)
     expected = np.asarray(expected, dtype=float)
@@ -739,13 +760,15 @@ def _isclose_rowwise(actual, expected, rtol=1e-9):
         np.abs(expected),
         np.full_like(actual, 1e-300, dtype=float),
     ])
-    typical_scale = max(float(np.median(row_scale)), 1e-300)
-    tol = rtol * row_scale + (np.finfo(float).eps * typical_scale * 64)
+    tol = rtol * row_scale
+    if noise_floor is not None:
+        tol = tol + (np.finfo(float).eps * max(float(noise_floor), 1e-300) * 64)
     return np.abs(actual - expected) <= tol
 
 
-def _allclose_rowwise(actual, expected, rtol=1e-9):
-    return bool(np.all(_isclose_rowwise(actual, expected, rtol=rtol)))
+def _allclose_rowwise(actual, expected, rtol=1e-9, *, noise_floor=None):
+    return bool(np.all(_isclose_rowwise(actual, expected, rtol=rtol,
+                                        noise_floor=noise_floor)))
 
 
 _GRIM_MEAN_RE = re.compile(r"\b(mean|average|avg)\b|均值|平均", re.I)
@@ -812,7 +835,18 @@ def detect_relations(sheet, r0, r1, c0, c1, header):
             # constant offset
             diff = y - x
             mean_diff = float(np.mean(diff))
-            if abs(mean_diff) > tol and _allclose_rowwise(y, x + mean_diff):
+            # Also a computed expectation, and the same margin applies. `mean_diff` is a
+            # mean over subtractions, so on a block spanning magnitudes the large rows'
+            # cancellation sets its error, and `x + mean_diff` carries that error onto rows
+            # whose own scale cannot cover it. Review found a genuine `y = x + k` that this
+            # branch missed for want of it -- the pair was then picked up by `exact_linear`
+            # as a slope of one, WITH a spurious `small_diff_set` beside it, because the
+            # same float jitter reads as three discrete differences where there is one.
+            # Same statistic as the fit's, for the same reason: a tenth of the rows to
+            # move it, rather than one or a majority.
+            offset_scale = float(np.percentile(np.abs(np.concatenate([x, y])), 90))
+            if abs(mean_diff) > tol and _allclose_rowwise(y, x + mean_diff,
+                                                          noise_floor=offset_scale):
                 findings.append(dict(kind="constant_offset", col_a=header[ci - c0], col_b=header[cj - c0],
                                      col_a_idx=ci, col_b_idx=cj, n=n, offset=mean_diff,
                                      severity="high",
@@ -854,7 +888,30 @@ def detect_relations(sheet, r0, r1, c0, c1, header):
                 except ValueError:
                     continue
                 fitted = slope * x + intercept
-                if np.std(y) > 0 and _allclose_rowwise(y, fitted, rtol=1e-7) and abs(r) > 0.99:
+                # The fit's intercept is estimated from block-wide sums, so its error is
+                # set by the large magnitudes present -- and lands whole on the smallest
+                # rows, where the row-relative term cannot see it.
+                #
+                # Which large magnitude is the whole question, and two obvious answers are
+                # both wrong. The MEDIAN is what the old block-wide floor used, and an
+                # outlier majority moves it: that is how a five per cent difference came to
+                # be reported as an equality. The MAX is worse, not better -- one row moves
+                # it, and one row is also enough to hold `abs(r) > 0.99` on its own, so a
+                # single huge point on the line let a cloud with real deviations of five
+                # report as exact. Measured over both shapes, no coefficient on the max
+                # separates them: the legitimate case needs up to 1.8 of `eps * max` and
+                # the illegitimate one is admitted from 0.96.
+                #
+                # The 90th percentile takes a tenth of the rows to move, not one and not a
+                # majority. Over the same shapes the legitimate case needs at most ~2.2 of
+                # `eps * p90` and the illegitimate one would need ~1e14, so the two are
+                # separated by orders of magnitude rather than by a tuned constant.
+                fit_scale = float(np.percentile(
+                    np.abs(np.concatenate([x, y])), 90))
+                if (np.std(y) > 0
+                        and _allclose_rowwise(y, fitted, rtol=1e-7,
+                                              noise_floor=fit_scale)
+                        and abs(r) > 0.99):
                     # A scale-relatively zero intercept means the fit is y = slope*x: the
                     # identity (slope~=1, caught by identical_column) or a pure scaling. When a
                     # constant_ratio already captured that scaling, a second exact_linear finding

--- a/tests/test_column_pair_bench_baseline.py
+++ b/tests/test_column_pair_bench_baseline.py
@@ -161,6 +161,14 @@ def _two_level_coded(rng, magnitude, digits):
     Does NOT grade the ratio tolerance: column A is half zeros, so the arm's non-zero-divisor
     guard holds it out, and its one distinct non-zero level would make y/x constant anyway.
     Read a move here as a change to `small_diff_set` or the linear arm.
+
+    Its `exact_linear` verdict moved partial -> pervasive when the linear arm regained an
+    absolute margin at the fit's own scale. `y = 2x` here is exactly affine, so the arm was
+    always right to report it; half the rows being zero left them with no row-relative
+    tolerance at all, so any residual in the fit rejected them and the family reported
+    only sometimes. Louder, and the same pairs -- not a new false positive but a
+    previously random one made consistent. The family's overall verdict did not move, no
+    silent family started speaking, and TRUE_BASELINE did not move at all.
     """
     hi = _sig(magnitude * 5.372681943, digits)
     x = [rng.choice((0.0, hi)) for _ in range(ROWS)]
@@ -367,12 +375,12 @@ BENIGN_BASELINE = {
     ("sparse_shared_support", 8): ('silent', {}),
     ("sparse_shared_support", 9): ('silent', {}),
     ("sparse_shared_support", 10): ('silent', {}),
-    ("two_level_coded", 4): ('pervasive', {'exact_linear': 'partial', 'small_diff_set': 'pervasive'}),
-    ("two_level_coded", 6): ('pervasive', {'exact_linear': 'partial', 'small_diff_set': 'pervasive'}),
-    ("two_level_coded", 7): ('pervasive', {'exact_linear': 'partial', 'small_diff_set': 'pervasive'}),
-    ("two_level_coded", 8): ('pervasive', {'exact_linear': 'partial', 'small_diff_set': 'pervasive'}),
-    ("two_level_coded", 9): ('pervasive', {'exact_linear': 'partial', 'small_diff_set': 'pervasive'}),
-    ("two_level_coded", 10): ('pervasive', {'exact_linear': 'partial', 'small_diff_set': 'pervasive'}),
+    ("two_level_coded", 4): ('pervasive', {'exact_linear': 'pervasive', 'small_diff_set': 'pervasive'}),
+    ("two_level_coded", 6): ('pervasive', {'exact_linear': 'pervasive', 'small_diff_set': 'pervasive'}),
+    ("two_level_coded", 7): ('pervasive', {'exact_linear': 'pervasive', 'small_diff_set': 'pervasive'}),
+    ("two_level_coded", 8): ('pervasive', {'exact_linear': 'pervasive', 'small_diff_set': 'pervasive'}),
+    ("two_level_coded", 9): ('pervasive', {'exact_linear': 'pervasive', 'small_diff_set': 'pervasive'}),
+    ("two_level_coded", 10): ('pervasive', {'exact_linear': 'pervasive', 'small_diff_set': 'pervasive'}),
     ("unit_decadic", 4): ('pervasive', {'constant_ratio': 'pervasive'}),
     ("unit_decadic", 6): ('pervasive', {'constant_ratio': 'pervasive'}),
     ("unit_decadic", 7): ('pervasive', {'constant_ratio': 'pervasive'}),

--- a/tests/test_column_pair_floor.py
+++ b/tests/test_column_pair_floor.py
@@ -242,30 +242,125 @@ def test_an_equality_below_its_floor_is_stopped_rather_than_left_to_the_other_br
     assert above.strip() == "[]", above
 
 
-def test_recorded_gap_an_outlier_row_can_buy_an_equality_that_is_not_one() -> None:
-    """A RECORDED GAP, not a target. Frozen because this floor makes it cheaper to reach.
+def test_an_outlier_row_cannot_buy_an_equality_that_is_not_one() -> None:
+    """Was a recorded gap one commit ago; the measurement that freed it took one line.
 
-    `_isclose_rowwise` adds an absolute term built from the MEDIAN row scale, so that
-    differences below the data's own noise floor do not void a relation. With most rows at
-    an ordinary magnitude that term is negligible. With a majority of rows orders of
-    magnitude larger, the median is large, the term is large, and a real difference on the
-    remaining row is inside it -- the columns are reported equal when they are not.
+    `_isclose_rowwise` carried a block-wide absolute term built from the MEDIAN row scale.
+    With a majority of rows orders of magnitude larger than the rest, that median moved to
+    them, the term grew to their scale, and a real difference on the remaining row sat
+    inside it -- two columns differing by five per cent reported equal. The function's own
+    docstring says it exists to stop exactly that, and the guard against it was itself
+    computed across rows, so a majority turned it around.
 
-    This is the mechanism the function's own docstring says it exists to prevent ("a single
-    coordinate/metadata row can be orders of magnitude larger than the measurement rows"),
-    reappearing because the guard against it is itself computed across rows. It predates
-    this change and fires at four rows on `main`; what this change does is make three rows
-    enough -- the smallest majority a floor of three permits is two.
-
-    Not fixed here: `_isclose_rowwise` is shared by every relation detector and a golden
-    suite pins its behaviour, so narrowing it is its own change with its own measurement.
-    Frozen so the next person meets it as a known quantity, and so that narrowing it later
-    has something to move.
+    It was frozen rather than fixed on the ground that narrowing a shared tolerance needed
+    its own measurement. The measurement: deleting the term moves one test in the suite,
+    this one. Nothing needed the floor.
     """
     outliers = [1e20, 3.3e19]
     left = outliers + [100.0]
     right = [v * (1 + 1e-12) for v in outliers] + [105.0]   # the last row differs by 5%
 
+    assert _relations(left, right) == []
+
+
+def test_a_fit_dominated_by_large_rows_still_reaches_the_small_ones() -> None:
+    """The margin the equality path does not need, and this one does.
+
+    `exact_linear`'s intercept is estimated from block-wide sums, so a majority of
+    large-magnitude rows sets its error -- a fixed absolute quantity, which then lands
+    undiminished on the small rows, whose own scale cannot cover it. Deleting the absolute
+    term everywhere made a genuine `y = 3x + 11` unreportable over such a block in most
+    draws, while every existing test kept passing: the suite had a mixed-scale case, with
+    ONE outlier row, which is not enough leverage to skew the fit.
+    """
+    import random
+
+    for seed in range(6):
+        rnd = random.Random(seed)
+        left = [rnd.uniform(1e12, 1e13) for _ in range(30)] + [rnd.uniform(1, 10)
+                                                               for _ in range(3)]
+        right = [3 * v + 11 for v in left]
+
+        kinds = [f["kind"] for f in _relations(left, right)]
+
+        assert "exact_linear" in kinds, (seed, kinds)
+
+
+def test_one_far_row_cannot_buy_a_line_through_a_scattered_cloud() -> None:
+    """The other direction, and the reason the margin is not taken from the maximum.
+
+    A single row far out on the line holds `abs(r) > 0.99` by itself, whatever the rest of
+    the cloud does -- the correlation gate is no protection here. If the margin came from
+    the largest magnitude, that one row would also set it, and it would then cover real
+    deviations of several units among the ordinary rows. Measured over both shapes, no
+    coefficient on the maximum separates them: the legitimate case above needs up to about
+    1.8 of `eps * max` and this one is admitted from about 0.96. The 90th percentile takes
+    a tenth of the rows to move, and separates them by orders of magnitude instead.
+    """
+    import random
+
+    for seed in range(8):
+        rnd = random.Random(seed)
+        left = list(range(1, 21)) + [1e15]
+        right = ([3 * v + 11 + rnd.choice([-5, -3, 3, 5]) for v in range(1, 21)]
+                 + [3 * 1e15 + 11])
+
+        kinds = [f["kind"] for f in _relations(left, right)]
+
+        assert "exact_linear" not in kinds, (seed, kinds)
+
+
+def test_a_constant_offset_over_a_wide_span_is_still_an_offset() -> None:
+    """The offset branch computes an expectation too, and was left without the margin.
+
+    `mean_diff` is a mean over subtractions, so a block of large rows sets its error, and
+    `x + mean_diff` then carries that error onto the SMALL rows -- whose own scale is a few
+    units, so the row-relative term is worth about a hundred-millionth and cannot cover it.
+    Both halves are needed to see this: a block of large rows alone has a row-relative
+    tolerance in the thousands and never notices. The first version of this test had no
+    small rows and passed with the margin removed, which is to say it tested nothing.
+
+    Without the margin the branch misses a genuine `y = x + k` and the pair is reported by
+    `exact_linear` as a slope of one instead, with a spurious `small_diff_set` beside it --
+    the same float jitter read as several discrete differences where there is one.
+    """
+    import random
+
+    rnd = random.Random(0)
+    left = ([rnd.uniform(0.5e12, 1e12) for _ in range(2000)]
+            + [rnd.uniform(1, 10) for _ in range(3)])
+    # A value with a full mantissa, not a round one: `x + k` on a round offset is
+    # exact and leaves no jitter for the margin to be about.
+    offset = 18448.312114772714
+
+    kinds = [f["kind"] for f in _relations(left, [v + offset for v in left])]
+
+    assert "constant_offset" in kinds, kinds
+
+
+def test_a_real_deviation_on_one_row_still_defeats_an_offset() -> None:
+    """The control for that margin: it excuses float noise, not a difference on the sheet.
+
+    Same shape, with one small row moved by five thousand -- a difference a reader would
+    see. If the margin covered that, it would be the old block-wide floor again under a
+    new name.
+
+    What this does NOT discriminate: swapping the offset margin's statistic from the 90th
+    percentile to the maximum leaves it green, because at this block's spread even the
+    maximum does not reach five thousand. The argument for the percentile over the maximum
+    is made and pinned on the LINEAR arm, where one far row both sets the maximum and
+    holds the correlation gate by itself -- see
+    `test_one_far_row_cannot_buy_a_line_through_a_scattered_cloud`. Here the assertion is
+    only that the margin stays somewhere near float noise.
+    """
+    import random
+
+    rnd = random.Random(0)
+    left = ([rnd.uniform(0.5e12, 1e12) for _ in range(2000)]
+            + [rnd.uniform(1, 10) for _ in range(3)])
+    offset = 18448.312114772714
+    right = [v + offset for v in left[:-1]] + [left[-1] + offset + 5000.0]
+
     kinds = [f["kind"] for f in _relations(left, right)]
 
-    assert kinds == ["identical_column"], kinds
+    assert "constant_offset" not in kinds, kinds


### PR DESCRIPTION
fix(detect): drop a noise floor that outlier rows could turn around

`_isclose_rowwise` compares at each row's own scale so that one huge
coordinate row cannot loosen the check for the measurement rows -- its
docstring says so. It also carried a second, block-wide term:
`eps * median(row_scale) * 64`, a float noise floor for the whole comparison.

The median moves with the rows. Where a MAJORITY of them are the large ones,
the floor grows to their scale and swallows real differences on the rest, which
is the first paragraph's own failure arriving through the guard against it.
Review demonstrated two columns reported equal that differ by five per cent.

The previous commit froze this as a recorded gap, on the ground that narrowing a
tolerance shared by every relation detector was its own change needing its own
measurement. That reasoning was not wrong, but it asserted a cost without
measuring it, and the measurement is one line: deleting the term moves exactly
one test in the suite -- the one recording the defect. The golden snapshot and
the column-pair bench's true-positive strata are untouched.

So the argument for keeping it has no example behind it. It was there for an
expected value computed from the block carrying cancellation error at the
constant's scale rather than the row's -- but where that arises the expected
value is large too, so the row-relative term already covers it, and nothing in
the suite exercises a case where it does not. If one is found it belongs to the
branch that computes that expectation, at its own scale, rather than to every
comparison in the file and built from a statistic the outlier rows can move.

The frozen gap test becomes the invariant it was waiting for.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Follow-up to the recorded gap frozen in #70, opened immediately because the
review that found it also showed the deferral's premise was untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)