### PR TITLE
docs: the version is in six places, and pin the sixth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,17 +209,22 @@ recheck/  batches/         LOCAL-ONLY audit working dirs — GITIGNORED, see bel
 
 ## Releasing
 
-The version is written in five places and `tests/test_packaging.py` pins all five to
+The version is written in six places and `tests/test_packaging.py` pins all six to
 `__version__`, so pytest is the check for them:
 
 `pyproject.toml`, `src/paperconan/__init__.py`, `skills/paperconan/SKILL.md`
-frontmatter, the sample in `skills/paperconan/references/output-schema.md`, and
-`examples/demo_paper/audit/scan.json`.
+frontmatter, the sample in `skills/paperconan/references/output-schema.md`,
+`examples/demo_paper/audit/scan.json`, and `uv.lock`.
+
+`uv.lock` is the one you do not edit: `uv run` rewrites it from `pyproject.toml`
+the next time it resolves, so bump the other five, run pytest, and commit the
+lockfile it updates. It went uncounted here until a release found it dirty in the
+working tree after the branch was already pushed.
 
 What pytest cannot check is any of them against the git tag — the tag does not exist
 when the suite runs. That pair is what `.github/workflows/release.yml` adds.
 
-1. Move all five. For the demo scan, edit the version string; regenerate it only if
+1. Move the five you edit by hand. For the demo scan, edit the version string; regenerate it only if
    detector output actually moved, because a regeneration writes an absolute `input_dir`
    into `examples/demo_paper/audit/scan.json` (`_audit.py` calls `os.path.abspath`) and
    the committed file holds a relative path.

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -65,3 +65,26 @@ def test_the_shipped_skill_declares_the_package_version():
 
     assert f"\nversion: {__version__}\n" in skill
     assert f'"tool_version": "{__version__}"' in schema
+
+
+def test_lockfile_version_matches_package():
+    """`uv.lock` carries the version too, and nothing else here was checking it.
+
+    It is not hand-edited -- `uv run` rewrites it from pyproject when it next
+    resolves -- so the failure mode is not a stale string someone forgot, it is a
+    release branch pushed while the lockfile is still dirty in the working tree.
+    That is exactly what happened the release this test was written for.
+
+    Which is also why this one cannot catch anything under `uv run pytest`: that
+    command re-resolves and fixes the lockfile before pytest starts, so the check
+    passes on a tree that was wrong a moment earlier. It bites where it matters --
+    CI and a plain `pytest` run, neither of which rewrites the file first.
+    """
+    root = Path(__file__).resolve().parents[1]
+    lock = (root / "uv.lock").read_text(encoding="utf-8")
+    block = lock.split('name = "paperconan"', 1)
+    assert len(block) == 2, "uv.lock has no paperconan package entry"
+    line = block[1].split("\n", 2)[1]
+    assert line == f'version = "{__version__}"', (
+        f"uv.lock says {line!r}; run `uv run pytest` and commit the updated lockfile"
+    )


### PR DESCRIPTION
`uv.lock` carries the version as well. The release guide counted five sites and
`test_packaging.py` pinned those five; the sixth had no check at all.

That surfaced during the 0.9.0 release: the lockfile showed up as an unstaged
change after the release branch was already pushed, because `uv run pytest` had
re-resolved and rewritten it. The failure mode is not a stale string someone
forgot to edit — nobody edits this one — it is a version bump committed without
the file uv regenerates.

**The new test cannot catch anything under `uv run pytest`.** That command
re-resolves and repairs the lockfile before pytest starts, so the assertion passes
on a tree that was wrong a moment earlier. Both workflows call `python -m pytest`
directly, and `release.yml` runs `tests/test_packaging.py` specifically, so it
bites where it counts. Verified both ways: breaking the lockfile version turns it
red under a plain pytest run and leaves it green under `uv run`, which is why the
caveat is in the docstring rather than left for the next person to rediscover.

The release-steps list now says to move the five sites by hand and commit the
lockfile pytest updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)