### PR TITLE
chore: release 0.9.0

### DIFF
--- a/examples/demo_paper/audit/scan.json
+++ b/examples/demo_paper/audit/scan.json
@@ -1,6 +1,6 @@
 {
   "tool": "paperconan",
-  "tool_version": "0.8.5",
+  "tool_version": "0.9.0",
   "schema_version": 2,
   "scan_status": "complete",
   "coverage": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "paperconan"
-version = "0.8.5"
+version = "0.9.0"
 description = "Numeric forensics for paper supplementary source-data: surfaces statistical signals and data inconsistencies."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paperconan
-version: 0.8.5
+version: 0.9.0
 description: Use when auditing paper source-data tables and registered image assets for statistical signals or data inconsistencies, interpreting paperconan scan.json/report.html, preparing cautious PubPeer or research-integrity notes, or finding open supplementary data from a DOI/title. Trigger on 论文数据检查, source data audit, paper data audit, suspicious numeric tables, figure review, multimodal image review, PubPeer prep, research integrity, DOI/title data fetch. Covers .xlsx/.csv/.tsv, tables in .pdf/.docx, and adaptive image review by an external multimodal Agent; not chart digitization or autonomous semantic judgment.
 ---
 

--- a/skills/paperconan/references/output-schema.md
+++ b/skills/paperconan/references/output-schema.md
@@ -8,7 +8,7 @@ essentials; this file is the complete reference (it travels in the skill bundle)
 ```json
 {
   "tool": "paperconan",
-  "tool_version": "0.8.5",        // matches the pyproject version; provenance for archived reports
+  "tool_version": "0.9.0",        // matches the pyproject version; provenance for archived reports
   "schema_version": 2,            // scan.json shape version; sidecar packets carry it too
   "scan_status": "complete",      // "complete" | "partial" | "failed" — check BEFORE adjudicating (see below)
   "coverage": {...},              // explicit scan-coverage accounting (see below)

--- a/src/paperconan/__init__.py
+++ b/src/paperconan/__init__.py
@@ -15,4 +15,4 @@ from ._html import write_html_report  # noqa: F401
 from .packet import distill_findings_for_review  # noqa: F401
 from .schema import PaperconanInputError  # noqa: F401
 
-__version__ = "0.8.5"
+__version__ = "0.9.0"

--- a/uv.lock
+++ b/uv.lock
@@ -600,7 +600,7 @@ wheels = [
 
 [[package]]
 name = "paperconan"
-version = "0.8.5"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Fourteen commits since v0.8.5, two of them new capability, so the minor version
moves rather than the patch.

**Fetch**
- follow a retraction or correction notice to the article it concerns
- keep the label a publisher puts on each supplementary file

**Detection**
- a workbook cell holding a numeral as text now reaches the detectors (#73) — the
  CSV and PDF/DOCX paths always parsed those, so the same table was analysable as
  .csv and invisible as .xlsx
- an equality may be stated on three rows
- a repeated segment's floor is graded by precision, not length alone
- a matched run is trimmed to its rare part instead of being rejected whole
- the within-row fold records the repeats it drops rather than dropping them silently

**Contributor docs and benches**
- a frozen behaviour bench for column-pair relations, and a planted true-positive
  stratum for the curve bench (#62)
- what a false-positive bench costs to get right (#59)
- the GitHub Release is now created from a pushed tag

## Release checklist

- [x] all five version sites moved to 0.9.0 (`test_packaging.py` pins them to
      `__version__`, and the suite is green)
- [x] `PYTHONPATH=. uv run pytest` — 2032 passed, 2 skipped
- [x] demo scan carries the new version string only; its findings are unchanged, so
      it is not regenerated — regenerating would write an absolute `input_dir` into a
      file that holds a relative one
- [x] `uv build`, then the wheel installed into a fresh venv and the CLI run there:
      `paperconan --version` reports 0.9.0 and a demo scan produces output identical
      to the committed one apart from paths and mtimes
- [ ] tag `v0.9.0` pushed after merge — the workflow matches nothing else, and a tag
      that does not match produces no run and no notification
- [ ] PyPI upload last, because PyPI forbids re-uploading a version: if the tag check
      is going to fail, it has to fail while the mistake is still fixable

🤖 Generated with [Claude Code](https://claude.com/claude-code)