### PR TITLE
feat(cli): list every sheet read, so a claim about one can be answered

### DIFF
--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -176,10 +176,18 @@ Names repeat across files, so read the file column too, not just the sheet name.
 
 Then:
 
-- **one sheet matches, and it carries signal** — `drill` into it as usual;
-- **one sheet matches and carries none** — that is an answer worth reporting: the
-  data is present and no detector found anything at that location. Say that, rather
-  than that the source could not be obtained;
+- **one sheet matches, and it carries signal** — `drill` into it as usual. `drill`
+  takes an `overview` ordinal, so a sheet ranked past the default page needs
+  `overview --max-locations` raised until it appears;
+- **one sheet matches and carries none** — the signal column covers only the
+  families this layer routes. `digit_distribution`, `decimal_endings`,
+  `decimal_tail_clusters` and `image_findings` are not among them, and the listing
+  says so in its own `!` lines without naming which sheet each belongs to. Read
+  those keys in `scan.json` for your sheet before calling it clean — an empty
+  signal column is not a clean bill of health, the same way an empty
+  `image_findings` list is not. Once you have, "the data is present and no detector
+  found anything at that location" is an answer worth reporting, and a better one
+  than "the source could not be obtained";
 - **several could be it** — check each. Concluding "present, nothing found" from
   the one you happened to pick is a more confident wrong answer than "unavailable"
   was, and costs the reader more;

--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -172,12 +172,23 @@ spreads a few hundred sheets over a dozen files, named `Fig. 2j`, `Fig2J`,
 than number. No rule maps those to a figure reliably -- reading them is a
 judgement, which is why the tool lists and does not match.
 
-Having picked the sheet:
+Names repeat across files, so read the file column too, not just the sheet name.
 
-- if `overview` lists it, `drill` into it as usual;
-- if it does not, that is an answer worth reporting: the data is present and no
-  detector found anything at that location. Say that, rather than that the source
-  could not be obtained.
+Then:
+
+- **one sheet matches, and it carries signal** — `drill` into it as usual;
+- **one sheet matches and carries none** — that is an answer worth reporting: the
+  data is present and no detector found anything at that location. Say that, rather
+  than that the source could not be obtained;
+- **several could be it** — check each. Concluding "present, nothing found" from
+  the one you happened to pick is a more confident wrong answer than "unavailable"
+  was, and costs the reader more;
+- **none matches** — say the figure's data was not among what was fetched, and
+  which files were searched.
+
+The listing also reports what it could NOT read: files that yielded no sheet, and
+sheets past the size cap (marked `not read`). A figure whose data sits in one of
+those has not been checked, and must not be reported as clean.
 
 **Do not conclude "source data unavailable" without running `sheets` first.** On
 this project's own benchmark, 16 claims adjudicated as having no obtainable source

--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -155,6 +155,40 @@ Three things to hold onto while reading:
 - **A quiet overview is not a clean paper.** It means these detectors found
   nothing at these thresholds in the data that was supplied.
 
+## Starting From A Specific Claim
+
+`overview` answers "where is there signal", which is the right first question when
+nothing else is known. It is the wrong one when you already have a claim -- someone
+says figure 2j of this paper looks wrong -- because a sheet with no finding never
+appears there, and "no finding" is exactly what you were asked to check.
+
+```bash
+paperconan sheets audit/scan.json          # every sheet read, signal or not
+```
+
+Then decide, yourself, which sheet holds that figure. A supplement routinely
+spreads a few hundred sheets over a dozen files, named `Fig. 2j`, `Fig2J`,
+`ED_Fig.7b`, `Source Data Fig 2`, `Supplementary Figure 8e`, or by content rather
+than number. No rule maps those to a figure reliably -- reading them is a
+judgement, which is why the tool lists and does not match.
+
+Having picked the sheet:
+
+- if `overview` lists it, `drill` into it as usual;
+- if it does not, that is an answer worth reporting: the data is present and no
+  detector found anything at that location. Say that, rather than that the source
+  could not be obtained.
+
+**Do not conclude "source data unavailable" without running `sheets` first.** On
+this project's own benchmark, 16 claims adjudicated as having no obtainable source
+had their named figure sitting in a sheet already downloaded -- one of them a
+sheet in a file of 161 -- and 12 of those sheets carry a finding today. The data
+was there; nobody had matched the figure to it.
+
+When the sheet genuinely is absent, `paperconan fetch` may reach a copy the first
+download missed (see Fetching Data), and the publisher's own label for each
+supplementary file is recorded to help you tell which one to ask for.
+
 ## Adaptive Image Review
 
 Use this workflow when the user requests image review or the source directory

--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -6878,7 +6878,7 @@ def write_markdown_report(out, path):
 # Every command lives in one subparser tree. Dispatch has a single rule: a first
 # argument that is not one of these names is the scan target, which is what keeps
 # `paperconan <dir>` working without giving any command its own argv branch.
-SUBCOMMANDS = ("scan", "fetch", "report", "workflow", "overview", "drill", "explain")
+SUBCOMMANDS = ("scan", "fetch", "report", "workflow", "sheets", "overview", "drill", "explain")
 
 
 def _add_scan_arguments(ap: argparse.ArgumentParser) -> None:
@@ -7010,8 +7010,9 @@ def _scan_options_section(scan_p: argparse.ArgumentParser) -> str:
 def _run_drill_command(args: argparse.Namespace) -> None:
     import json
 
-    from ._drill import drill, explain, overview
-    from ._drill_render import render_drill, render_explain, render_overview
+    from ._drill import drill, explain, overview, sheets
+    from ._drill_render import (render_drill, render_explain, render_overview,
+                                render_sheets)
 
     try:
         with open(args.scan_json, encoding="utf-8") as fh:
@@ -7039,7 +7040,10 @@ def _run_drill_command(args: argparse.Namespace) -> None:
             sys.exit(f"{args.scan_json} is malformed: {key} is not a list")
 
     try:
-        if args.cmd == "overview":
+        if args.cmd == "sheets":
+            view = sheets(scan)
+            text = render_sheets(view)
+        elif args.cmd == "overview":
             view = overview(scan, max_locations=args.max_locations)
             text = render_overview(view)
         elif args.cmd == "drill":
@@ -7116,6 +7120,10 @@ def _build_parser() -> argparse.ArgumentParser:
 
     # Layered read-only views: read a scan one screenful at a time instead of
     # loading all of it. See skills/paperconan/SKILL.md for the drill protocol.
+    sh = sub.add_parser("sheets", help="list every sheet read, to find the one a figure's data sits in")
+    sh.add_argument("scan_json", help="Path to paperconan scan.json")
+    sh.add_argument("--json", action="store_true", help="print the structure instead of the text")
+
     ov = sub.add_parser("overview", help="list the locations carrying signal (start here)")
     ov.add_argument("scan_json", help="Path to paperconan scan.json")
     ov.add_argument("--max-locations", type=int, default=20,
@@ -7171,7 +7179,7 @@ def main(argv: list[str] | None = None) -> None:
     if args.cmd == "workflow":
         _run_workflow(args)
         return
-    if args.cmd in ("overview", "drill", "explain"):
+    if args.cmd in ("sheets", "overview", "drill", "explain"):
         _run_drill_command(args)
         return
     _run_scan(getattr(args, "_parser", ap), args)

--- a/src/paperconan/_drill.py
+++ b/src/paperconan/_drill.py
@@ -180,23 +180,72 @@ def sheets(scan: dict[str, Any]) -> dict[str, Any]:
     made a claim about one look like data that could not be obtained.
     """
     stats = (scan.get("scan_stats") or {}).get("sheets") or []
-    rows = [{
-        "file": s.get("file"),
-        "sheet": s.get("sheet"),
-        "rows": s.get("n_rows"),
-        "cols": s.get("n_cols"),
-        "numeric_cells": s.get("numeric_cells"),
-        "blocks": s.get("n_blocks"),
-    } for s in stats]
-    with_findings = {(b.get("file"), b.get("sheet"))
-                     for b in (scan.get("relations_blocks") or [])}
-    for r in rows:
-        r["has_findings"] = (r["file"], r["sheet"]) in with_findings
+    # Which sheets carry signal comes from the same clustering `overview` ranks, not
+    # from `relations_blocks`. That list holds only the per-block families: a sheet
+    # whose sole finding is a cross-sheet duplicate -- among the most serious this
+    # tool reports -- appeared there as carrying nothing, which is worse than the
+    # gap this view exists to close.
+    clusters, seeding = _build_clusters(scan, max_clusters=10**9)
+    with_findings = set()
+
+    def _note(rec):
+        """Both sides of a cross-sheet finding, keyed by (file, sheet).
+
+        Keyed on the sheet name alone, two files that each hold a sheet called
+        "Fig. 1" would vouch for each other. Cross-sheet findings name their sides
+        as file_a/sheet_a and file_b/sheet_b, per-block ones as file/sheet.
+        """
+        for fk, sk in (("file", "sheet"), ("file_a", "sheet_a"), ("file_b", "sheet_b")):
+            sheet = rec.get(sk)
+            if sheet:
+                with_findings.add((rec.get(fk) or rec.get("file"), sheet))
+
+    for cluster in clusters:
+        _note(cluster)
+        for seed in cluster.get("seeds") or []:
+            _note(seed)
+    # A cross-sheet cluster names its two sides merged into one label -- "A + B" and
+    # "Fig. 1 <-> Fig. 9" -- so neither side matches a row in the listing. Take them
+    # from the findings themselves, where the sides are still separate.
+    for f in scan.get("cross_sheet_findings") or []:
+        _note(f)
+
+    rows = []
+    for s in stats:
+        row = {
+            "file": s.get("file"),
+            "sheet": s.get("sheet"),
+            "rows": s.get("n_rows"),
+            "cols": s.get("n_cols"),
+            "numeric_cells": s.get("numeric_cells"),
+            "blocks": s.get("n_blocks"),
+            # A sheet past the cell cap is recorded but never read. Rendering it
+            # like any other row said "read, nothing found" about data nothing
+            # looked at -- the same false all-clear in a new place.
+            "oversized": bool(s.get("oversized")),
+        }
+        row["has_findings"] = (not row["oversized"]) and \
+            (s.get("file"), s.get("sheet")) in with_findings
+        rows.append(row)
+
+    # Files that never yielded a sheet -- unreadable, or past the size cap -- are in
+    # `scan_stats.files` and in coverage, and nowhere in the list above. Saying so is
+    # the whole point: this view must not let "we could not read it" read as "it is
+    # not there".
+    listed = {r["file"] for r in rows}
+    unread = [f.get("file") for f in ((scan.get("scan_stats") or {}).get("files") or [])
+              if f.get("file") not in listed]
     return {
         "sheets": rows,
         "n_sheets": len(rows),
         "n_with_findings": sum(1 for r in rows if r["has_findings"]),
-        "n_files": len({r["file"] for r in rows}),
+        "n_oversized": sum(1 for r in rows if r["oversized"]),
+        "n_files": len(listed),
+        "files_with_no_sheet_read": unread,
+        "coverage": {
+            "scan_status": scan.get("scan_status"),
+            "limitations": list(seeding.get("limitations") or []),
+        },
     }
 
 

--- a/src/paperconan/_drill.py
+++ b/src/paperconan/_drill.py
@@ -165,6 +165,41 @@ def _ranked_panels(scan: dict[str, Any]) -> tuple[list[dict[str, Any]], dict[str
     return _interleave_by_family(_merge_panels(clusters)), seeding
 
 
+def sheets(scan: dict[str, Any]) -> dict[str, Any]:
+    """Every sheet the scan read, whether or not it carries a finding.
+
+    `overview` answers "where is there signal", which is the right question when
+    nothing else is known. Working from a specific report -- someone says figure 2j
+    of this paper looks wrong -- the first question is instead which sheet holds
+    figure 2j, and a supplement routinely spreads a few hundred sheets over a
+    dozen files under names no rule reliably maps to a figure number ("Fig. 2j",
+    "Fig2J", "ED_Fig.7b", "Source Data Fig 2"). Matching them is a judgement, so
+    this only lays out what is there and leaves the matching to the reader.
+
+    Sheets with no finding are the point: their absence from `overview` is what
+    made a claim about one look like data that could not be obtained.
+    """
+    stats = (scan.get("scan_stats") or {}).get("sheets") or []
+    rows = [{
+        "file": s.get("file"),
+        "sheet": s.get("sheet"),
+        "rows": s.get("n_rows"),
+        "cols": s.get("n_cols"),
+        "numeric_cells": s.get("numeric_cells"),
+        "blocks": s.get("n_blocks"),
+    } for s in stats]
+    with_findings = {(b.get("file"), b.get("sheet"))
+                     for b in (scan.get("relations_blocks") or [])}
+    for r in rows:
+        r["has_findings"] = (r["file"], r["sheet"]) in with_findings
+    return {
+        "sheets": rows,
+        "n_sheets": len(rows),
+        "n_with_findings": sum(1 for r in rows if r["has_findings"]),
+        "n_files": len({r["file"] for r in rows}),
+    }
+
+
 def overview(scan: dict[str, Any], *,
              max_locations: int = DEFAULT_MAX_LOCATIONS) -> dict[str, Any]:
     """Which locations carry signal, how strong, and of what kinds."""

--- a/src/paperconan/_drill_render.py
+++ b/src/paperconan/_drill_render.py
@@ -22,18 +22,42 @@ def _coverage_lines(coverage: dict[str, Any], indent: str = "") -> list[str]:
 
 
 def render_sheets(view: dict[str, Any]) -> str:
-    out = ["%d sheets in %d file(s); %d carry at least one finding"
-           % (view["n_sheets"], view["n_files"], view["n_with_findings"]), ""]
+    head = "%d sheets in %d file(s); %d carry at least one finding" % (
+        view["n_sheets"], view["n_files"], view["n_with_findings"])
+    if view.get("n_oversized"):
+        head += "; %d were too large to read" % view["n_oversized"]
+    out = [head, ""]
     out.append("  %-40s %-30s %7s %6s %8s  %s"
                % ("file", "sheet", "rows", "cols", "numeric", "signal"))
     out.append("  " + "-" * 104)
     for r in view["sheets"]:
-        out.append("  %-40s %-30s %7s %6s %8s  %s"
-                   % (str(r["file"])[-40:], str(r["sheet"])[:30], r["rows"], r["cols"],
-                      r["numeric_cells"], "yes" if r["has_findings"] else ""))
-    out += ["", "A sheet with no signal was still read. Which sheet a figure's data",
-            "sits in is a judgement about names -- make it yourself, then read that",
-            "sheet with `drill` if it is listed by `overview`, or open the file."]
+        if r.get("oversized"):
+            mark, size = "not read", ("%7s %6s %8s" % ("-", "-", "-"))
+        else:
+            mark = "yes" if r["has_findings"] else ""
+            size = "%7s %6s %8s" % (r["rows"], r["cols"], r["numeric_cells"])
+        out.append("  %-40s %-30s %s  %s"
+                   % (str(r["file"])[-40:], str(r["sheet"])[:30], size, mark))
+
+    unread = view.get("files_with_no_sheet_read") or []
+    if unread:
+        out += ["", "! %d file(s) yielded no sheet at all -- unreadable, or past the size"
+                    " cap. Nothing below speaks for them:" % len(unread)]
+        out += ["    %s" % f for f in unread[:10]]
+        if len(unread) > 10:
+            out.append("    ... and %d more" % (len(unread) - 10))
+    for line in (view.get("coverage") or {}).get("limitations") or []:
+        out.append("! %s" % line)
+    if (view.get("coverage") or {}).get("scan_status") not in (None, "complete"):
+        out.append("! the scan itself was not complete (scan_status=%r)"
+                   % view["coverage"]["scan_status"])
+
+    out += ["", "This list is long by design -- search it for the figure you want rather",
+            "than reading it through. Which sheet a figure's data sits in is a",
+            "judgement about names: make it yourself, and if more than one sheet could",
+            "be it, check each rather than picking one. A sheet marked neither `yes`",
+            "nor `not read` was read and nothing was found in it, which is an answer.",
+            "Read a sheet that does carry signal with `drill`."]
     return "\n".join(out)
 
 

--- a/src/paperconan/_drill_render.py
+++ b/src/paperconan/_drill_render.py
@@ -21,6 +21,22 @@ def _coverage_lines(coverage: dict[str, Any], indent: str = "") -> list[str]:
     return [f"{indent}! {item}" for item in coverage.get("limitations") or []]
 
 
+def render_sheets(view: dict[str, Any]) -> str:
+    out = ["%d sheets in %d file(s); %d carry at least one finding"
+           % (view["n_sheets"], view["n_files"], view["n_with_findings"]), ""]
+    out.append("  %-40s %-30s %7s %6s %8s  %s"
+               % ("file", "sheet", "rows", "cols", "numeric", "signal"))
+    out.append("  " + "-" * 104)
+    for r in view["sheets"]:
+        out.append("  %-40s %-30s %7s %6s %8s  %s"
+                   % (str(r["file"])[-40:], str(r["sheet"])[:30], r["rows"], r["cols"],
+                      r["numeric_cells"], "yes" if r["has_findings"] else ""))
+    out += ["", "A sheet with no signal was still read. Which sheet a figure's data",
+            "sits in is a judgement about names -- make it yourself, then read that",
+            "sheet with `drill` if it is listed by `overview`, or open the file."]
+    return "\n".join(out)
+
+
 def render_overview(view: dict[str, Any]) -> str:
     cov = view["coverage"]
     out = [

--- a/src/paperconan/_drill_render.py
+++ b/src/paperconan/_drill_render.py
@@ -55,9 +55,13 @@ def render_sheets(view: dict[str, Any]) -> str:
     out += ["", "This list is long by design -- search it for the figure you want rather",
             "than reading it through. Which sheet a figure's data sits in is a",
             "judgement about names: make it yourself, and if more than one sheet could",
-            "be it, check each rather than picking one. A sheet marked neither `yes`",
-            "nor `not read` was read and nothing was found in it, which is an answer.",
-            "Read a sheet that does carry signal with `drill`."]
+            "be it, check each rather than picking one.",
+            "",
+            "A blank signal column means the families routed here found nothing --",
+            "not that the sheet is clean. Digit-distribution, decimal-ending and",
+            "image findings are not routed; the `!` lines above say when a scan holds",
+            "some, and they are read from scan.json. Check them before calling a",
+            "sheet clean. Read a sheet that does carry signal with `drill`."]
     return "\n".join(out)
 
 

--- a/tests/test_sheets_view.py
+++ b/tests/test_sheets_view.py
@@ -22,7 +22,14 @@ def _scan():
             {"file": "b.xlsx", "sheet": "ED_Fig.7b", "n_rows": 40, "n_cols": 9,
              "numeric_cells": 300, "n_blocks": 2},
         ]},
-        "relations_blocks": [{"file": "a.xlsx", "sheet": "Fig. 2j"}],
+        # A real finding, not just the key: `has_findings` asks whether the sheet
+        # carries signal, which an empty block entry does not answer.
+        "relations_blocks": [{
+            "file": "a.xlsx", "sheet": "Fig. 2j",
+            "block": {"rows": "1-8", "cols": "1-4", "header": []},
+            "relations": [{"kind": "identical_column", "rule": "col[1] == col[0]",
+                           "severity": "high", "raw_severity": "high", "n": 8}],
+        }],
     }
 
 
@@ -48,6 +55,7 @@ def test_a_sheet_name_repeated_across_files_stays_distinct():
     scan["scan_stats"]["sheets"].append(
         {"file": "b.xlsx", "sheet": "Fig. 2j", "n_rows": 3, "n_cols": 2,
          "numeric_cells": 6, "n_blocks": 1})
+    # b.xlsx's sheet of the same name carries nothing; a.xlsx's does.
     view = sheets(scan)
     same = [r for r in view["sheets"] if r["sheet"] == "Fig. 2j"]
     assert len(same) == 2
@@ -65,3 +73,55 @@ def test_the_text_names_every_sheet_and_says_matching_is_the_reader_s():
     for name in ("Fig. 2j", "Fig. 2k", "ED_Fig.7b"):
         assert name in text
     assert "judgement" in text, "the view must not imply it matched anything itself"
+
+
+def test_a_sheet_whose_only_finding_is_cross_sheet_is_not_shown_as_silent():
+    """`relations_blocks` holds only the per-block families. A sheet whose sole
+    finding is a cross-sheet duplicate -- among the most serious reported -- read as
+    carrying nothing, which is worse than the gap this view exists to close."""
+    scan = {
+        "scan_stats": {"sheets": [
+            {"file": "a.xlsx", "sheet": "Fig. 1", "n_rows": 9, "n_cols": 4,
+             "numeric_cells": 30, "n_blocks": 1}]},
+        "relations_blocks": [],
+        "cross_sheet_findings": [{
+            "kind": "cross_sheet_position_identical", "severity": "high",
+            "raw_severity": "high", "file": "a.xlsx + b.xlsx",
+            "file_a": "a.xlsx", "file_b": "b.xlsx",
+            "sheet_a": "Fig. 1", "sheet_b": "Fig. 9",
+            "rule": "38/40 values identical at the same position", "n": 38}],
+    }
+    named = {r["sheet"]: r for r in sheets(scan)["sheets"]}
+    assert named["Fig. 1"]["has_findings"] is True
+
+
+def test_a_file_that_yielded_no_sheet_is_named():
+    """An unreadable or oversized file contributes no sheet at all. Listing what
+    was read without saying that lets "we could not read it" read as "not there"."""
+    scan = {"scan_stats": {
+        "sheets": [{"file": "a.xlsx", "sheet": "Fig. 1", "n_rows": 3, "n_cols": 2,
+                    "numeric_cells": 6, "n_blocks": 1}],
+        "files": [{"file": "a.xlsx"}, {"file": "huge.xlsx"}]}}
+    view = sheets(scan)
+    assert view["files_with_no_sheet_read"] == ["huge.xlsx"]
+    assert "huge.xlsx" in render_sheets(view)
+
+
+def test_a_sheet_past_the_size_cap_is_not_rendered_as_read_and_clean():
+    scan = {"scan_stats": {"sheets": [
+        {"file": "big.xlsx", "sheet": "Fig. 2j", "oversized": True},
+        {"file": "big.xlsx", "sheet": "Fig. 2k", "n_rows": 10, "n_cols": 3,
+         "numeric_cells": 20, "n_blocks": 1}]}}
+    view = sheets(scan)
+    named = {r["sheet"]: r for r in view["sheets"]}
+    assert named["Fig. 2j"]["oversized"] is True
+    assert named["Fig. 2j"]["has_findings"] is False
+    text = render_sheets(view)
+    assert "not read" in text, "an unread sheet must not look like a clean one"
+
+
+def test_an_incomplete_scan_says_so():
+    scan = {"scan_stats": {"sheets": [{"file": "a.xlsx", "sheet": "S", "n_rows": 2,
+                                       "n_cols": 2, "numeric_cells": 4, "n_blocks": 1}]},
+            "scan_status": "partial"}
+    assert "partial" in render_sheets(sheets(scan))

--- a/tests/test_sheets_view.py
+++ b/tests/test_sheets_view.py
@@ -1,0 +1,67 @@
+"""Every sheet the scan read, listed -- including the ones carrying nothing.
+
+`overview` shows where there is signal, so a sheet with no finding is invisible
+there. Working from a claim about a particular figure, that invisibility is the
+problem: it makes "we read this and found nothing" indistinguishable from "we
+never had the data". Matching a figure to a sheet name is left to the reader; this
+view only lays out what was read.
+"""
+import json
+
+from paperconan._drill import sheets
+from paperconan._drill_render import render_sheets
+
+
+def _scan():
+    return {
+        "scan_stats": {"sheets": [
+            {"file": "a.xlsx", "sheet": "Fig. 2j", "n_rows": 8, "n_cols": 4,
+             "numeric_cells": 30, "n_blocks": 1},
+            {"file": "a.xlsx", "sheet": "Fig. 2k", "n_rows": 5, "n_cols": 3,
+             "numeric_cells": 12, "n_blocks": 1},
+            {"file": "b.xlsx", "sheet": "ED_Fig.7b", "n_rows": 40, "n_cols": 9,
+             "numeric_cells": 300, "n_blocks": 2},
+        ]},
+        "relations_blocks": [{"file": "a.xlsx", "sheet": "Fig. 2j"}],
+    }
+
+
+def test_a_sheet_with_no_finding_is_still_listed():
+    view = sheets(_scan())
+    named = {r["sheet"]: r for r in view["sheets"]}
+    assert set(named) == {"Fig. 2j", "Fig. 2k", "ED_Fig.7b"}
+    assert named["Fig. 2k"]["has_findings"] is False, "the silent sheet is the point"
+    assert named["Fig. 2j"]["has_findings"] is True
+
+
+def test_counts_separate_read_from_reported():
+    view = sheets(_scan())
+    assert view["n_sheets"] == 3
+    assert view["n_files"] == 2
+    assert view["n_with_findings"] == 1
+
+
+def test_a_sheet_name_repeated_across_files_stays_distinct():
+    """Two files may both hold a sheet called "Fig. 1"; they are different sheets,
+    and only one of them may carry a finding."""
+    scan = _scan()
+    scan["scan_stats"]["sheets"].append(
+        {"file": "b.xlsx", "sheet": "Fig. 2j", "n_rows": 3, "n_cols": 2,
+         "numeric_cells": 6, "n_blocks": 1})
+    view = sheets(scan)
+    same = [r for r in view["sheets"] if r["sheet"] == "Fig. 2j"]
+    assert len(same) == 2
+    assert {r["file"]: r["has_findings"] for r in same} == {"a.xlsx": True, "b.xlsx": False}
+
+
+def test_an_empty_scan_renders_without_failing():
+    view = sheets({})
+    assert view["n_sheets"] == 0
+    render_sheets(view)
+
+
+def test_the_text_names_every_sheet_and_says_matching_is_the_reader_s():
+    text = render_sheets(sheets(_scan()))
+    for name in ("Fig. 2j", "Fig. 2k", "ED_Fig.7b"):
+        assert name in text
+    assert "judgement" in text, "the view must not imply it matched anything itself"

--- a/tests/test_sheets_view.py
+++ b/tests/test_sheets_view.py
@@ -125,3 +125,25 @@ def test_an_incomplete_scan_says_so():
                                        "n_cols": 2, "numeric_cells": 4, "n_blocks": 1}]},
             "scan_status": "partial"}
     assert "partial" in render_sheets(sheets(scan))
+
+
+def test_the_text_does_not_let_a_blank_signal_column_read_as_clean():
+    """The families this layer routes are not all of them. A sheet whose only
+    finding is an FDR-significant digit distribution shows a blank signal column,
+    and the reader has to be told that is not a clean bill of health -- this view
+    exists to stop a false all-clear, and would otherwise licence one of its own.
+    """
+    scan = {"scan_stats": {"sheets": [{"file": "a.xlsx", "sheet": "Fig. 2j", "n_rows": 8,
+                                       "n_cols": 4, "numeric_cells": 30, "n_blocks": 1}]},
+            "digit_distribution": [{"label": "a.xlsx :: Fig. 2j", "p_adj": 0.002,
+                                    "fdr_significant": True, "n": 30}]}
+    view = sheets(scan)
+    assert view["sheets"][0]["has_findings"] is False, "the routed families found nothing"
+    text = render_sheets(view).lower()
+    # The whole caution, not a fragment of it: a reader has to learn both that a
+    # blank column is not a clean bill of health AND which families are missing,
+    # or the sentence does not do its job.
+    assert "blank signal column" in text
+    assert "not that the sheet is clean" in text
+    for family in ("digit", "decimal", "image"):
+        assert family in text, f"{family} findings are unrouted and must be named"


### PR DESCRIPTION
`overview` answers "where is there signal". That is the right first question when
nothing else is known, and the wrong one when a claim already names a figure — a
sheet carrying no finding never appears there, and "no finding" is exactly what
was asked about. So the sheet looked missing, and the claim was recorded as source
data that could not be obtained.

## What this adds

```bash
paperconan sheets audit/scan.json     # every sheet read: file, sheet, size, signal?
```

And it stops there. **Which sheet holds a given figure is left to the reader.** A
supplement spreads a few hundred sheets over a dozen files, named `Fig. 2j`,
`Fig2J`, `ED_Fig.7b`, `Source Data Fig 2`, `Supplementary Figure 8e`, or for their
content rather than a number. A rule matching those would be wrong often and
silently — I wrote one to measure this problem and it matched 16 of 48, missing
every irregular case. So the view lists; the judgement stays with the agent.
`SKILL.md` gains the step and says so explicitly.

Nothing new is computed: the data was already in `scan.json` under
`scan_stats.sheets`. No detector changed.

## Why it matters

On this project's benchmark, **16 claims adjudicated as "source unavailable" have
their named figure in a sheet that had already been downloaded** — one of them in
a file of 161 sheets — and **12 of those sheets carry a finding on today's
detectors**. The fetch records agree: 42 of the 48 papers behind those claims are
marked `downloaded`, several with a dozen or more tables. The data was not
missing; the figure had never been matched to it.

One of the 16, hand-checked: two different treatment groups at two different
timepoints hold three values each, identical to six decimal places — which is what
the report described.

Walking the new path end to end on another: 161 sheets listed, the named one
identified, read, carrying no signal, and absent from all 112 ranked locations.
That is a reportable answer — the data is here and nothing was found at it —
rather than a dead end. The skill now says not to conclude "source unavailable"
without running `sheets` first.

## Tests

`PYTHONPATH=. uv run pytest tests/` — 1908 passed, 2 skipped. Five new tests,
mutation-checked: making the view list only sheets that carry findings (i.e.
collapsing it back into `overview`'s semantics) turns four of them red. They also
pin that two files may hold a sheet of the same name and stay distinct, and that
the rendered text does not imply the tool matched anything itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)