### PR TITLE
fix(prefilter): stop calling a short identical pair sparse by its pooled count

### DIFF
--- a/src/paperconan/_audit.py
+++ b/src/paperconan/_audit.py
@@ -503,7 +503,7 @@ def col_array(sheet, r0, r1, c):
 
 def _sample(arr, k=8):
     """A tiny value peek for downstream LLM triage: the first <=k finite numeric
-    values of `arr` as built-in floats rounded to 6 significant figures. Bounded to
+    values of `arr` as built-in floats rounded to 6 decimal places. Bounded to
     <=k elements so it CANNOT reintroduce the evidence-bloat OOM (~64 bytes here)."""
     out = []
     for v in arr[:k]:

--- a/src/paperconan/_prefilter.py
+++ b/src/paperconan/_prefilter.py
@@ -45,6 +45,25 @@ def _is_arith_axis(samples: list[Any] | None) -> bool:
     return len(set(diffs)) == 1 and diffs[0] != 0
 
 
+def _all_distinct(vals: list[float]) -> bool:
+    rounded = [round(v, 12) for v in vals]
+    return len(set(rounded)) == len(rounded)
+
+
+def _sorted_progression(vals: list[float]) -> bool:
+    """Sorted, the values step by one constant difference or one constant ratio."""
+    s = sorted(vals)
+    if len(s) < 3:
+        return False
+    diffs = {round(b - a, 9) for a, b in zip(s, s[1:])}
+    if len(diffs) == 1 and 0 not in diffs:
+        return True
+    if s[0] > 0:
+        ratios = {round(b / a, 9) for a, b in zip(s, s[1:])}
+        return len(ratios) == 1 and 1.0 not in ratios
+    return False
+
+
 _AGG = (
     "average", "mean", "median", "std", " sd", "sd ", "stdev", "stddev",
     "s.d", "sem", "s.e.m", "variance", " var", "error", "95%", " ci",
@@ -590,7 +609,21 @@ def _low_information_sparse(kind: str | None, n: int, sa: list[Any] | None,
         return False
     unique = len({round(v, 12) for v in vals})
     zeros = sum(1 for v in vals if abs(v) <= 1e-12)
-    return unique <= 4 or zeros >= len(vals) // 2
+    if zeros >= len(vals) // 2:
+        return True
+    if kind == "identical_column":
+        # Two copies of one column pool to that column's values, so a pair of three or
+        # four rows below the precision gate holds at most four distinct values when
+        # its samples agree, and the pooled count alone would flag it. Judge the
+        # sampled columns instead: the pair is not sparse when each column's sampled
+        # values all differ and, sorted, do not step by a constant difference or ratio
+        # -- a 1, 2, 3 or 1, 10, 100 column says no more at this length than a repeated
+        # value. Both columns are checked because samples are rounded, and two columns
+        # equal within the detector's tolerance can round differently.
+        col_a, col_b = _nums(sa), _nums(sb)
+        if all(_all_distinct(c) and not _sorted_progression(c) for c in (col_a, col_b)):
+            return False
+    return unique <= 4
 
 
 def _is_cross_sheet(kind: str | None) -> bool:

--- a/tests/test_batch2_prefilter.py
+++ b/tests/test_batch2_prefilter.py
@@ -1519,3 +1519,94 @@ def test_prefilter_downweights_cross_sheet_enriched_axis_context():
 
     assert f["prefilter"] == "downweight"
     assert f["prefilter_reason"] == "shared_axis_overlap"
+
+
+def test_prefilter_does_not_call_a_short_identical_pair_sparse_when_its_rows_all_differ():
+    """Pooling two identical columns counts each value once, so a pair of three or four
+    rows below the precision gate had at most four distinct values and read as sparse
+    on that count alone."""
+    cp = _collector()
+    for values in ([18.2, 14.8, 6.4], [23.8, 26.7, 28.5, 32.2]):
+        f = cp.prefilter_relation_finding(
+            "identical_column", "Tnf", "Il6", len(values), 1.0, "col[5] == col[1]",
+            values, list(values),
+        )
+
+        assert f["flags"]["low_information_sparse"] is False, values
+        assert f["prefilter_reason"] != "low_information_sparse_transform", values
+
+
+def test_prefilter_still_calls_a_short_identical_pair_sparse_when_its_values_repeat():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "identical_column", "Tnf", "Il6", 4, 1.0, "col[5] == col[1]",
+        [49.0, 1.0, 49.0, 0.0], [49.0, 1.0, 49.0, 0.0],
+    )
+
+    assert f["flags"]["low_information_sparse"] is True
+
+
+def test_prefilter_leaves_longer_identical_pairs_as_they_were():
+    """Six rows with one repeat has five distinct values: not sparse before the change,
+    and the change must not make a single repeat enough."""
+    cp = _collector()
+    values = [3.1, 7.4, 2.2, 9.8, 5.6, 3.1]
+    f = cp.prefilter_relation_finding(
+        "identical_column", "Tnf", "Il6", 6, 1.0, "col[5] == col[1]",
+        values, list(values),
+    )
+
+    assert f["flags"]["low_information_sparse"] is False
+
+
+def test_prefilter_calls_a_half_zero_transform_sparse_even_with_many_distinct_values():
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "exact_linear", "", "", 6, 1.0, "col[2] = col[1] * 2",
+        [0.0, 0.0, 0.0, 1.5, 2.5, 3.5], [0.0, 0.0, 0.0, 3.0, 5.0, 7.0],
+    )
+
+    assert f["flags"]["low_information_sparse"] is True
+
+
+def test_prefilter_keeps_the_pooled_count_for_transforms_between_different_columns():
+    """The identical-pair exception is about two copies of one column. A transform
+    between two different columns still pools them, as before. Four rows, because the
+    scan does not emit a three-row constant_ratio by default."""
+    cp = _collector()
+    f = cp.prefilter_relation_finding(
+        "constant_ratio", "Tnf", "Il6", 4, 1.0, "col[5] = col[1] * -1",
+        [1.0, -1.0, 2.0, -2.0], [-1.0, 1.0, -2.0, 2.0],
+    )
+
+    assert f["flags"]["low_information_sparse"] is True
+
+
+def test_prefilter_still_calls_a_short_identical_pair_sparse_when_it_is_a_sequence():
+    """Distinct values are not enough: sorted into a constant step or ratio, three or
+    four of them say no more than a repeated value."""
+    cp = _collector()
+    for values in ([1.0, 2.0, 3.0], [0.0, 50.0, 100.0], [24.0, 48.0, 72.0],
+                   [1.0, 2.0, 4.0, 8.0], [0.1, 1.0, 10.0, 100.0], [2.0, 1.0, 4.0, 3.0]):
+        f = cp.prefilter_relation_finding(
+            "identical_column", "Tnf", "Il6", len(values), 1.0, "col[5] == col[1]",
+            values, list(values),
+        )
+
+        assert f["flags"]["low_information_sparse"] is True, values
+
+
+def test_prefilter_judges_an_identical_pair_the_same_whichever_column_comes_first():
+    """Samples are rounded, so two columns equal within the detector's tolerance can
+    sample differently; here one sample has a repeat and the other does not."""
+    cp = _collector()
+    distinct = [1000.0, 1000.000002, 2000.0]
+    repeated = [1000.000001, 1000.000001, 2000.0]
+    flags = [
+        cp.prefilter_relation_finding(
+            "identical_column", "Tnf", "Il6", 3, 1.0, "col[5] == col[1]", sa, sb,
+        )["flags"]["low_information_sparse"]
+        for sa, sb in ((distinct, repeated), (repeated, distinct))
+    ]
+
+    assert flags == [True, True], flags


### PR DESCRIPTION
## What was wrong

The relation prefilter's `low_information_sparse` flag pools the two columns' samples and calls the pair sparse when the pool has at most four distinct values. When no earlier rule decides first, the flag leads to a `downweight` with reason `low_information_sparse_transform`.

For a transform between two different columns, the pool holds two sets of values. For `identical_column`, the columns are copies, so the pool counts each value once. Below the precision gate, an identical pair of three or four rows whose samples agree therefore met the test whatever values it held.

Under the default `review` profile that downweight demotes the finding to `low`, with three consequences:
- `_distill_relations` passes a relation into the review packet only while its displayed severity is `high`, so the finding leaves the packet.
- The HTML report files the finding under `low`.
- `explain` shows `displayed=low`.

## What changed

- **`_low_information_sparse` for `identical_column`:** the pair is not sparse when both hold:
  - each column's sampled values all differ;
  - sorted, the values do not step by a constant difference or a constant ratio. A 1, 2, 3 or 1, 10, 100 column at this length says no more than a repeated value.

  Both columns are checked. Samples are rounded, so two columns that are equal within the detector's tolerance can sample differently, and checking only one could make the verdict depend on column order.
- **Unchanged:**
  - the zero test;
  - transforms between two different columns;
  - pairs of five to seven rows, for pairs the scan emits.
- **`_audit._sample` docstring:** values are rounded to 6 decimal places, not 6 significant figures. The distinctness check reads those rounded samples.
- **Tests:**
  - distinct three- and four-row identical pairs are not flagged;
  - repeated values still are;
  - a six-row pair with one repeat is unchanged;
  - the zero branch still flags;
  - a four-row `constant_ratio` still uses the pooled count;
  - sequences (constant step, constant ratio, unsorted consecutive values) are still flagged;
  - the verdict is the same with the columns swapped.

## Review

One adversarial review, with no Critical findings. It confirmed the premise: for n ≤ 7 the stored sample is exactly the n paired rows, in row order. Its findings and how each was handled:
- **Important.** Distinct but sequence-like columns (1, 2, 3; 0, 50, 100; 1, 2, 4, 8) were released too, and the axis rule does not catch three-value sequences. They are now excluded.
- **Minor.** Only the first column was checked, so the verdict could flip with column order when rounding makes the samples differ. Both columns are now checked, which also covers an empty first sample.
- **Minor.** A test used a three-row `constant_ratio`, which the scan does not emit by default. It now uses four rows.
- **Minor.** The prose overstated three things. The packet/report consequence holds only under the `review` profile. "Rows" are rounded samples. "Pairs of five to seven rows unchanged" holds for pairs the scan emits. The `_sample` docstring said significant figures.
- **Not addressed.** A column whose raw values differ only beyond the sixth decimal still reads as repeated. That direction is conservative and matches `main`.

## Measured

Configuration: the 62 benchmark papers under `--profile review`. `main`'s scans are compared with full re-scans of this branch, so the profile's verdicts come from the real pipeline.

**Verdicts.** Every finding in both trees was compared.
- 43 findings went from demoted/`low` to kept/`high`.
- 1 went from demoted/`low` to kept/`low`; its detector severity was `low`.
- No other finding changed verdict, appeared, or disappeared.

**What was released.** The 44 findings are in 7 papers, and 22 of them sit on sheets holding a confirmed benchmark signal. The other 22 were read from their values and not checked against the source tables:
- 15 have the same repeated-column shape on an adjacent panel of one of those papers, outside the reported claim.
- 3 are near-ceiling percentages.
- 1 is a short integer column.
- 3 are identical pairs between differently labelled groups (different animals or genotypes), unverified.

The sequence exclusion added after review re-flagged 3 findings the first version had released: a 24/48/72 time column, a 1, 2, 3 index, and consecutive integer counts.

**Review packets.** Relation findings in `distill_findings_for_review` go from 200 on `main` to 243.

**First page.** For every one of the 62 papers, `overview`'s first page is identical on `main` and on this branch, because it ranks on detector severity.

These numbers are not asserted by a test and will drift. Re-measure with the same configuration rather than quoting them.

## Tests

`python -m pytest tests`: 1921 passed, 2 skipped.

The new tests were checked by mutation with 9 mutants: the exception removed, identical pairs never sparse, any repeat making a pair sparse, the zero branch removed, the exception applied to every kind, only the first column checked, the sequence check removed, the ratio branch removed, and values left unsorted before the step test. Each mutant turned its expected tests red. Every run used a fresh `PYTHONPYCACHEPREFIX`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
