### PR TITLE
fix(drill): sort locations whose every finding matched a prefilter drop rule after their band-mates

### DIFF
--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -87,13 +87,15 @@ Three things to hold onto while reading:
   column can be demoted merely for sharing a block with many other relations.
   Do not skip a finding because its displayed severity is low.
   `overview` ranks on the detector's severity, so a demoted finding still counts
-  toward its location's rank. One exception: a location whose every finding the
-  filter demoted outright -- for a recorded reason other than a downweight -- is
-  ranked after the other locations of the same strength (severity is still compared
-  first, so the verdict never outweighs it) and says so with a
-  `filter: all N demoted outright` line. That line is the filter's verdict, not a
-  conclusion. A location holding even one finding that was kept, only downweighted,
-  or demoted with no recorded reason is not treated this way and carries no such line.
+  toward its location's rank. One adjustment: a location whose every finding matched
+  a prefilter drop rule (`explain` shows `deterministic_relation_prefilter` or
+  `within_col_structural_filter`) sorts after the locations of its strength that did
+  not, and carries a `filter: N/N matched a prefilter drop rule` line. Locations are
+  then interleaved by kind, which decides the printed order, so such a location can
+  still sit high on the page, or behind a weaker location of another kind. The line
+  reports the prefilter's verdict, not a conclusion. A location holding even one
+  finding that was kept, downweighted, demoted by another guard (for example
+  `derived_or_unit_conversion`), or demoted with no recorded reason carries no line.
 - **Read the `!` lines — every layer has them.** `overview` and both `drill`
   forms carry a `coverage` block; `explain` states its own limits inline (an
   evidence window the scan trimmed, structured parameters only `--json` shows).

--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -86,6 +86,14 @@ Three things to hold onto while reading:
   a dense block or a repeated axis is often a fair call, but an exactly duplicated
   column can be demoted merely for sharing a block with many other relations.
   Do not skip a finding because its displayed severity is low.
+  `overview` ranks on the detector's severity, so a demoted finding still counts
+  toward its location's rank. One exception: a location whose every finding the
+  filter demoted outright -- for a recorded reason other than a downweight -- is
+  ranked after the other locations of the same strength (severity is still compared
+  first, so the verdict never outweighs it) and says so with a
+  `filter: all N demoted outright` line. That line is the filter's verdict, not a
+  conclusion. A location holding even one finding that was kept, only downweighted,
+  or demoted with no recorded reason is not treated this way and carries no such line.
 - **Read the `!` lines — every layer has them.** `overview` and both `drill`
   forms carry a `coverage` block; `explain` states its own limits inline (an
   evidence window the scan trimmed, structured parameters only `--json` shows).

--- a/skills/paperconan/SKILL.md
+++ b/skills/paperconan/SKILL.md
@@ -88,13 +88,14 @@ Three things to hold onto while reading:
   Do not skip a finding because its displayed severity is low.
   `overview` ranks on the detector's severity, so a demoted finding still counts
   toward its location's rank. One adjustment: a location whose every finding matched
-  a prefilter drop rule (`explain` shows `deterministic_relation_prefilter` or
-  `within_col_structural_filter`) sorts after the locations of its strength that did
-  not, and carries a `filter: N/N matched a prefilter drop rule` line. Locations are
-  then interleaved by kind, which decides the printed order, so such a location can
-  still sit high on the page, or behind a weaker location of another kind. The line
-  reports the prefilter's verdict, not a conclusion. A location holding even one
-  finding that was kept, downweighted, demoted by another guard (for example
+  a prefilter drop rule (`explain` lists `deterministic_relation_prefilter` or
+  `within_col_structural_filter` among its reasons) sorts after the locations of its
+  strength that did not, and carries a `filter: N/N matched a prefilter drop rule`
+  line. Locations are then interleaved by kind, which decides the printed order, so
+  such a location can still sit high on the page, or behind a weaker location of
+  another kind. The line reports the prefilter's verdict, not a conclusion, and some
+  drop rules match on a header word alone. A location holding even one finding that
+  was kept, downweighted, demoted by another guard (for example
   `derived_or_unit_conversion`), or demoted with no recorded reason carries no line.
 - **Read the `!` lines — every layer has them.** `overview` and both `drill`
   forms carry a `coverage` block; `explain` states its own limits inline (an

--- a/src/paperconan/_drill.py
+++ b/src/paperconan/_drill.py
@@ -75,12 +75,12 @@ def _families(cluster: dict[str, Any]) -> list[str]:
     return seen
 
 
-def _all_demoted_outright(cluster: dict[str, Any]) -> bool:
-    """Every finding here was demoted outright (see `demoted_outright`). A single
-    finding that was not -- kept, only downweighted, or demoted with no recorded
-    reason -- leaves the location ranked on its detector severity alone."""
+def _all_matched_drop_rule(cluster: dict[str, Any]) -> bool:
+    """Every finding here matched a prefilter drop rule (see `matched_drop_rule`).
+    One finding that did not -- kept, downweighted, demoted by another guard, or
+    demoted with no recorded reason -- keeps the panel out of this adjustment."""
     seeds = cluster["seeds"]
-    return bool(seeds) and all(s.get("demoted_outright") for s in seeds)
+    return bool(seeds) and all(s.get("matched_drop_rule") for s in seeds)
 
 
 # ---------- L1 ----------
@@ -119,12 +119,13 @@ def _merge_panels(clusters: list[dict[str, Any]]) -> list[dict[str, Any]]:
     panels = list(merged.values())
     panels.sort(key=lambda c: (
         _SEVERITY_RANK.get(c["strongest_raw_severity"], 3),
-        # Ranking is on the detector's severity, frozen before the profile ran, so
-        # a panel the filter had wholly demoted still took its slot on those
-        # findings. It now goes to the back of its band. The verdict is compared
-        # after severity, not before: the filter can be wrong, and a verdict that
-        # can be wrong must not outweigh the detector's severity.
-        _all_demoted_outright(c),
+        # Ranking is on the detector's severity, frozen before the profile ran, so a
+        # panel whose every finding a prefilter drop rule had matched still took its
+        # slot on those findings. It now sorts after the panels of its band that did
+        # not. Severity stays ahead of the verdict because the filter can be wrong.
+        # This is the order `_interleave_by_family` receives; it round-robins kinds,
+        # so the printed position also depends on which other kinds are present.
+        _all_matched_drop_rule(c),
         -c["n_high_seeds"],
         -len(c["seeds"]),
         c["cluster_id"],
@@ -280,8 +281,8 @@ def overview(scan: dict[str, Any], *,
             "strongest": cluster["strongest_raw_severity"],
             "signals": len(cluster["seeds"]),
             "high": cluster["n_high_seeds"],
-            "demoted_outright": sum(1 for s in cluster["seeds"]
-                                    if s.get("demoted_outright")),
+            "matched_drop_rule": sum(1 for s in cluster["seeds"]
+                                     if s.get("matched_drop_rule")),
             "families": _families(cluster),
         })
 

--- a/src/paperconan/_drill.py
+++ b/src/paperconan/_drill.py
@@ -64,7 +64,7 @@ def _clusters_of(scan: dict[str, Any]) -> tuple[list[dict[str, Any]], dict[str, 
     fails to reach the reader. Discarding it here made `overview` print an empty
     `limitations` list on a scan where thousands of findings had been dropped.
     """
-    return _build_clusters(scan, max_clusters=10**9)
+    return _build_clusters(scan, max_clusters=10**9, with_verdict=True)
 
 
 def _families(cluster: dict[str, Any]) -> list[str]:
@@ -73,6 +73,14 @@ def _families(cluster: dict[str, Any]) -> list[str]:
         if seed["kind"] and seed["kind"] not in seen:
             seen.append(seed["kind"])
     return seen
+
+
+def _all_demoted_outright(cluster: dict[str, Any]) -> bool:
+    """Every finding here was demoted outright (see `demoted_outright`). A single
+    finding that was not -- kept, only downweighted, or demoted with no recorded
+    reason -- leaves the location ranked on its detector severity alone."""
+    seeds = cluster["seeds"]
+    return bool(seeds) and all(s.get("demoted_outright") for s in seeds)
 
 
 # ---------- L1 ----------
@@ -111,6 +119,12 @@ def _merge_panels(clusters: list[dict[str, Any]]) -> list[dict[str, Any]]:
     panels = list(merged.values())
     panels.sort(key=lambda c: (
         _SEVERITY_RANK.get(c["strongest_raw_severity"], 3),
+        # Ranking is on the detector's severity, frozen before the profile ran, so
+        # a panel the filter had wholly demoted still took its slot on those
+        # findings. It now goes to the back of its band. The verdict is compared
+        # after severity, not before: the filter can be wrong, and a verdict that
+        # can be wrong must not outweigh the detector's severity.
+        _all_demoted_outright(c),
         -c["n_high_seeds"],
         -len(c["seeds"]),
         c["cluster_id"],
@@ -266,6 +280,8 @@ def overview(scan: dict[str, Any], *,
             "strongest": cluster["strongest_raw_severity"],
             "signals": len(cluster["seeds"]),
             "high": cluster["n_high_seeds"],
+            "demoted_outright": sum(1 for s in cluster["seeds"]
+                                    if s.get("demoted_outright")),
             "families": _families(cluster),
         })
 

--- a/src/paperconan/_drill_render.py
+++ b/src/paperconan/_drill_render.py
@@ -89,10 +89,11 @@ def render_overview(view: dict[str, Any]) -> str:
         suffix = f", … {more} more" if more > 0 else ""
         out.append(f"      {', '.join(families)}{suffix}")
         # Said here because the page is where the choice to open a location is
-        # made. It reports the filter's verdict, which explain lets the reader judge.
-        if loc["signals"] and loc.get("demoted_outright") == loc["signals"]:
-            out.append(f"      filter: all {loc['signals']} demoted outright — "
-                       "explain gives the reason")
+        # made. It reports the prefilter's verdict, which explain lets the reader judge.
+        if loc["signals"] and loc.get("matched_drop_rule") == loc["signals"]:
+            n = loc["signals"]
+            out.append(f"      filter: {n}/{n} matched a prefilter drop rule — "
+                       "explain names it")
     # Branch on the scan, not on this page: with --max-locations 0 the page is
     # empty while the scan is not, and the all-clear text would contradict both
     # the header and the coverage line on the same screen.

--- a/src/paperconan/_drill_render.py
+++ b/src/paperconan/_drill_render.py
@@ -93,7 +93,7 @@ def render_overview(view: dict[str, Any]) -> str:
         if loc["signals"] and loc.get("matched_drop_rule") == loc["signals"]:
             n = loc["signals"]
             out.append(f"      filter: {n}/{n} matched a prefilter drop rule — "
-                       "explain names it")
+                       "reasons in explain")
     # Branch on the scan, not on this page: with --max-locations 0 the page is
     # empty while the scan is not, and the all-clear text would contradict both
     # the header and the coverage line on the same screen.
@@ -263,9 +263,11 @@ def render_explain(view: dict[str, Any]) -> str:
         f"  severity:  detector={sev['raw']}  displayed={sev['effective']}"
         f"  ({sev['profile_action']})",
     ]
-    if sev["raw"] != sev["effective"]:
+    if sev["raw"] != sev["effective"] or sev.get("profile_action", "kept") != "kept":
         # A demotion is a judgement the reviewer may want to overturn, so the
         # reason has to travel with it rather than being implied by the number.
+        # A finding the detector already rated low can still have been demoted,
+        # and overview's filter line sends the reader here for that reason.
         out.append("  down-weighted because:")
         for reason in sev["context"] or ["(no reason recorded)"]:
             out.append(f"      · {reason}")

--- a/src/paperconan/_drill_render.py
+++ b/src/paperconan/_drill_render.py
@@ -88,6 +88,11 @@ def render_overview(view: dict[str, Any]) -> str:
         more = len(loc["families"]) - len(families)
         suffix = f", … {more} more" if more > 0 else ""
         out.append(f"      {', '.join(families)}{suffix}")
+        # Said here because the page is where the choice to open a location is
+        # made. It reports the filter's verdict, which explain lets the reader judge.
+        if loc["signals"] and loc.get("demoted_outright") == loc["signals"]:
+            out.append(f"      filter: all {loc['signals']} demoted outright — "
+                       "explain gives the reason")
     # Branch on the scan, not on this page: with --max-locations 0 the page is
     # empty while the scan is not, and the all-clear text would contradict both
     # the header and the coverage line on the same screen.

--- a/src/paperconan/_profiles.py
+++ b/src/paperconan/_profiles.py
@@ -90,30 +90,36 @@ def _demote_or_hide(f: dict, profile: Profile) -> None:
         f["profile_action"] = "demoted"
 
 
-# The prefilters return one of two verdicts: "drop" (the pattern is usually derived
-# or structural) and "downweight" (worth less, not nothing). Both reach
-# `_demote_or_hide`, so neither `severity` nor `profile_action` can tell them apart.
-# The finding's `prefilter` field does, but it does not describe the profile's
-# decision: the within-column flood and reused-progression demoters in `_audit.py`
-# write `prefilter="drop"` and can leave the finding kept by the profile, and the
-# axis, boundary, derived, replot and omics guards demote without writing it. The
-# context tag is the profile's own record of why, so the reading layer decides
-# through `demoted_outright`, which reads the tag.
+# The relation and within-column prefilters return "keep", "downweight" or "drop".
+# The profile demotes on both of the last two through `_demote_or_hide`, so neither
+# `severity` nor `profile_action` can tell them apart; the context tag written just
+# before the demotion can. The finding's `prefilter` field is not a substitute: the
+# within-column flood and reused-progression demoters in `_audit.py` write
+# `prefilter="drop"` and can leave the finding kept by the profile.
+#
+# The other guards in `apply_profile_to_findings` demote with no such distinction, so
+# their tags say nothing about strength, and two of them (derived, omics) decide on
+# words in headers and sheet names, ahead of a prefilter that may have judged the same
+# finding differently. Only a prefilter's drop tag records the verdict "drop, not
+# merely downweight", so it is the only tag the reading layer acts on.
+_RELATION_DROP = "deterministic_relation_prefilter"
 _RELATION_DOWNWEIGHT = "deterministic_relation_downweight"
+_WITHIN_COL_DROP = "within_col_structural_filter"
 _WITHIN_COL_DOWNWEIGHT = "within_col_downweight"
-DOWNWEIGHT_CONTEXTS = frozenset({_RELATION_DOWNWEIGHT, _WITHIN_COL_DOWNWEIGHT})
+PREFILTER_DROP_CONTEXTS = frozenset({_RELATION_DROP, _WITHIN_COL_DROP})
 
 
-def demoted_outright(f: dict) -> bool:
-    """The profile demoted this finding on a verdict stronger than a downweight.
+def matched_drop_rule(f: dict) -> bool:
+    """The profile demoted this finding because a prefilter's drop rule matched it.
 
-    A demotion with no recorded reason does not count. A finding shown as demoted
-    with nothing saying why is the shape a real signal disappears in, so it is not
-    moved on a verdict nobody can read.
+    A downweight, a demotion by another guard, and a demotion with no recorded reason
+    do not count. Context entries that are not strings are ignored, so a hand-edited
+    or foreign scan cannot break the reading layer through this field.
     """
     if f.get("profile_action", "kept") == "kept":
         return False
-    return bool(set(f.get("false_positive_context") or []) - DOWNWEIGHT_CONTEXTS)
+    return any(isinstance(c, str) and c in PREFILTER_DROP_CONTEXTS
+               for c in f.get("false_positive_context") or [])
 
 
 def _names_for(f: dict) -> str:
@@ -292,7 +298,7 @@ def apply_profile_to_findings(findings: Iterable[dict], profile: str | None,
         elif relation_decision := _relation_prefilter(f):
             action, reason = relation_decision
             ctx = (
-                "deterministic_relation_prefilter"
+                _RELATION_DROP
                 if action == "drop"
                 else _RELATION_DOWNWEIGHT
             )
@@ -318,7 +324,7 @@ def apply_profile_to_findings(findings: Iterable[dict], profile: str | None,
         elif wc_decision := _within_col_prefilter(f, wc_high):
             action, reason = wc_decision
             ctx = (
-                "within_col_structural_filter"
+                _WITHIN_COL_DROP
                 if action == "drop"
                 else _WITHIN_COL_DOWNWEIGHT
             )

--- a/src/paperconan/_profiles.py
+++ b/src/paperconan/_profiles.py
@@ -90,6 +90,32 @@ def _demote_or_hide(f: dict, profile: Profile) -> None:
         f["profile_action"] = "demoted"
 
 
+# The prefilters return one of two verdicts: "drop" (the pattern is usually derived
+# or structural) and "downweight" (worth less, not nothing). Both reach
+# `_demote_or_hide`, so neither `severity` nor `profile_action` can tell them apart.
+# The finding's `prefilter` field does, but it does not describe the profile's
+# decision: the within-column flood and reused-progression demoters in `_audit.py`
+# write `prefilter="drop"` and can leave the finding kept by the profile, and the
+# axis, boundary, derived, replot and omics guards demote without writing it. The
+# context tag is the profile's own record of why, so the reading layer decides
+# through `demoted_outright`, which reads the tag.
+_RELATION_DOWNWEIGHT = "deterministic_relation_downweight"
+_WITHIN_COL_DOWNWEIGHT = "within_col_downweight"
+DOWNWEIGHT_CONTEXTS = frozenset({_RELATION_DOWNWEIGHT, _WITHIN_COL_DOWNWEIGHT})
+
+
+def demoted_outright(f: dict) -> bool:
+    """The profile demoted this finding on a verdict stronger than a downweight.
+
+    A demotion with no recorded reason does not count. A finding shown as demoted
+    with nothing saying why is the shape a real signal disappears in, so it is not
+    moved on a verdict nobody can read.
+    """
+    if f.get("profile_action", "kept") == "kept":
+        return False
+    return bool(set(f.get("false_positive_context") or []) - DOWNWEIGHT_CONTEXTS)
+
+
 def _names_for(f: dict) -> str:
     return " ".join(str(f.get(k) or "") for k in (
         "col", "col_a", "col_b", "mean_col", "n_col", "sd_col",
@@ -268,7 +294,7 @@ def apply_profile_to_findings(findings: Iterable[dict], profile: str | None,
             ctx = (
                 "deterministic_relation_prefilter"
                 if action == "drop"
-                else "deterministic_relation_downweight"
+                else _RELATION_DOWNWEIGHT
             )
             _add_context(
                 f,
@@ -294,7 +320,7 @@ def apply_profile_to_findings(findings: Iterable[dict], profile: str | None,
             ctx = (
                 "within_col_structural_filter"
                 if action == "drop"
-                else "within_col_downweight"
+                else _WITHIN_COL_DOWNWEIGHT
             )
             _add_context(
                 f,

--- a/src/paperconan/_profiles.py
+++ b/src/paperconan/_profiles.py
@@ -98,10 +98,11 @@ def _demote_or_hide(f: dict, profile: Profile) -> None:
 # `prefilter="drop"` and can leave the finding kept by the profile.
 #
 # The other guards in `apply_profile_to_findings` demote with no such distinction, so
-# their tags say nothing about strength, and two of them (derived, omics) decide on
-# words in headers and sheet names, ahead of a prefilter that may have judged the same
-# finding differently. Only a prefilter's drop tag records the verdict "drop, not
-# merely downweight", so it is the only tag the reading layer acts on.
+# their tags do not say how strongly the filter meant it. A prefilter's drop tag is
+# the one place the filter says "drop, not merely downweight", and it is the only tag
+# the reading layer acts on. It is the filter's stated verdict, not stronger evidence:
+# some drop rules match on a header word alone. That is why the reading layer compares
+# it only after severity, adds a label, and removes nothing.
 _RELATION_DROP = "deterministic_relation_prefilter"
 _RELATION_DOWNWEIGHT = "deterministic_relation_downweight"
 _WITHIN_COL_DROP = "within_col_structural_filter"
@@ -113,13 +114,16 @@ def matched_drop_rule(f: dict) -> bool:
     """The profile demoted this finding because a prefilter's drop rule matched it.
 
     A downweight, a demotion by another guard, and a demotion with no recorded reason
-    do not count. Context entries that are not strings are ignored, so a hand-edited
-    or foreign scan cannot break the reading layer through this field.
+    do not count. A context that is not a list, and entries in it that are not
+    strings, are ignored, so a hand-edited or foreign scan cannot make this check raise
+    or be read as a drop rule.
     """
     if f.get("profile_action", "kept") == "kept":
         return False
-    return any(isinstance(c, str) and c in PREFILTER_DROP_CONTEXTS
-               for c in f.get("false_positive_context") or [])
+    contexts = f.get("false_positive_context")
+    if not isinstance(contexts, list):
+        return False
+    return any(isinstance(c, str) and c in PREFILTER_DROP_CONTEXTS for c in contexts)
 
 
 def _names_for(f: dict) -> str:

--- a/src/paperconan/_workflow.py
+++ b/src/paperconan/_workflow.py
@@ -26,6 +26,7 @@ import shutil
 from typing import Any
 
 from ._finding_groups import BLOCK_FINDING_GROUPS
+from ._profiles import demoted_outright
 
 # 2: envelope requires source_finding_refs; coverage replaced `omitted_reason`
 #    with `limitations` and gained scan_status / scan_incomplete / coverage_complete.
@@ -320,9 +321,21 @@ def _cluster_key(seed: dict[str, Any]) -> tuple:
     )
 
 
-def _build_clusters(scan: dict[str, Any], max_clusters: int) -> tuple[list[dict], dict]:
-    seeds = [_block_seed(blk, group, f) for blk, group, f in _iter_raw_findings(scan)]
-    seeds += [_cross_sheet_seed(f) for f in scan.get("cross_sheet_findings", []) or []]
+def _build_clusters(scan: dict[str, Any], max_clusters: int, *,
+                    with_verdict: bool = False) -> tuple[list[dict], dict]:
+    """Seeds grouped into clusters, ranked.
+
+    `with_verdict` is for the reading layer. It records on each seed whether the
+    display profile demoted that finding outright, which depends on the profile;
+    workflow packets are built without it, so they stay independent of the display
+    profile.
+    """
+    pairs = [(_block_seed(blk, group, f), f) for blk, group, f in _iter_raw_findings(scan)]
+    pairs += [(_cross_sheet_seed(f), f) for f in scan.get("cross_sheet_findings", []) or []]
+    if with_verdict:
+        for seed, f in pairs:
+            seed["demoted_outright"] = demoted_outright(f)
+    seeds = [seed for seed, _f in pairs]
 
     # Disambiguate rather than refuse. Raising here was the wrong call: real
     # supplements do collide — a locator that cannot separate two findings is a

--- a/src/paperconan/_workflow.py
+++ b/src/paperconan/_workflow.py
@@ -26,7 +26,7 @@ import shutil
 from typing import Any
 
 from ._finding_groups import BLOCK_FINDING_GROUPS
-from ._profiles import demoted_outright
+from ._profiles import matched_drop_rule
 
 # 2: envelope requires source_finding_refs; coverage replaced `omitted_reason`
 #    with `limitations` and gained scan_status / scan_incomplete / coverage_complete.
@@ -326,7 +326,8 @@ def _build_clusters(scan: dict[str, Any], max_clusters: int, *,
     """Seeds grouped into clusters, ranked.
 
     `with_verdict` is for the reading layer. It records on each seed whether the
-    display profile demoted that finding outright, which depends on the profile;
+    display profile demoted that finding on a prefilter drop rule, which depends on
+    the profile;
     workflow packets are built without it, so they stay independent of the display
     profile.
     """
@@ -334,7 +335,7 @@ def _build_clusters(scan: dict[str, Any], max_clusters: int, *,
     pairs += [(_cross_sheet_seed(f), f) for f in scan.get("cross_sheet_findings", []) or []]
     if with_verdict:
         for seed, f in pairs:
-            seed["demoted_outright"] = demoted_outright(f)
+            seed["matched_drop_rule"] = matched_drop_rule(f)
     seeds = [seed for seed, _f in pairs]
 
     # Disambiguate rather than refuse. Raising here was the wrong call: real

--- a/tests/test_page_filter_verdict.py
+++ b/tests/test_page_filter_verdict.py
@@ -1,51 +1,59 @@
-"""The first page and the false-positive filter's verdict.
+"""The first page and the prefilter's drop verdict.
 
 `overview` ranks on the detector's severity, frozen before the profile runs, so a
 location whose every finding the filter had already demoted could take a first-page
 slot on the strength of findings the scan itself had marked as likely false positives.
 
-The filter returns two verdicts and they must not be treated alike. "drop" says the
-pattern is usually derived or structural; "downweight" says worth less, not nothing.
-Only the first is grounds for moving a location, and only to the back of its own
-severity band: the verdict is compared after severity, because the filter can be
-wrong and a verdict that can be wrong must not outweigh the detector's severity.
+Of the profile's demotions, only a prefilter's drop rule is acted on here. The
+prefilters distinguish "drop" from "downweight" and the profile then demotes both
+alike, so the context tag is the record of which it was; the other guards record no
+strength, and two of them decide on words in headers and sheet names. A downweight
+means worth less, not nothing, and a location holding one is left alone.
 
-Every fixture uses one finding kind, so family interleaving -- which round-robins
-across kinds -- cannot reorder what these tests look at.
+Within its severity band a location that matched sorts after its band-mates, and
+severity is compared first because the filter can be wrong. Family interleaving then
+round-robins kinds, so most fixtures here use one kind and the page order is the sort
+order; `test_with_several_kinds_the_move_is_among_its_own_kind` pins what still holds
+when kinds differ.
 """
 from __future__ import annotations
 
 import re
 
+import pytest
+
 from paperconan._drill import drill, overview
 from paperconan._drill_render import render_overview
 
 DROP = "deterministic_relation_prefilter"
+WC_DROP = "within_col_structural_filter"
 DOWNWEIGHT = "deterministic_relation_downweight"
+WC_DOWNWEIGHT = "within_col_downweight"
+GUARD = "derived_or_unit_conversion"
 
 
-def _finding(i, severity="high", action="kept", context=()):
+def _finding(i, severity="high", action="kept", context=(), kind="identical_column"):
     return {
-        "kind": "identical_column",
+        "kind": kind,
         "severity": severity if action == "kept" else "low",
-        "raw_severity": severity, "n": 6, "rule": f"col[{i}] == col[{i + 1}]",
+        "raw_severity": severity, "n": 6, "rule": f"{kind} col[{i}] == col[{i + 1}]",
         "profile_action": action, "false_positive_context": list(context),
     }
 
 
-def _outright(count):
-    return [_finding(i, action="demoted", context=[DROP]) for i in range(count)]
+def _dropped(count, tag=DROP, kind="identical_column", action="demoted"):
+    return [_finding(i, action=action, context=[tag], kind=kind) for i in range(count)]
 
 
-def _block(sheet, findings):
+def _block(sheet, findings, cols="1-12", group="relations"):
     return {"file": "s.xlsx", "sheet": sheet,
-            "block": {"rows": "2-9", "cols": "1-12", "header": []},
-            "relations": findings}
+            "block": {"rows": "2-9", "cols": cols, "header": []},
+            group: findings}
 
 
-def _scan(*blocks, cross=()):
+def _scan(*blocks):
     return {"tool": "paperconan", "schema_version": 1, "n_files": 1,
-            "relations_blocks": list(blocks), "cross_sheet_findings": list(cross)}
+            "relations_blocks": list(blocks), "cross_sheet_findings": []}
 
 
 def _sheet(loc):
@@ -56,72 +64,122 @@ def _order(scan):
     return [_sheet(loc) for loc in overview(scan)["locations"]]
 
 
-def test_a_location_demoted_outright_sorts_after_its_band_mates():
-    order = _order(_scan(_block("Flagged", _outright(5)),
-                         _block("Kept", [_finding(0)])))
+def _before(order, first, second):
+    return order.index(first) < order.index(second)
 
-    assert order.index("Kept") < order.index("Flagged"), (
-        f"five high findings the filter demoted outright outranked one it kept: {order}"
+
+def test_a_location_matching_a_drop_rule_sorts_after_its_band_mates():
+    order = _order(_scan(_block("Flagged", _dropped(5)), _block("Kept", [_finding(0)])))
+
+    assert _before(order, "Kept", "Flagged"), (
+        f"five high findings a drop rule matched outranked one the filter kept: {order}"
     )
 
 
-def test_the_verdict_is_compared_after_severity_not_before():
-    order = _order(_scan(_block("Flagged", _outright(5)),
+def test_the_within_column_drop_rule_counts_too():
+    kind = "within_col_value_duplication"
+    order = _order(_scan(
+        _block("Flagged", _dropped(5, tag=WC_DROP, kind=kind), group="within_col"),
+        _block("Kept", [_finding(0, kind=kind)], group="within_col")))
+
+    assert _before(order, "Kept", "Flagged"), (
+        f"the within-column drop rule was not acted on: {order}"
+    )
+
+
+def test_severity_is_compared_before_the_verdict():
+    order = _order(_scan(_block("Flagged", _dropped(5)),
                          _block("Weaker", [_finding(0, severity="medium")])))
 
-    assert order.index("Flagged") < order.index("Weaker"), (
-        f"the filter's verdict moved a high location behind a medium one: {order}"
+    assert _before(order, "Flagged", "Weaker"), (
+        f"the verdict outweighed severity in the sort: {order}"
     )
 
 
-def test_a_downweight_verdict_does_not_move_a_location():
-    downweighted = [_finding(i, action="demoted", context=[DOWNWEIGHT]) for i in range(5)]
-    order = _order(_scan(_block("Downweighted", downweighted),
+@pytest.mark.parametrize("tag", [DOWNWEIGHT, WC_DOWNWEIGHT])
+def test_a_downweight_does_not_move_a_location(tag):
+    order = _order(_scan(_block("Downweighted", _dropped(5, tag=tag)),
                          _block("Kept", [_finding(0)])))
 
-    assert order.index("Downweighted") < order.index("Kept"), (
-        f"a downweight was treated as a drop and moved the location back: {order}"
+    assert _before(order, "Downweighted", "Kept"), (
+        f"a downweight ({tag}) moved the location back as if it were a drop: {order}"
     )
 
 
-def test_one_finding_the_filter_left_alone_keeps_the_location_in_place():
-    order = _order(_scan(_block("Mixed", _outright(4) + [_finding(9)]),
+def test_a_demotion_by_another_guard_does_not_move_a_location():
+    order = _order(_scan(_block("Guarded", _dropped(5, tag=GUARD)),
                          _block("Kept", [_finding(0)])))
 
-    assert order.index("Mixed") < order.index("Kept"), (
-        f"a location with a kept finding was moved back as if wholly demoted: {order}"
+    assert _before(order, "Guarded", "Kept"), (
+        f"a guard that records no strength moved the location back: {order}"
+    )
+
+
+def test_one_finding_outside_the_rule_keeps_the_location_in_place():
+    order = _order(_scan(_block("Mixed", _dropped(4) + [_finding(9)]),
+                         _block("Kept", [_finding(0)])))
+
+    assert _before(order, "Mixed", "Kept"), (
+        f"a location with a kept finding was moved back as if every finding matched: {order}"
     )
 
 
 def test_a_demotion_with_no_recorded_reason_does_not_move_a_location():
     unexplained = [_finding(i, action="demoted") for i in range(5)]
-    order = _order(_scan(_block("Unexplained", unexplained),
-                         _block("Kept", [_finding(0)])))
+    order = _order(_scan(_block("Unexplained", unexplained), _block("Kept", [_finding(0)])))
 
-    assert order.index("Unexplained") < order.index("Kept"), (
+    assert _before(order, "Unexplained", "Kept"), (
         f"a demotion nobody can read the reason for moved the location back: {order}"
     )
 
 
-def _cross(a, b, i, action="kept", context=()):
-    return {
-        "kind": "cross_sheet_position_identical",
-        "severity": "high" if action == "kept" else "low", "raw_severity": "high",
-        "rule": f"{a} row {i} == {b} row {i}", "file_a": "s.xlsx", "file_b": "s.xlsx",
-        "sheet_a": a, "sheet_b": b, "row_a": i, "row_b": i, "same_position_count": 6,
-        "profile_action": action, "false_positive_context": list(context),
-    }
+def test_a_hidden_finding_counts_like_a_demoted_one():
+    order = _order(_scan(_block("Hidden", _dropped(5, action="hidden")),
+                         _block("Kept", [_finding(0)])))
 
-
-def test_a_cross_sheet_location_carries_the_verdict_too():
-    flagged = [_cross("F1", "F2", i, action="demoted",
-                      context=["same_data_replot_or_duplicate_upload"]) for i in range(5)]
-    view = overview(_scan(cross=flagged + [_cross("K1", "K2", 0)]))
-    order = [loc["location"] for loc in view["locations"]]
-
-    assert order.index("s.xlsx :: K1 ↔ K2") < order.index("s.xlsx :: F1 ↔ F2"), (
-        f"cross-sheet seeds do not carry the verdict: {order}"
+    assert _before(order, "Kept", "Hidden"), (
+        f"the triage profile's hidden findings were not acted on: {order}"
     )
+
+
+def test_a_merged_panel_is_judged_on_all_its_findings():
+    """One panel, two column spans. `_merge_panels` builds the panel from its first
+    member and appends the rest, so a verdict read off that member alone would miss
+    the kept finding in the second span."""
+    left = _block("Panel", _dropped(3), cols="1-6")
+    right = _block("Panel", [_finding(9)], cols="7-12")
+    order = _order(_scan(left, right, _block("Kept", [_finding(0)])))
+
+    assert _before(order, "Panel", "Kept"), (
+        f"a merged panel holding a kept finding was moved back on its first member: {order}"
+    )
+
+
+def test_with_several_kinds_the_move_is_among_its_own_kind():
+    """Interleaving round-robins kinds, so a location that matched can still print
+    ahead of a same-strength location of another kind, or behind a weaker one. What
+    holds is its place among its own kind."""
+    order = _order(_scan(
+        _block("A flagged", _dropped(5)),
+        _block("A kept", [_finding(0)]),
+        _block("B kept", [_finding(i, kind="constant_offset") for i in range(3)])))
+
+    assert _before(order, "A kept", "A flagged"), (
+        f"among its own kind, the location that matched was not moved back: {order}"
+    )
+
+
+def test_a_malformed_context_is_ignored_not_trusted_or_fatal():
+    """Hand-edited or foreign scans: a context that is not a list of strings must
+    neither crash the reading layer nor be read as a drop rule."""
+    odd = _dropped(3)
+    odd[0]["false_positive_context"] = [{"ctx": DROP}]
+    odd[1]["false_positive_context"] = DOWNWEIGHT          # a bare string, not a list
+    scan = _scan(_block("Odd", odd), _block("Kept", [_finding(0)]))
+
+    loc = {_sheet(x): x for x in overview(scan)["locations"]}
+    assert loc["Odd"]["matched_drop_rule"] == 1, loc["Odd"]
+    assert _before(_order(scan), "Odd", "Kept")
 
 
 def _lines_under(text, n):
@@ -135,21 +193,23 @@ def _lines_under(text, n):
     return "\n".join(under)
 
 
-def test_the_page_says_when_every_signal_at_a_location_was_demoted_outright():
+def test_the_page_says_when_every_signal_matched_a_drop_rule():
     mixed = [_finding(0, action="demoted", context=[DROP]), _finding(1)]
-    view = overview(_scan(_block("Flagged", _outright(3)), _block("Mixed", mixed)))
+    view = overview(_scan(_block("Flagged", _dropped(3)), _block("Mixed", mixed)))
     loc = {_sheet(x): x for x in view["locations"]}
 
-    assert loc["Flagged"]["demoted_outright"] == 3
-    assert loc["Mixed"]["demoted_outright"] == 1
+    assert loc["Flagged"]["matched_drop_rule"] == 3
+    assert loc["Mixed"]["matched_drop_rule"] == 1
 
     text = render_overview(view)
-    assert "filter: all 3 demoted outright" in _lines_under(text, loc["Flagged"]["n"]), text
+    assert ("filter: 3/3 matched a prefilter drop rule"
+            in _lines_under(text, loc["Flagged"]["n"])), text
     assert "filter:" not in _lines_under(text, loc["Mixed"]["n"]), text
 
 
 def test_drill_opens_the_location_overview_numbered():
-    scan = _scan(_block("Flagged", _outright(5)), _block("Kept", [_finding(0)]))
+    scan = _scan(_block("Flagged", _dropped(5)), _block("Kept", [_finding(0)]),
+                 _block("B kept", [_finding(i, kind="constant_offset") for i in range(3)]))
 
     for loc in overview(scan)["locations"]:
         assert drill(scan, loc["n"])["cluster_id"] == loc["cluster_id"], (

--- a/tests/test_page_filter_verdict.py
+++ b/tests/test_page_filter_verdict.py
@@ -13,8 +13,8 @@ means worth less, not nothing, and a location holding one is left alone.
 Within its severity band a location that matched sorts after its band-mates, and
 severity is compared first because the filter can be wrong. Family interleaving then
 round-robins kinds, so most fixtures here use one kind and the page order is the sort
-order; `test_with_several_kinds_the_move_is_among_its_own_kind` pins what still holds
-when kinds differ.
+order; `test_with_several_kinds_the_move_is_among_its_leading_kind` pins what still
+holds when kinds differ.
 """
 from __future__ import annotations
 
@@ -22,8 +22,8 @@ import re
 
 import pytest
 
-from paperconan._drill import drill, overview
-from paperconan._drill_render import render_overview
+from paperconan._drill import drill, explain, overview
+from paperconan._drill_render import render_explain, render_overview
 
 DROP = "deterministic_relation_prefilter"
 WC_DROP = "within_col_structural_filter"
@@ -155,10 +155,11 @@ def test_a_merged_panel_is_judged_on_all_its_findings():
     )
 
 
-def test_with_several_kinds_the_move_is_among_its_own_kind():
-    """Interleaving round-robins kinds, so a location that matched can still print
-    ahead of a same-strength location of another kind, or behind a weaker one. What
-    holds is its place among its own kind."""
+def test_with_several_kinds_the_move_is_among_its_leading_kind():
+    """Interleaving files each location under the first kind it lists and round-robins
+    those, so a location that matched can still print ahead of a same-strength location
+    of another kind, or behind a weaker one. What holds is its place among the
+    locations filed under the same leading kind."""
     order = _order(_scan(
         _block("A flagged", _dropped(5)),
         _block("A kept", [_finding(0)]),
@@ -169,17 +170,34 @@ def test_with_several_kinds_the_move_is_among_its_own_kind():
     )
 
 
-def test_a_malformed_context_is_ignored_not_trusted_or_fatal():
+@pytest.mark.parametrize("value", [
+    [{"ctx": DROP}],            # an entry that is not a string
+    DOWNWEIGHT,                 # a bare string, not a list
+    {DROP: 1},                  # a mapping whose key is a drop tag
+    1, True, 2.5,               # scalars
+])
+def test_a_malformed_context_is_ignored_not_trusted_or_fatal(value):
     """Hand-edited or foreign scans: a context that is not a list of strings must
-    neither crash the reading layer nor be read as a drop rule."""
-    odd = _dropped(3)
-    odd[0]["false_positive_context"] = [{"ctx": DROP}]
-    odd[1]["false_positive_context"] = DOWNWEIGHT          # a bare string, not a list
+    neither make the check raise nor be read as a drop rule."""
+    odd = _dropped(2)
+    odd[0]["false_positive_context"] = value
     scan = _scan(_block("Odd", odd), _block("Kept", [_finding(0)]))
 
     loc = {_sheet(x): x for x in overview(scan)["locations"]}
-    assert loc["Odd"]["matched_drop_rule"] == 1, loc["Odd"]
-    assert _before(_order(scan), "Odd", "Kept")
+    assert loc["Odd"]["matched_drop_rule"] == 1, (value, loc["Odd"])
+    assert _before(_order(scan), "Odd", "Kept"), value
+
+
+def test_explain_shows_the_drop_tag_when_detector_severity_was_already_low():
+    """The page's filter line sends the reader to explain. A finding the detector
+    already rated low can still be demoted, and explain used to print its reasons
+    only when the displayed severity differed from the detector's."""
+    low = [_finding(i, severity="low", action="demoted", context=[DROP]) for i in range(2)]
+    scan = _scan(_block("Low", low))
+    fid = drill(scan, 1, kind="identical_column")["findings"][0]["finding_id"]
+
+    text = render_explain(explain(scan, fid))
+    assert DROP in text, text
 
 
 def _lines_under(text, n):

--- a/tests/test_page_filter_verdict.py
+++ b/tests/test_page_filter_verdict.py
@@ -1,0 +1,157 @@
+"""The first page and the false-positive filter's verdict.
+
+`overview` ranks on the detector's severity, frozen before the profile runs, so a
+location whose every finding the filter had already demoted could take a first-page
+slot on the strength of findings the scan itself had marked as likely false positives.
+
+The filter returns two verdicts and they must not be treated alike. "drop" says the
+pattern is usually derived or structural; "downweight" says worth less, not nothing.
+Only the first is grounds for moving a location, and only to the back of its own
+severity band: the verdict is compared after severity, because the filter can be
+wrong and a verdict that can be wrong must not outweigh the detector's severity.
+
+Every fixture uses one finding kind, so family interleaving -- which round-robins
+across kinds -- cannot reorder what these tests look at.
+"""
+from __future__ import annotations
+
+import re
+
+from paperconan._drill import drill, overview
+from paperconan._drill_render import render_overview
+
+DROP = "deterministic_relation_prefilter"
+DOWNWEIGHT = "deterministic_relation_downweight"
+
+
+def _finding(i, severity="high", action="kept", context=()):
+    return {
+        "kind": "identical_column",
+        "severity": severity if action == "kept" else "low",
+        "raw_severity": severity, "n": 6, "rule": f"col[{i}] == col[{i + 1}]",
+        "profile_action": action, "false_positive_context": list(context),
+    }
+
+
+def _outright(count):
+    return [_finding(i, action="demoted", context=[DROP]) for i in range(count)]
+
+
+def _block(sheet, findings):
+    return {"file": "s.xlsx", "sheet": sheet,
+            "block": {"rows": "2-9", "cols": "1-12", "header": []},
+            "relations": findings}
+
+
+def _scan(*blocks, cross=()):
+    return {"tool": "paperconan", "schema_version": 1, "n_files": 1,
+            "relations_blocks": list(blocks), "cross_sheet_findings": list(cross)}
+
+
+def _sheet(loc):
+    return loc["location"].split(" :: ", 1)[1].split(" rows ", 1)[0]
+
+
+def _order(scan):
+    return [_sheet(loc) for loc in overview(scan)["locations"]]
+
+
+def test_a_location_demoted_outright_sorts_after_its_band_mates():
+    order = _order(_scan(_block("Flagged", _outright(5)),
+                         _block("Kept", [_finding(0)])))
+
+    assert order.index("Kept") < order.index("Flagged"), (
+        f"five high findings the filter demoted outright outranked one it kept: {order}"
+    )
+
+
+def test_the_verdict_is_compared_after_severity_not_before():
+    order = _order(_scan(_block("Flagged", _outright(5)),
+                         _block("Weaker", [_finding(0, severity="medium")])))
+
+    assert order.index("Flagged") < order.index("Weaker"), (
+        f"the filter's verdict moved a high location behind a medium one: {order}"
+    )
+
+
+def test_a_downweight_verdict_does_not_move_a_location():
+    downweighted = [_finding(i, action="demoted", context=[DOWNWEIGHT]) for i in range(5)]
+    order = _order(_scan(_block("Downweighted", downweighted),
+                         _block("Kept", [_finding(0)])))
+
+    assert order.index("Downweighted") < order.index("Kept"), (
+        f"a downweight was treated as a drop and moved the location back: {order}"
+    )
+
+
+def test_one_finding_the_filter_left_alone_keeps_the_location_in_place():
+    order = _order(_scan(_block("Mixed", _outright(4) + [_finding(9)]),
+                         _block("Kept", [_finding(0)])))
+
+    assert order.index("Mixed") < order.index("Kept"), (
+        f"a location with a kept finding was moved back as if wholly demoted: {order}"
+    )
+
+
+def test_a_demotion_with_no_recorded_reason_does_not_move_a_location():
+    unexplained = [_finding(i, action="demoted") for i in range(5)]
+    order = _order(_scan(_block("Unexplained", unexplained),
+                         _block("Kept", [_finding(0)])))
+
+    assert order.index("Unexplained") < order.index("Kept"), (
+        f"a demotion nobody can read the reason for moved the location back: {order}"
+    )
+
+
+def _cross(a, b, i, action="kept", context=()):
+    return {
+        "kind": "cross_sheet_position_identical",
+        "severity": "high" if action == "kept" else "low", "raw_severity": "high",
+        "rule": f"{a} row {i} == {b} row {i}", "file_a": "s.xlsx", "file_b": "s.xlsx",
+        "sheet_a": a, "sheet_b": b, "row_a": i, "row_b": i, "same_position_count": 6,
+        "profile_action": action, "false_positive_context": list(context),
+    }
+
+
+def test_a_cross_sheet_location_carries_the_verdict_too():
+    flagged = [_cross("F1", "F2", i, action="demoted",
+                      context=["same_data_replot_or_duplicate_upload"]) for i in range(5)]
+    view = overview(_scan(cross=flagged + [_cross("K1", "K2", 0)]))
+    order = [loc["location"] for loc in view["locations"]]
+
+    assert order.index("s.xlsx :: K1 ↔ K2") < order.index("s.xlsx :: F1 ↔ F2"), (
+        f"cross-sheet seeds do not carry the verdict: {order}"
+    )
+
+
+def _lines_under(text, n):
+    lines = text.splitlines()
+    start = next(i for i, ln in enumerate(lines) if re.match(rf"^\s*{n}\s{{2}}\S", ln))
+    under = []
+    for ln in lines[start + 1:]:
+        if not ln.startswith("      "):
+            break
+        under.append(ln)
+    return "\n".join(under)
+
+
+def test_the_page_says_when_every_signal_at_a_location_was_demoted_outright():
+    mixed = [_finding(0, action="demoted", context=[DROP]), _finding(1)]
+    view = overview(_scan(_block("Flagged", _outright(3)), _block("Mixed", mixed)))
+    loc = {_sheet(x): x for x in view["locations"]}
+
+    assert loc["Flagged"]["demoted_outright"] == 3
+    assert loc["Mixed"]["demoted_outright"] == 1
+
+    text = render_overview(view)
+    assert "filter: all 3 demoted outright" in _lines_under(text, loc["Flagged"]["n"]), text
+    assert "filter:" not in _lines_under(text, loc["Mixed"]["n"]), text
+
+
+def test_drill_opens_the_location_overview_numbered():
+    scan = _scan(_block("Flagged", _outright(5)), _block("Kept", [_finding(0)]))
+
+    for loc in overview(scan)["locations"]:
+        assert drill(scan, loc["n"])["cluster_id"] == loc["cluster_id"], (
+            f"overview #{loc['n']} and drill #{loc['n']} name different locations"
+        )


### PR DESCRIPTION
## What was wrong

`overview` ranks locations on `raw_severity`, which `initialize_profile_fields` freezes before the display profile runs. The ranking does not consult `profile_action`; in the reading layer, only `explain` displays it. So a location whose every finding the false-positive filter had already demoted still took a first-page slot, and the page printed `high` beside it.

The filter's verdict could not simply drive ranking. The relation and within-column prefilters return `keep`, `downweight` or `drop`, and `_profiles.py` demotes on both of the last two through the same `_demote_or_hide`, so `severity` and `profile_action` come out identical. In the benchmark, a relation confirmed as a real signal carried the `downweight` tag, and a probe that ranked on `profile_action` pushed it off the first page.

## What changed

- `_profiles.matched_drop_rule(f)` is true when the profile demoted a finding because a prefilter's drop rule matched, i.e. the context tag is `deterministic_relation_prefilter` or `within_col_structural_filter`.
  - A downweight, a demotion by another guard, and a demotion with no recorded reason do not count.
  - A context that is not a list, and entries in it that are not strings, are ignored.
  - These two tags count because the prefilters are the only step that says drop rather than downweight. That is the filter's stated verdict, not stronger evidence: some drop rules match on a header word alone, for example a column named with `count`, `replicate` or `group`. That is why the verdict is compared only after severity and shown as a label.
- `_build_clusters(..., with_verdict=True)`: only the reading layer passes this, and it attaches the verdict to each seed.
  - Workflow packets are built without it, so they stay independent of the display profile.
  - `test_the_profile_is_part_of_the_run_configuration` went red when the verdict was first put on every seed, which is how that constraint was found.
- `_merge_panels`: within a severity band, a panel whose every finding matched a drop rule sorts after the panels that did not. Severity is still compared first.
  - This is the order `_interleave_by_family` receives. Interleaving round-robins each location's leading kind, so on the printed page such a location can still sit ahead of a same-strength location of another kind, or behind a weaker one.
  - Interleaving already reorders across severity like this on `main`.
- `overview` gains a `matched_drop_rule` count per location. The text page prints `filter: N/N matched a prefilter drop rule — reasons in explain` under a location where that count equals its signals.
- `explain` now prints the demotion reasons whenever the profile demoted a finding. Before, it printed them only when displayed severity differed from the detector's, so a finding the detector had already rated low showed no reason, even though the page line sends the reader there.
- SKILL.md gains one paragraph on what the line means, what it does not, and how interleaving affects it.
- No cross-sheet finding can match: neither prefilter's kind list includes a cross-sheet kind.

## Review

Two rounds of adversarial review.

**Round 1** found:
- The definition counted any non-downweight tag, including guards that decide on header and sheet-name words.
- Several prose claims were false at the page level because of interleaving.
- Three behaviours were untested: the within-column drop tag, triage `hidden`, and merged panels.
- A dict entry in `false_positive_context` crashed the reading layer.

**Round 2** found:
- Some prefilter drop rules also match on a header word alone, so the stated reason for counting them was wrong. The reason is reworded above and in SKILL.md.
- A scalar context crashed the reading layer, and a mapping was read as a drop tag. Both are fixed.
- `explain` hid the reason when detector severity was already low. Fixed.
- The page line promised that `explain` would name the specific rule. The within-column flood demoter can later overwrite `prefilter_reason`, so the line is reworded. That overwrite predates this change and is not fixed here.
- A test docstring overstated what interleaving preserves. Reworded.

The reviewer also ran two mutants that survive: a kept finding carrying a drop tag, and the verdict skipped on cross-sheet seeds. No tests were added for them, because neither situation can occur in a scan the tool writes. The profile writes a drop tag only immediately before demoting, and no cross-sheet kind is in either prefilter's kind list.

## Measured

Configuration: 62 benchmark papers scanned with 0.9.0 under `--profile review`. The comparison uses the real `overview`/`drill` of `main` and of this branch, reading the default page of 20 locations. "Flagged" means every finding at the location matched a prefilter drop rule. It is computed from the raw findings with one definition for both trees.

| | main | branch |
|---|---|---|
| first-page slots | 1182 | 1182 |
| flagged slots | 47 | 33 |
| flagged slots printed `high` | 47 | 33 |
| flagged slots in ranks 1-5 | 10 | 5 |

Both directions: 14 locations left the first page, and every one of them was flagged. 14 arrived, and none of them was flagged.

Confirmed benchmark signals whose sheet could be located: 37.
- 34 kept their rank, 1 moved up, 0 left the page, and 2 were off the page on both sides.
- Of the 35 on the page, the claimed sheet's first listed location is flagged for none of them, on either tree. One of those sheets has a different location that is flagged.
- Claims with no recorded evidence text could not be located and are not counted.

These numbers are not asserted by a test and will drift. Re-measure them with the same configuration rather than quoting them.

## Tests

`python -m pytest tests` on this branch: 1934 passed, 2 skipped..

`tests/test_page_filter_verdict.py` has 20 tests. Each guard was checked by mutation: 16 mutants, each turning its expected tests red. Every run used a fresh `PYTHONPYCACHEPREFIX`; without it, mutants that keep file size and restore within the same second are served from a stale `.pyc`.

Not in scope, found along the way: `uv run pytest` fails to collect `tests/test_detection_recall_e2e.py`, because `from tests import …` needs the repo root on `sys.path`. CI uses `python -m pytest`, which works. The failure is the same on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
